### PR TITLE
Temporarily set pixi bin path in CI to not collide with user install

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -113,6 +113,8 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           frozen: true
           manifest-path: pixi.toml
+          # TODO: Remove this when we do not have self-hosted runners in the public repo
+          pixi-bin-path: ~/actions-runner/.pixi/bin/pixi
       - name: Build and test
         run: |
           pixi run install_all


### PR DESCRIPTION
self hosted runners strike again

My pixi installation kept disappearing, until I realized that it was my self-hosted runner clobbering it :)