### PR TITLE
Reorder ament_cmake include in CMakeLists to resolve test and symlink install issues

### DIFF
--- a/roboplan/CMakeLists.txt
+++ b/roboplan/CMakeLists.txt
@@ -10,6 +10,12 @@ find_package(Eigen3 REQUIRED)
 find_package(pinocchio REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
+# Ament CMake is not immediately required, but we include it at the top so that
+# if it is found we can use it in build testing before requiring a
+# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
+# issues with symlink installs.
+find_package(ament_cmake QUIET)
+
 # Add libraries
 add_library(expected INTERFACE)
 target_include_directories(expected
@@ -101,7 +107,6 @@ if (BUILD_TESTING)
 endif()
 
 # If ament_cmake is detected, export the package to be visible in ROS 2.
-find_package(ament_cmake QUIET)
 if ( ament_cmake_FOUND )
     message(STATUS "ament_cmake found. Exporting for ROS 2.")
     ament_package()

--- a/roboplan/test/CMakeLists.txt
+++ b/roboplan/test/CMakeLists.txt
@@ -34,9 +34,6 @@ target_link_libraries(
 # If ament_gtest is detected, make the tests visible in ROS 2.
 find_package(ament_cmake_gtest QUIET)
 if ( ament_cmake_gtest_FOUND )
-    # See https://github.com/ament/ament_cmake/issues/588
-    find_package(ament_cmake_test REQUIRED)
-
     ament_add_gtest_test(test_types)
     ament_add_gtest_test(test_scene)
     ament_add_gtest_test(test_path_utils)

--- a/roboplan_example_models/CMakeLists.txt
+++ b/roboplan_example_models/CMakeLists.txt
@@ -7,6 +7,12 @@ endif()
 
 # Find dependencies.
 
+# Ament CMake is not immediately required, but we include it at the top so that
+# if it is found we can use it in build testing before requiring a
+# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
+# issues with symlink installs.
+find_package(ament_cmake QUIET)
+
 # Build and install the library containing the resource paths.
 add_library(roboplan_example_models SHARED src/resources.cpp)
 target_include_directories(roboplan_example_models PUBLIC
@@ -74,7 +80,6 @@ install(
 )
 
 # If ament_cmake is detected, export the package to be visible in ROS 2.
-find_package(ament_cmake QUIET)
 if ( ament_cmake_FOUND )
     message(STATUS "ament_cmake found. Exporting for ROS 2.")
     ament_package()

--- a/roboplan_examples/CMakeLists.txt
+++ b/roboplan_examples/CMakeLists.txt
@@ -10,6 +10,12 @@ find_package(roboplan REQUIRED)
 find_package(roboplan_simple_ik REQUIRED)
 find_package(roboplan_example_models REQUIRED)
 
+# Ament CMake is not immediately required, but we include it at the top so that
+# if it is found we can use it in build testing before requiring a
+# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
+# issues with symlink installs.
+find_package(ament_cmake QUIET)
+
 # Build and install the examples.
 add_executable(example_scene examples/example_scene.cpp)
 target_link_libraries(example_scene
@@ -42,7 +48,6 @@ install(
 )
 
 # If ament_cmake is detected, export the package to be visible in ROS 2.
-find_package(ament_cmake QUIET)
 if ( ament_cmake_FOUND )
     message(STATUS "ament_cmake found. Exporting for ROS 2.")
     ament_package()

--- a/roboplan_rrt/CMakeLists.txt
+++ b/roboplan_rrt/CMakeLists.txt
@@ -8,6 +8,12 @@ endif()
 # Find dependencies.
 find_package(roboplan REQUIRED)
 
+# Ament CMake is not immediately required, but we include it at the top so that
+# if it is found we can use it in build testing before requiring a
+# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
+# issues with symlink installs.
+find_package(ament_cmake QUIET)
+
 # Add libraries
 add_library(roboplan_rrt SHARED
     src/rrt.cpp
@@ -84,7 +90,6 @@ if (BUILD_TESTING)
 endif()
 
 # If ament_cmake is detected, export the package to be visible in ROS 2.
-find_package(ament_cmake QUIET)
 if ( ament_cmake_FOUND )
     message(STATUS "ament_cmake found. Exporting for ROS 2.")
     ament_package()

--- a/roboplan_rrt/test/CMakeLists.txt
+++ b/roboplan_rrt/test/CMakeLists.txt
@@ -17,9 +17,6 @@ target_link_libraries(
 # If ament_gtest is detected, make the tests visible in ROS 2.
 find_package(ament_cmake_gtest QUIET)
 if ( ament_cmake_gtest_FOUND )
-    # See https://github.com/ament/ament_cmake/issues/588
-    find_package(ament_cmake_test REQUIRED)
-
     ament_add_gtest_test(test_rrt)
 else()
     include(GoogleTest)

--- a/roboplan_simple_ik/CMakeLists.txt
+++ b/roboplan_simple_ik/CMakeLists.txt
@@ -8,6 +8,12 @@ endif()
 # Find dependencies.
 find_package(roboplan REQUIRED)
 
+# Ament CMake is not immediately required, but we include it at the top so that
+# if it is found we can use it in build testing before requiring a
+# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
+# issues with symlink installs.
+find_package(ament_cmake QUIET)
+
 # Add libraries
 add_library(roboplan_simple_ik SHARED
     src/simple_ik.cpp
@@ -76,7 +82,6 @@ install(TARGETS roboplan_simple_ik
         )
 
 # If ament_cmake is detected, export the package to be visible in ROS 2.
-find_package(ament_cmake QUIET)
 if ( ament_cmake_FOUND )
     message(STATUS "ament_cmake found. Exporting for ROS 2.")
     ament_package()

--- a/roboplan_toppra/CMakeLists.txt
+++ b/roboplan_toppra/CMakeLists.txt
@@ -9,6 +9,12 @@ endif()
 find_package(roboplan REQUIRED)
 find_package(toppra REQUIRED)
 
+# Ament CMake is not immediately required, but we include it at the top so that
+# if it is found we can use it in build testing before requiring a
+# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
+# issues with symlink installs.
+find_package(ament_cmake QUIET)
+
 # Add libraries
 add_library(roboplan_toppra SHARED
     src/toppra.cpp
@@ -86,7 +92,6 @@ if (BUILD_TESTING)
 endif()
 
 # If ament_cmake is detected, export the package to be visible in ROS 2.
-find_package(ament_cmake QUIET)
 if ( ament_cmake_FOUND )
     message(STATUS "ament_cmake found. Exporting for ROS 2.")
     ament_package()

--- a/roboplan_toppra/test/CMakeLists.txt
+++ b/roboplan_toppra/test/CMakeLists.txt
@@ -17,9 +17,6 @@ target_link_libraries(
 # If ament_gtest is detected, make the tests visible in ROS 2.
 find_package(ament_cmake_gtest QUIET)
 if ( ament_cmake_gtest_FOUND )
-    # See https://github.com/ament/ament_cmake/issues/588
-    find_package(ament_cmake_test REQUIRED)
-
     ament_add_gtest_test(test_toppra)
 else()
     include(GoogleTest)


### PR DESCRIPTION
Resolves #62.

In "normal" ROS workflows we always have the `ament_cmake` lookup at the top... so all those includes are just there by default. For the first time in ROS history, apparently that's not the case, which seems to be why the gtest lookup was failing.

In any case, having the order flipped there seems to cause the infinite cmake lookup recursion issue linked in the ticket, so we can either put it up top or just move the build testing to AFTER we `ament_package`. Ugly stuff all around, but let me know your preference.