### PR TITLE
Add cmake option to generate Python stubs

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -147,7 +147,6 @@ target_link_libraries(roboplan_ext PRIVATE
   roboplan_toppra::roboplan_toppra
   tl_expected::tl_expected
 )
-set_target_properties(roboplan_ext PROPERTIES PREFIX "")
 
 if(AMENT_BUILD)
   ament_get_python_install_dir(PYTHON_INSTALL_DIR)


### PR DESCRIPTION
Needed for cross-compilation support in conda