### PR TITLE
Patch Viser visualizer to load STL mesh colors properly

### DIFF
--- a/bindings/src/roboplan/viser_visualizer.py
+++ b/bindings/src/roboplan/viser_visualizer.py
@@ -211,7 +211,7 @@ class ViserVisualizer(BaseVisualizer):
             )
         elif isinstance(geom, MESH_TYPES):
             mesh = trimesh.load(geometry_object.meshPath)
-            if color is None:
+            if color_override is None:
                 frame = self.viewer.scene.add_mesh_trimesh(name, mesh)
             else:
                 frame = self.viewer.scene.add_mesh_simple(


### PR DESCRIPTION
Found a small fix that addresses STL color issues.

<img width="370" height="435" alt="image" src="https://github.com/user-attachments/assets/922f4084-74bf-4249-8c8e-3080d85c1f74" />

<img width="1181" height="894" alt="image" src="https://github.com/user-attachments/assets/91bf0db2-4d6c-478c-b33b-8eb4bc11b689" />

