### PR TITLE
Use parallel builds in vanilla CMake script

### DIFF
--- a/scripts/build_cmake.bash
+++ b/scripts/build_cmake.bash
@@ -20,7 +20,7 @@ build_project() {
   cmake "${PROJECT_NAME}/CMakeLists.txt" \
     -B"build/${PROJECT_NAME}" \
     -DCMAKE_INSTALL_PREFIX="${PWD}/install/${PROJECT_NAME}"
-  cmake --build "build/${PROJECT_NAME}"
+  cmake --build "build/${PROJECT_NAME}" --parallel "$(nproc)"
   cmake --install "build/${PROJECT_NAME}"
 }
 


### PR DESCRIPTION
Should add this because why not?

We're not (and hope to never be) in a space where using all cores OOMs the system. Especially since this anyway builds 1 cmake project at a time.