### PR TITLE
Get toppra from binaries or FetchContent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/toppra"]
-	path = external/toppra
-	url = https://github.com/hungpham2511/toppra.git

--- a/roboplan_oink/cmake/roboplan_oinkConfig.cmake.in
+++ b/roboplan_oink/cmake/roboplan_oinkConfig.cmake.in
@@ -2,16 +2,15 @@
 
 find_package(roboplan REQUIRED)
 
-# Try to find OsqpEigen - it may be in the same install prefix as roboplan_oink
-# if it was built via FetchContent. PACKAGE_PREFIX_DIR is set by @PACKAGE_INIT@
-# and points to the installation prefix of this package.
-set(OSQP_SEARCH_PATH "${PACKAGE_PREFIX_DIR}")
-find_package(osqp QUIET PATHS "${OSQP_SEARCH_PATH}" NO_DEFAULT_PATH)
+# Try to find osqp and OsqpEigen - they may be in the same install prefix as
+# roboplan_oink if they were built via FetchContent. PACKAGE_PREFIX_DIR is set
+# by @PACKAGE_INIT@ and points to the installation prefix of this package.
+find_package(osqp QUIET PATHS "${PACKAGE_PREFIX_DIR}" NO_DEFAULT_PATH)
 if(NOT osqp_FOUND)
   find_package(osqp QUIET)
 endif()
 
-find_package(OsqpEigen QUIET PATHS "${OSQP_SEARCH_PATH}" NO_DEFAULT_PATH)
+find_package(OsqpEigen QUIET PATHS "${PACKAGE_PREFIX_DIR}" NO_DEFAULT_PATH)
 if(NOT OsqpEigen_FOUND)
   find_package(OsqpEigen REQUIRED)
 endif()

--- a/roboplan_oink/package.xml
+++ b/roboplan_oink/package.xml
@@ -11,6 +11,8 @@
 
   <depend>roboplan</depend>
 
+  <test_depend>roboplan_example_models</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/roboplan_rrt/package.xml
+++ b/roboplan_rrt/package.xml
@@ -11,6 +11,8 @@
 
   <depend>roboplan</depend>
 
+  <test_depend>roboplan_example_models</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/roboplan_toppra/CMakeLists.txt
+++ b/roboplan_toppra/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT toppra_FOUND)
     FetchContent_Declare(
         toppra
         GIT_REPOSITORY https://github.com/hungpham2511/toppra.git
-        GIT_TAG 0.6.5  # TODO: update to 0.6.6 when it's out
+        GIT_TAG 0.6.6
         SOURCE_SUBDIR cpp
     )
     FetchContent_MakeAvailable(toppra)

--- a/roboplan_toppra/CMakeLists.txt
+++ b/roboplan_toppra/CMakeLists.txt
@@ -13,6 +13,7 @@ include(FetchContent)
 find_package(toppra QUIET)
 if(NOT toppra_FOUND)
     message(STATUS "toppra not found. Fetching from GitHub...")
+    set(BUILD_TESTS OFF CACHE BOOL "Disable toppra tests" FORCE)
     FetchContent_Declare(
         toppra
         GIT_REPOSITORY https://github.com/hungpham2511/toppra.git
@@ -20,6 +21,10 @@ if(NOT toppra_FOUND)
         SOURCE_SUBDIR cpp
     )
     FetchContent_MakeAvailable(toppra)
+
+    # toppra creates non-namespaced targets when built via FetchContent,
+    # so we will make an alias to correct this.
+    add_library(toppra::toppra ALIAS toppra)
 endif()
 
 # Ament CMake is not immediately required, but we include it at the top so that

--- a/roboplan_toppra/CMakeLists.txt
+++ b/roboplan_toppra/CMakeLists.txt
@@ -7,7 +7,20 @@ endif()
 
 # Find dependencies.
 find_package(roboplan REQUIRED)
-find_package(toppra REQUIRED)
+
+# If toppra is not found, fetch it from GitHub.
+include(FetchContent)
+find_package(toppra QUIET)
+if(NOT toppra_FOUND)
+    message(STATUS "toppra not found. Fetching from GitHub...")
+    FetchContent_Declare(
+        toppra
+        GIT_REPOSITORY https://github.com/hungpham2511/toppra.git
+        GIT_TAG 0.6.5  # TODO: update to 0.6.6 when it's out
+        SOURCE_SUBDIR cpp
+    )
+    FetchContent_MakeAvailable(toppra)
+endif()
 
 # Ament CMake is not immediately required, but we include it at the top so that
 # if it is found we can use it in build testing before requiring a

--- a/roboplan_toppra/CMakeLists.txt
+++ b/roboplan_toppra/CMakeLists.txt
@@ -8,6 +8,12 @@ endif()
 # Find dependencies.
 find_package(roboplan REQUIRED)
 
+# Ament CMake is not immediately required, but we include it at the top so that
+# if it is found we can use it in build testing before requiring a
+# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
+# issues with symlink installs.
+find_package(ament_cmake QUIET)
+
 # If toppra is not found, fetch it from GitHub.
 include(FetchContent)
 find_package(toppra QUIET)
@@ -25,14 +31,10 @@ if(NOT toppra_FOUND)
 
     # toppra creates non-namespaced targets when built via FetchContent,
     # so we will make an alias to correct this.
-    add_library(toppra::toppra ALIAS toppra)
+    if(TARGET toppra AND NOT TARGET toppra::toppra)
+        add_library(toppra::toppra ALIAS toppra)
+    endif()
 endif()
-
-# Ament CMake is not immediately required, but we include it at the top so that
-# if it is found we can use it in build testing before requiring a
-# find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion
-# issues with symlink installs.
-find_package(ament_cmake QUIET)
 
 # Add libraries
 add_library(roboplan_toppra SHARED

--- a/roboplan_toppra/CMakeLists.txt
+++ b/roboplan_toppra/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(toppra QUIET)
 if(NOT toppra_FOUND)
     message(STATUS "toppra not found. Fetching from GitHub...")
     set(BUILD_TESTS OFF CACHE BOOL "Disable toppra tests" FORCE)
+    set(PYTHON_BINDINGS OFF CACHE BOOL "Disable toppra Python bindings" FORCE)
     FetchContent_Declare(
         toppra
         GIT_REPOSITORY https://github.com/hungpham2511/toppra.git

--- a/roboplan_toppra/cmake/roboplan_toppraConfig.cmake.in
+++ b/roboplan_toppra/cmake/roboplan_toppraConfig.cmake.in
@@ -1,6 +1,13 @@
 @PACKAGE_INIT@
 
 find_package(roboplan REQUIRED)
-find_package(toppra REQUIRED)
+
+# Try to find toppra - it may be in the same install prefix as roboplan_toppra
+# if it was built via FetchContent. PACKAGE_PREFIX_DIR is set by @PACKAGE_INIT@
+# and points to the installation prefix of this package.
+find_package(toppra QUIET PATHS "${PACKAGE_PREFIX_DIR}" NO_DEFAULT_PATH)
+if(NOT toppra_FOUND)
+  find_package(toppra QUIET)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/roboplan_toppraTargets.cmake")

--- a/roboplan_toppra/package.xml
+++ b/roboplan_toppra/package.xml
@@ -10,7 +10,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>roboplan</depend>
-  <depend>toppra</depend>
+  <!-- uncomment when toppra is on the ROS buildfarm for all distros -->
+  <!-- <depend>toppra</depend> -->
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/roboplan_toppra/package.xml
+++ b/roboplan_toppra/package.xml
@@ -13,6 +13,8 @@
   <!-- uncomment when toppra is on the ROS buildfarm for all distros -->
   <!-- <depend>toppra</depend> -->
 
+  <test_depend>roboplan_example_models</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/scripts/build_cmake.bash
+++ b/scripts/build_cmake.bash
@@ -8,61 +8,34 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT_DIR="${SCRIPT_DIR}/.."
 pushd ${REPO_ROOT_DIR} || exit
 
+# Helper function to build a CMake project.
+build_project() {
+  local PROJECT_NAME=$1
+
+  if [ -z "$PROJECT_NAME" ]; then
+    echo "Error: No project name provided."
+    return 1
+  fi
+
+  cmake "${PROJECT_NAME}/CMakeLists.txt" \
+    -B"build/${PROJECT_NAME}" \
+    -DCMAKE_INSTALL_PREFIX="${PWD}/install/${PROJECT_NAME}"
+  cmake --build "build/${PROJECT_NAME}"
+  cmake --install "build/${PROJECT_NAME}"
+}
+
 # Build all the packages with CMake
 # rm -rf build install  # If you want a clean build
 mkdir -p build install
 export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:${PWD}/install/
 
-# TODO: Make into reusable function?
-cmake roboplan_example_models/CMakeLists.txt \
-    -Bbuild/roboplan_example_models \
-    -DCMAKE_INSTALL_PREFIX=${PWD}/install/roboplan_example_models
-cmake --build build/roboplan_example_models
-cmake --install build/roboplan_example_models
-
-cmake roboplan/CMakeLists.txt \
-  -Bbuild/roboplan \
-  -DCMAKE_INSTALL_PREFIX=${PWD}/install/roboplan
-cmake --build build/roboplan
-cmake --install build/roboplan
-
-cmake roboplan_simple_ik/CMakeLists.txt \
-  -Bbuild/roboplan_simple_ik \
-  -DCMAKE_INSTALL_PREFIX=${PWD}/install/roboplan_simple_ik
-cmake --build build/roboplan_simple_ik
-cmake --install build/roboplan_simple_ik
-
-cmake roboplan_rrt/CMakeLists.txt \
-  -Bbuild/roboplan_rrt \
-  -DCMAKE_INSTALL_PREFIX=${PWD}/install/roboplan_rrt
-cmake --build build/roboplan_rrt
-cmake --install build/roboplan_rrt
-
-cmake roboplan_oink/CMakeLists.txt \
-  -Bbuild/roboplan_oink \
-  -DCMAKE_INSTALL_PREFIX=${PWD}/install/roboplan_oink
-cmake --build build/roboplan_oink
-cmake --install build/roboplan_oink
-
-cmake external/toppra/cpp/CMakeLists.txt \
-  -Bbuild/toppra \
-  -DCMAKE_INSTALL_PREFIX=${PWD}/install/toppra \
-  -DBUILD_TESTS=OFF \
-  -DPYTHON_BINDINGS=OFF
-cmake --build build/toppra
-cmake --install build/toppra
-
-cmake roboplan_toppra/CMakeLists.txt \
-  -Bbuild/roboplan_toppra \
-  -DCMAKE_INSTALL_PREFIX=${PWD}/install/roboplan_toppra
-cmake --build build/roboplan_toppra
-cmake --install build/roboplan_toppra
-
-cmake roboplan_examples/CMakeLists.txt \
-  -Bbuild/roboplan_examples \
-  -DCMAKE_INSTALL_PREFIX=${PWD}/install/roboplan_examples
-cmake --build build/roboplan_examples
-cmake --install build/roboplan_examples
+build_project roboplan_example_models
+build_project roboplan
+build_project roboplan_simple_ik
+build_project roboplan_oink
+build_project roboplan_toppra
+build_project roboplan_rrt
+build_project roboplan_examples
 
 echo "
 =======================


### PR DESCRIPTION
Removes submodules from this repo for ROS buildfarm compatibility.

(plus bonus overdue cleanup of the `build_cmake.bash` script!)