### PR TITLE
Fix usage of tinyxml2 and tl_expected dependencies

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -135,14 +135,25 @@ target_include_directories(roboplan_ext PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 set_property(TARGET roboplan_ext PROPERTY CXX_STANDARD 20)
+
+# Ensures that the library is always called tl_expected::tl_expected regardless
+# of whether it was built from source in roboplan or comes from ROS binaries.
+find_package(tl_expected QUIET)
+if(NOT TARGET tl_expected::tl_expected AND TARGET roboplan::tl_expected)
+    add_library(tl_expected::tl_expected INTERFACE IMPORTED)
+    set_target_properties(tl_expected::tl_expected PROPERTIES
+        INTERFACE_LINK_LIBRARIES roboplan::tl_expected
+    )
+endif()
+
 target_link_libraries(roboplan_ext PRIVATE
-  roboplan::expected
   roboplan::roboplan
   roboplan_example_models::roboplan_example_models
   roboplan_oink::roboplan_oink
   roboplan_rrt::roboplan_rrt
   roboplan_simple_ik::roboplan_simple_ik
   roboplan_toppra::roboplan_toppra
+  tl_expected::tl_expected
 )
 
 if(AMENT_BUILD)

--- a/bindings/package.xml
+++ b/bindings/package.xml
@@ -17,6 +17,7 @@
   <depend>roboplan_rrt</depend>
   <depend>roboplan_simple_ik</depend>
   <depend>roboplan_toppra</depend>
+  <depend>tl_expected</depend>
 
   <test_depend>roboplan_example_models</test_depend>
 

--- a/roboplan/CMakeLists.txt
+++ b/roboplan/CMakeLists.txt
@@ -16,14 +16,22 @@ find_package(yaml-cpp REQUIRED)
 # issues with symlink installs.
 find_package(ament_cmake QUIET)
 
-# Add libraries
-add_library(expected INTERFACE)
-target_include_directories(expected
-  INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+set(TARGETS_LIST roboplan)
 
-# ROS already has a TinyXML2 vendor, so add this only in non-ROS contexts.
+# Add tl_expected from source only if not found.
+find_package(tl_expected QUIET)
+if (NOT tl_expected_FOUND)
+    add_library(tl_expected INTERFACE)
+    target_include_directories(
+        tl_expected
+        INTERFACE
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+    )
+    list(APPEND TARGETS_LIST tl_expected)
+endif()
+
+# Add tinyxml2 from source only if not found.
 find_package(tinyxml2_vendor QUIET)
 find_package(TinyXML2 QUIET)
 if ( NOT tinyxml2_vendor_FOUND AND NOT TinyXML2_FOUND )
@@ -31,8 +39,10 @@ if ( NOT tinyxml2_vendor_FOUND AND NOT TinyXML2_FOUND )
         include/tinyxml2/tinyxml2.cpp
         include/tinyxml2/tinyxml2.h)
     add_library(tinyxml2::tinyxml2 ALIAS tinyxml2)
+    list(APPEND TARGETS_LIST tinyxml2)
 endif()
 
+# Add roboplan libraries.
 add_library(roboplan SHARED
     src/core/path_utils.cpp
     src/core/scene.cpp
@@ -56,12 +66,7 @@ else()
 endif()
 set_property(TARGET roboplan PROPERTY CXX_STANDARD 20)
 
-if ( NOT tinyxml2_vendor_FOUND AND NOT TinyXML2_FOUND )
-    set(ROBOPLAN_TARGETS expected tinyxml2 roboplan)
-else()
-    set(ROBOPLAN_TARGETS expected roboplan)
-endif()
-
+set(ROBOPLAN_TARGETS ${TARGETS_LIST})
 install(
   TARGETS
   ${ROBOPLAN_TARGETS}

--- a/roboplan/package.xml
+++ b/roboplan/package.xml
@@ -11,8 +11,10 @@
 
   <depend>eigen</depend>
   <depend>pinocchio</depend>
-  <depend>tinyxml2</depend>
-  <depend>tinyxml2_vendor</depend>
+  <!-- NOTE: Ensure to update this as humble, jazzy, and kilted go end of life. -->
+  <depend condition="$ROS_DISTRO != humble and $ROS_DISTRO != jazzy and $ROS_DISTRO != kilted">tinyxml2</depend>
+  <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == jazzy or $ROS_DISTRO == kilted">tinyxml2_vendor</depend>
+  <depend>tl_expected</depend>
   <depend>yaml_cpp_vendor</depend>
 
   <test_depend>roboplan_example_models</test_depend>

--- a/roboplan_rrt/CMakeLists.txt
+++ b/roboplan_rrt/CMakeLists.txt
@@ -22,11 +22,8 @@ target_include_directories(roboplan_rrt PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(roboplan_rrt
-    roboplan::expected
-    roboplan::roboplan
-)
 set_property(TARGET roboplan_rrt PROPERTY CXX_STANDARD 20)
+target_link_libraries(roboplan_rrt roboplan::roboplan)
 
 install(
   TARGETS

--- a/roboplan_toppra/CMakeLists.txt
+++ b/roboplan_toppra/CMakeLists.txt
@@ -23,12 +23,11 @@ target_include_directories(roboplan_toppra PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+set_property(TARGET roboplan_toppra PROPERTY CXX_STANDARD 20)
 target_link_libraries(roboplan_toppra
-    roboplan::expected
     roboplan::roboplan
     toppra::toppra
 )
-set_property(TARGET roboplan_toppra PROPERTY CXX_STANDARD 20)
 
 install(
   TARGETS


### PR DESCRIPTION
This PR does two things:

1. Stops depending on `tinyxml2_vendor` package in newer ROS distros (Rolling / Lyrical and later) by using conditionals in the `roboplan/package.xml`. This is to avoid deprecation warnings.
2. If using ROS, relies on binary version of `tl_expected` instead of building it from source. This adds a little LLM-assisted CMake magic to handle these cases.