### PR TITLE
Use native mimic joint functionality in Pinocchio

### DIFF
--- a/benchmarks/test_benchmark_rrt.py
+++ b/benchmarks/test_benchmark_rrt.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(examples_dir))
 from common import get_model_data
 
 
-def solve(scene: Scene, rrt: RRT, seed: int = 1234):
+def solve(scene: Scene, rrt: RRT, q_indices, seed: int = 1234):
     """
     Runs an RRT test by sampling random, collision-free joint configurations
     then attempting to plan a path between them.
@@ -25,13 +25,17 @@ def solve(scene: Scene, rrt: RRT, seed: int = 1234):
     """
     rrt.setRngSeed(seed)
 
+    q_start_full = scene.randomCollisionFreePositions()
+    assert q_start_full is not None
+
+    q_goal_full = scene.randomCollisionFreePositions()
+    assert q_goal_full is not None
+
     start = JointConfiguration()
-    start.positions = scene.randomCollisionFreePositions()
-    assert start.positions is not None
+    start.positions = q_start_full[q_indices]
 
     goal = JointConfiguration()
-    goal.positions = scene.randomCollisionFreePositions()
-    assert goal.positions is not None
+    goal.positions = q_goal_full[q_indices]
 
     try:
         path = rrt.plan(start, goal)
@@ -41,7 +45,7 @@ def solve(scene: Scene, rrt: RRT, seed: int = 1234):
     return 0 if path is None else 1
 
 
-def solve_many(scene: Scene, rrt: RRT, iterations: int = 10, seed: int = 1234):
+def solve_many(scene: Scene, rrt: RRT, q_indices, iterations: int = 10, seed: int = 1234):
     """
     Runs the specified number of iterations of RRT with a random seed.
 
@@ -49,7 +53,7 @@ def solve_many(scene: Scene, rrt: RRT, iterations: int = 10, seed: int = 1234):
     """
     successes = 0
     for i in range(iterations):
-        successes += solve(scene, rrt, seed + i)
+        successes += solve(scene, rrt, q_indices, seed + i)
     return successes
 
 
@@ -71,26 +75,52 @@ def create_scene(model_name: str) -> Scene:
 
 
 @pytest.fixture(scope="session", params=["so101", "kinova", "ur5", "franka", "dual"])
-def scene(request):
-    return create_scene(request.param)
+def benchmark_setup(request):
+    """Scene and RRT configuration aligned with example_rrt.py."""
+    model_name = request.param
+    model_data = get_model_data()[model_name]
+    scene = create_scene(model_name)
+    group_info = scene.getJointGroupInfo(model_data.default_joint_group)
+    return {
+        "model_name": model_name,
+        "scene": scene,
+        "group_name": model_data.default_joint_group,
+        "q_indices": group_info.q_indices,
+    }
 
 
-def test_benchmark_rrt(benchmark, scene):
+def test_benchmark_rrt(benchmark, benchmark_setup):
+    scene = benchmark_setup["scene"]
     options = RRTOptions()
+    options.group_name = benchmark_setup["group_name"]
     options.max_nodes = 100000
     options.max_planning_time = 10.0
     rrt = RRT(scene, options)
 
-    success_rate = benchmark(solve_many, scene, rrt, iterations=10)
+    success_rate = benchmark(
+        solve_many,
+        scene,
+        rrt,
+        benchmark_setup["q_indices"],
+        iterations=10,
+    )
     assert success_rate >= 0.95
 
 
-def test_benchmark_rrt_connect(benchmark, scene):
+def test_benchmark_rrt_connect(benchmark, benchmark_setup):
+    scene = benchmark_setup["scene"]
     options = RRTOptions()
+    options.group_name = benchmark_setup["group_name"]
     options.max_nodes = 100000
     options.rrt_connect = True
     options.max_planning_time = 10.0
     rrt = RRT(scene, options)
 
-    success_rate = benchmark(solve_many, scene, rrt, iterations=10)
+    success_rate = benchmark(
+        solve_many,
+        scene,
+        rrt,
+        benchmark_setup["q_indices"],
+        iterations=10,
+    )
     assert success_rate >= 0.95

--- a/benchmarks/test_benchmark_rrt.py
+++ b/benchmarks/test_benchmark_rrt.py
@@ -45,7 +45,9 @@ def solve(scene: Scene, rrt: RRT, q_indices, seed: int = 1234):
     return 0 if path is None else 1
 
 
-def solve_many(scene: Scene, rrt: RRT, q_indices, iterations: int = 10, seed: int = 1234):
+def solve_many(
+    scene: Scene, rrt: RRT, q_indices, iterations: int = 10, seed: int = 1234
+):
     """
     Runs the specified number of iterations of RRT with a random seed.
 

--- a/bindings/src/modules/core.cpp
+++ b/bindings/src/modules/core.cpp
@@ -194,6 +194,8 @@ void init_core_scene(nanobind::module_& m) {
           "yaml_config_path"_a = std::filesystem::path())
       .def("getName", &Scene::getName, "Gets the scene's name.")
       .def("getJointNames", &Scene::getJointNames,
+           "Gets the scene's actuated joint names (non-mimic joints only).")
+      .def("getJointNamesWithMimics", &Scene::getJointNamesWithMimics,
            "Gets the scene's full joint names, including mimic joints.")
       .def("getJointInfo", unwrap_expected(&Scene::getJointInfo),
            "Gets the information for a specific joint.", "joint_name"_a)
@@ -240,7 +242,10 @@ void init_core_scene(nanobind::module_& m) {
       .def("getJointGroupInfo", unwrap_expected(&Scene::getJointGroupInfo),
            "Get the joint group information of a scene by its name.", "name"_a)
       .def("getCurrentJointPositions", &Scene::getCurrentJointPositions,
-           "Get the current joint positions for the full robot state.")
+           "Get the current Pinocchio configuration vector (model.nq).")
+      .def("getCurrentJointPositionsWithMimics", &Scene::getCurrentJointPositionsWithMimics,
+           "Get current joint positions in getJointNamesWithMimics() order, including mimic "
+           "values.")
       .def("setJointPositions", &Scene::setJointPositions,
            "Set the joint positions for the full robot state.", "positions"_a)
       .def("getJointPositionIndices", &Scene::getJointPositionIndices,

--- a/bindings/src/modules/core.cpp
+++ b/bindings/src/modules/core.cpp
@@ -195,8 +195,6 @@ void init_core_scene(nanobind::module_& m) {
       .def("getName", &Scene::getName, "Gets the scene's name.")
       .def("getJointNames", &Scene::getJointNames,
            "Gets the scene's full joint names, including mimic joints.")
-      .def("getActuatedJointNames", &Scene::getActuatedJointNames,
-           "Gets the scene's actuated (non-mimic) joint names.")
       .def("getJointInfo", unwrap_expected(&Scene::getJointInfo),
            "Gets the information for a specific joint.", "joint_name"_a)
       .def("configurationDistance", &Scene::configurationDistance,

--- a/bindings/src/modules/core.cpp
+++ b/bindings/src/modules/core.cpp
@@ -211,16 +211,6 @@ void init_core_scene(nanobind::module_& m) {
            "Checks collisions at specified joint positions.", "q"_a, "debug"_a = false)
       .def("isValidPose", &Scene::isValidPose,
            "Checks if the specified joint positions are valid with respect to joint limits.", "q"_a)
-      // Modification is not guaranteed to be done in place for python objects, as they
-      // may be copied by nanobind. To guarantee values are correctly updated, we use
-      // a lambda function to return a reference to the changed value.
-      .def(
-          "applyMimics",
-          [](const Scene& self, Eigen::VectorXd& q) -> Eigen::VectorXd {
-            self.applyMimics(q);
-            return q;
-          },
-          "Applies mimic joint relationships to a position vector.", "q"_a)
       .def("toFullJointPositions", &Scene::toFullJointPositions,
            "Converts partial joint positions to full joint positions.", "group_name"_a, "q"_a)
       .def("interpolate", &Scene::interpolate, "Interpolates between two joint configurations.",

--- a/bindings/src/roboplan/roboplan_ext/core.pyi
+++ b/bindings/src/roboplan/roboplan_ext/core.pyi
@@ -403,6 +403,9 @@ class Scene:
         """Gets the scene's name."""
 
     def getJointNames(self) -> list[str]:
+        """Gets the scene's actuated joint names (non-mimic joints only)."""
+
+    def getJointNamesWithMimics(self) -> list[str]:
         """Gets the scene's full joint names, including mimic joints."""
 
     def getJointInfo(self, joint_name: str) -> JointInfo:
@@ -452,7 +455,12 @@ class Scene:
         """Get the joint group information of a scene by its name."""
 
     def getCurrentJointPositions(self) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
-        """Get the current joint positions for the full robot state."""
+        """Get the current Pinocchio configuration vector (model.nq)."""
+
+    def getCurrentJointPositionsWithMimics(self) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
+        """
+        Get current joint positions in getJointNamesWithMimics() order, including mimic values.
+        """
 
     def setJointPositions(self, positions: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> None:
         """Set the joint positions for the full robot state."""

--- a/bindings/src/roboplan/roboplan_ext/core.pyi
+++ b/bindings/src/roboplan/roboplan_ext/core.pyi
@@ -431,9 +431,6 @@ class Scene:
         Checks if the specified joint positions are valid with respect to joint limits.
         """
 
-    def applyMimics(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
-        """Applies mimic joint relationships to a position vector."""
-
     def toFullJointPositions(self, group_name: str, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
         """Converts partial joint positions to full joint positions."""
 

--- a/bindings/src/roboplan/roboplan_ext/core.pyi
+++ b/bindings/src/roboplan/roboplan_ext/core.pyi
@@ -405,9 +405,6 @@ class Scene:
     def getJointNames(self) -> list[str]:
         """Gets the scene's full joint names, including mimic joints."""
 
-    def getActuatedJointNames(self) -> list[str]:
-        """Gets the scene's actuated (non-mimic) joint names."""
-
     def getJointInfo(self, joint_name: str) -> JointInfo:
         """Gets the information for a specific joint."""
 

--- a/bindings/test/test_scene.py
+++ b/bindings/test/test_scene.py
@@ -77,7 +77,7 @@ def test_scene() -> Scene:
 
 def test_scene_properties(test_scene: Scene) -> None:
     assert test_scene.getName() == "test_scene"
-    assert test_scene.getJointNames() == [
+    expected_joint_names = [
         "shoulder_pan_joint",
         "shoulder_lift_joint",
         "elbow_joint",
@@ -85,6 +85,12 @@ def test_scene_properties(test_scene: Scene) -> None:
         "wrist_2_joint",
         "wrist_3_joint",
     ]
+    assert test_scene.getJointNames() == expected_joint_names
+    assert test_scene.getJointNamesWithMimics() == expected_joint_names
+    assert np.allclose(
+        test_scene.getCurrentJointPositionsWithMimics(),
+        test_scene.getCurrentJointPositions(),
+    )
 
     joint_info = test_scene.getJointInfo("shoulder_pan_joint")
     assert joint_info.type == JointType.REVOLUTE
@@ -336,7 +342,18 @@ def test_jerk_limits_vector(test_scene: Scene) -> None:
 def test_mimics() -> None:
     # Native Pinocchio mimics: mimic has no q slot; link3 pose follows revolute via FK.
     test_scene = Scene("test_scene", urdf=URDF, srdf=SRDF)
+    assert test_scene.getJointNames() == ["continuous_joint", "revolute_joint"]
+    assert test_scene.getJointNamesWithMimics() == [
+        "continuous_joint",
+        "revolute_joint",
+        "mimic_joint",
+    ]
     q = np.array([1.0, 0.0, 0.5])
+    test_scene.setJointPositions(q)
+    assert np.allclose(test_scene.getCurrentJointPositions(), q)
+    assert np.allclose(
+        test_scene.getCurrentJointPositionsWithMimics(), [1.0, 0.0, 0.5, 0.5]
+    )
     T0 = test_scene.forwardKinematics(q, "link3")
     q[2] = 1.0
     T1 = test_scene.forwardKinematics(q, "link3")

--- a/bindings/test/test_scene.py
+++ b/bindings/test/test_scene.py
@@ -332,6 +332,7 @@ def test_jerk_limits_vector(test_scene: Scene) -> None:
     assert np.allclose(lower_limits, expected_lower_limits)
     assert np.allclose(upper_limits, expected_upper_limits)
 
+
 def test_mimics() -> None:
     # Native Pinocchio mimics: mimic has no q slot; link3 pose follows revolute via FK.
     test_scene = Scene("test_scene", urdf=URDF, srdf=SRDF)

--- a/bindings/test/test_scene.py
+++ b/bindings/test/test_scene.py
@@ -332,12 +332,11 @@ def test_jerk_limits_vector(test_scene: Scene) -> None:
     assert np.allclose(lower_limits, expected_lower_limits)
     assert np.allclose(upper_limits, expected_upper_limits)
 
-
 def test_mimics() -> None:
-    # Equivalent to the C++ test, but the updated joint state is returned as a new
-    # object rather than updated in place.
+    # Native Pinocchio mimics: mimic has no q slot; link3 pose follows revolute via FK.
     test_scene = Scene("test_scene", urdf=URDF, srdf=SRDF)
-    q = np.zeros(4)
+    q = np.array([1.0, 0.0, 0.5])
+    T0 = test_scene.forwardKinematics(q, "link3")
     q[2] = 1.0
-    s = test_scene.applyMimics(q)
-    assert s[3] == 1.0
+    T1 = test_scene.forwardKinematics(q, "link3")
+    assert not np.allclose(T0, T1)

--- a/roboplan/include/roboplan/core/scene.hpp
+++ b/roboplan/include/roboplan/core/scene.hpp
@@ -71,10 +71,6 @@ public:
   /// @return A vector of joint names.
   const std::vector<std::string>& getJointNames() const { return joint_names_; };
 
-  /// @brief Gets the scene's actuated (non-mimic) joint names.
-  /// @return A vector of joint names.
-  const std::vector<std::string>& getActuatedJointNames() const { return actuated_joint_names_; };
-
   /// @brief Gets the information for a specific joint.
   /// @param joint_name The name of the joint.
   /// @return The joint information struct if successful, else a string describing the error.
@@ -318,9 +314,6 @@ private:
 
   /// @brief The full list of joint names in the model (including mimic joints).
   std::vector<std::string> joint_names_;
-
-  /// @brief The list of actuated (non-mimic) joint names in the model.
-  std::vector<std::string> actuated_joint_names_;
 
   /// @brief Map from joint names to their corresponding information.
   std::unordered_map<std::string, JointInfo> joint_info_map_;

--- a/roboplan/include/roboplan/core/scene.hpp
+++ b/roboplan/include/roboplan/core/scene.hpp
@@ -162,8 +162,8 @@ public:
   const Eigen::VectorXd& getCurrentJointPositions() const { return cur_state_.positions; }
 
   /// @brief Set the joint positions for the full robot state.
-  /// @return The desired joint position vector.
-  void setJointPositions(const Eigen::VectorXd& positions) { cur_state_.positions = positions; }
+  /// @param positions The desired joint position vector (size model.nq).
+  void setJointPositions(const Eigen::VectorXd& positions);
 
   /// @brief Get the joint position indices for a set of joint names.
   /// @param joint_names The joint names for which to look up position indices.

--- a/roboplan/include/roboplan/core/scene.hpp
+++ b/roboplan/include/roboplan/core/scene.hpp
@@ -67,9 +67,13 @@ public:
   /// @return The Pinocchio collision (geometry) model.
   const pinocchio::GeometryModel& getCollisionModel() const { return collision_model_; };
 
+  /// @brief Gets the scene's actuated joint names (non-mimic joints only).
+  /// @return A vector of joint names.
+  const std::vector<std::string>& getJointNames() const { return actuated_joint_names_; };
+
   /// @brief Gets the scene's full joint names, including mimic joints.
   /// @return A vector of joint names.
-  const std::vector<std::string>& getJointNames() const { return joint_names_; };
+  const std::vector<std::string>& getJointNamesWithMimics() const { return joint_names_; };
 
   /// @brief Gets the information for a specific joint.
   /// @param joint_name The name of the joint.
@@ -153,9 +157,17 @@ public:
   /// @return The joint group information if successful, else a string describing the error.
   tl::expected<JointGroupInfo, std::string> getJointGroupInfo(const std::string& name) const;
 
-  /// @brief Get the current joint positions for the full robot state.
+  /// @brief Get the current Pinocchio configuration vector (model.nq).
+  /// @details This is the internal planning layout (e.g. continuous joints as [cos, sin]).
+  /// Joint count may differ from getJointNames().size().
   /// @return The current joint position vector.
   const Eigen::VectorXd& getCurrentJointPositions() const { return cur_state_.positions; }
+
+  /// @brief Get current joint positions for all joints in getJointNamesWithMimics() order.
+  /// @details Actuated joints copy values from the Pinocchio configuration; mimic joints use
+  /// scaling * mimicked_position + offset per degree of freedom.
+  /// @return The joint position vector aligned with getJointNamesWithMimics().
+  Eigen::VectorXd getCurrentJointPositionsWithMimics() const;
 
   /// @brief Set the joint positions for the full robot state.
   /// @param positions The desired joint position vector (size model.nq).
@@ -314,6 +326,9 @@ private:
 
   /// @brief The full list of joint names in the model (including mimic joints).
   std::vector<std::string> joint_names_;
+
+  /// @brief Actuated (non-mimic) joint names in model order.
+  std::vector<std::string> actuated_joint_names_;
 
   /// @brief Map from joint names to their corresponding information.
   std::unordered_map<std::string, JointInfo> joint_info_map_;

--- a/roboplan/include/roboplan/core/scene.hpp
+++ b/roboplan/include/roboplan/core/scene.hpp
@@ -111,12 +111,8 @@ public:
   /// @return True if the positions respect joint limits, else false.
   bool isValidPose(const Eigen::VectorXd& q) const;
 
-  /// @brief Applies mimic joint relationships to a position vector.
-  /// @param q The joint positions.
-  void applyMimics(Eigen::VectorXd& q) const;
-
   /// @brief Converts partial joint positions to full joint positions.
-  /// @details This includes adding new joints and applying mimic relationships.
+  /// @details This includes adding new joints.
   /// @param group_name The name of the joint group.
   /// @param q The original (partial) joint positions.
   /// @return The full joint positions.

--- a/roboplan/include/roboplan/core/scene_utils.hpp
+++ b/roboplan/include/roboplan/core/scene_utils.hpp
@@ -64,4 +64,11 @@ tl::expected<Eigen::VectorXd, std::string>
 expandContinuousJointPositions(const Scene& scene, const std::string& group_name,
                                const Eigen::VectorXd& q_orig);
 
+/// @brief Builds joint positions for all joints in getJointNamesWithMimics() order.
+/// @details Non-mimic joints copy their Pinocchio q block; mimic joints use the mimic law.
+/// @param scene The scene from which to look up joint information.
+/// @param q The Pinocchio configuration vector (model.nq).
+/// @return Position vector aligned with getJointNamesWithMimics().
+Eigen::VectorXd jointPositionsWithMimicsFromPinocchio(const Scene& scene, const Eigen::VectorXd& q);
+
 }  // namespace roboplan

--- a/roboplan/src/core/path_utils.cpp
+++ b/roboplan/src/core/path_utils.cpp
@@ -35,8 +35,7 @@ std::vector<Eigen::Matrix4d> computeFramePath(const Scene& scene, const Eigen::V
 
   for (size_t idx = 0; idx <= num_steps; ++idx) {
     const auto fraction = static_cast<double>(idx) / static_cast<double>(num_steps);
-    auto q_interp = scene.interpolate(q_start, q_end, fraction);
-    scene.applyMimics(q_interp);
+    const auto q_interp = scene.interpolate(q_start, q_end, fraction);
     frame_path.push_back(scene.forwardKinematics(q_interp, frame_name));
   }
 
@@ -48,8 +47,7 @@ std::vector<Eigen::Matrix4d> computeFramePath(const Scene& scene,
                                               const std::string& frame_name) {
   std::vector<Eigen::Matrix4d> frame_path;
   frame_path.reserve(q_vec.size());
-  for (auto q : q_vec) {
-    scene.applyMimics(q);
+  for (const auto& q : q_vec) {
     frame_path.push_back(scene.forwardKinematics(q, frame_name));
   }
   return frame_path;

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -869,4 +869,3 @@ std::ostream& operator<<(std::ostream& os, const Scene& scene) {
 }
 
 }  // namespace roboplan
-

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -72,7 +72,7 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
   size_t q_idx = 0;
   size_t v_idx = 0;
   joint_names_.reserve(model_.njoints - 1);
-  actuated_joint_names_.reserve(model_.njoints - 1);
+  actuated_joint_names_.reserve((model_.njoints - 1) - model_.mimicking_joints.size());
   for (int idx = 1; idx < model_.njoints; ++idx) {  // omits "universe" joint.
     const auto& joint_name = model_.names.at(idx);
     joint_names_.push_back(joint_name);

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -385,6 +385,17 @@ Eigen::VectorXd Scene::interpolate(const Eigen::VectorXd& q_start, const Eigen::
   return pinocchio::interpolate(model_, q_start, q_end, fraction);
 }
 
+void Scene::setJointPositions(const Eigen::VectorXd& positions) {
+  if (positions.size() != model_.nq) {
+    throw std::invalid_argument("setJointPositions: expected " + std::to_string(model_.nq) +
+                                " configuration values (model.nq), got " +
+                                std::to_string(positions.size()) +
+                                ". For robots with mimic joints, use the mimic-enabled model "
+                                "layout (not the expanded URDF DOF count).");
+  }
+  cur_state_.positions = positions;
+}
+
 Eigen::VectorXd Scene::integrate(const Eigen::VectorXd& q, const Eigen::VectorXd& v) const {
   return pinocchio::integrate(model_, q, v);
 }
@@ -462,6 +473,10 @@ Scene::getPositionLimitVectors(const std::string& group_name, const bool collaps
                                  maybe_joint_info.error());
     }
     const auto& joint_info = maybe_joint_info.value();
+    if (joint_info.mimic_info) {
+      // Mimic joints have nq=0; they do not occupy slots in the configuration vector.
+      continue;
+    }
 
     switch (joint_info.type) {
     case JointType::FLOATING:

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -56,9 +56,8 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
     package_paths_str.push_back(std::string(path));
   }
 
-  // Start by creating a Pinocchio model with mimic support to parse all the relationships.
-  pinocchio::Model mimic_model;
-  pinocchio::urdf::buildModelFromXML(urdf, mimic_model, /*verbose*/ false, /*mimic*/ true);
+  // Single model with Pinocchio native mimics
+  pinocchio::urdf::buildModelFromXML(urdf, model_, /*verbose*/ false, /*mimic*/ true);
 
   YAML::Node yaml_config;
   if (!yaml_config_path.empty() && !std::filesystem::is_directory(yaml_config_path)) {
@@ -72,13 +71,13 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
   // Create additional robot information.
   size_t q_idx = 0;
   size_t v_idx = 0;
-  joint_names_.reserve(mimic_model.njoints - 1);
-  actuated_joint_names_.reserve(mimic_model.njoints - mimic_model.mimicking_joints.size() - 1);
-  for (int idx = 1; idx < mimic_model.njoints; ++idx) {  // omits "universe" joint.
-    const auto& joint_name = mimic_model.names.at(idx);
+  joint_names_.reserve(model_.njoints - 1);
+  actuated_joint_names_.reserve(model_.njoints - model_.mimicking_joints.size() - 1);
+  for (int idx = 1; idx < model_.njoints; ++idx) {  // omits "universe" joint.
+    const auto& joint_name = model_.names.at(idx);
     joint_names_.push_back(joint_name);
 
-    const auto& joint = mimic_model.joints.at(idx);
+    const auto& joint = model_.joints.at(idx);
     if (joint.shortname() == "JointModelMimic") {
       // If the joint is a mimic joint, do nothing for now.
       // The information will be extracted later.
@@ -94,21 +93,21 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
     switch (info.type) {
     case JointType::PRISMATIC:
     case JointType::REVOLUTE:
-      info.limits.min_position[0] = mimic_model.lowerPositionLimit(q_idx);
-      info.limits.max_position[0] = mimic_model.upperPositionLimit(q_idx);
+      info.limits.min_position[0] = model_.lowerPositionLimit(q_idx);
+      info.limits.max_position[0] = model_.upperPositionLimit(q_idx);
       break;
     case JointType::PLANAR:
       // Only the position limits need to be incorporated, as orientation is unlimited.
       for (size_t dof = 0; dof < 2; ++dof) {
-        info.limits.min_position[dof] = mimic_model.lowerPositionLimit(q_idx + dof);
-        info.limits.max_position[dof] = mimic_model.upperPositionLimit(q_idx + dof);
+        info.limits.min_position[dof] = model_.lowerPositionLimit(q_idx + dof);
+        info.limits.max_position[dof] = model_.upperPositionLimit(q_idx + dof);
       }
       break;
     case JointType::FLOATING:
       // Only the position limits need to be incorporated, as orientation is unlimited.
       for (size_t dof = 0; dof < 3; ++dof) {
-        info.limits.min_position[dof] = mimic_model.lowerPositionLimit(q_idx + dof);
-        info.limits.max_position[dof] = mimic_model.upperPositionLimit(q_idx + dof);
+        info.limits.min_position[dof] = model_.lowerPositionLimit(q_idx + dof);
+        info.limits.max_position[dof] = model_.upperPositionLimit(q_idx + dof);
       }
       break;
     default:  // Includes continuous joints, where no operation is needed.
@@ -140,7 +139,7 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
       }
     }
     for (int idx = 0; idx < joint.nv(); ++idx) {
-      info.limits.max_velocity[idx] = mimic_model.velocityLimit(v_idx);
+      info.limits.max_velocity[idx] = model_.velocityLimit(v_idx);
       if (maybe_acc_limits) {
         info.limits.max_acceleration[idx] = maybe_acc_limits.value()[idx].as<double>();
       }
@@ -153,14 +152,14 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
   }
 
   // Add the mimic joint information once all the other joints have been parsed.
-  const auto num_mimics = mimic_model.mimicked_joints.size();
+  const auto num_mimics = model_.mimicked_joints.size();
   for (size_t idx = 0; idx < num_mimics; ++idx) {
-    const auto mimicking_idx = mimic_model.mimicking_joints[idx];
-    const auto& mimicking_joint_name = mimic_model.names[mimicking_idx];
-    const auto& mimicking_joint = mimic_model.joints[mimicking_idx];
+    const auto mimicking_idx = model_.mimicking_joints[idx];
+    const auto& mimicking_joint_name = model_.names[mimicking_idx];
+    const auto& mimicking_joint = model_.joints[mimicking_idx];
 
-    const auto mimicked_idx = mimic_model.mimicked_joints[idx];
-    const auto& mimicked_joint_name = mimic_model.names[mimicked_idx];
+    const auto mimicked_idx = model_.mimicked_joints[idx];
+    const auto& mimicked_joint_name = model_.names[mimicked_idx];
 
     auto* mimic_joint = boost::get<pinocchio::JointModelMimic>(&mimicking_joint);
     const auto mimicked_joint_info = joint_info_map_.at(mimicked_joint_name);
@@ -199,8 +198,7 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
     joint_info_map_.emplace(mimicking_joint_name, info);
   }
 
-  // Replace the model with its non-mimic version.
-  pinocchio::urdf::buildModelFromXML(urdf, model_);
+  // Collision geometry uses the same mimic-enabled model so placements stay consistent with FK.
   pinocchio::urdf::buildGeom(model_, std::istringstream(urdf), pinocchio::COLLISION,
                              collision_model_, package_paths_str);
   collision_model_.addAllCollisionPairs();
@@ -240,7 +238,7 @@ Eigen::VectorXd Scene::randomPositions() {
   for (const auto& joint_name : joint_names_) {
     const auto& info = joint_info_map_.at(joint_name);
     if (info.mimic_info) {
-      continue;  // Skip mimic joints as they are set later.
+      continue;  // Mimic joints have nq=0; only sample actuated coordinates.
     }
 
     const auto q_idx = model_.idx_qs.at(model_.getJointId(joint_name));
@@ -279,7 +277,6 @@ Eigen::VectorXd Scene::randomPositions() {
     }
   }
 
-  applyMimics(positions);
   return positions;
 }
 
@@ -320,8 +317,8 @@ bool Scene::isValidPose(const Eigen::VectorXd& q) const {
   for (const auto& joint_name : joint_names_) {
     const auto& info = joint_info_map_.at(joint_name);
     if (info.mimic_info) {
-      ++q_idx;
-      continue;  // Skip over mimic joints since we validate their parent.
+      // Mimic joints occupy no q slots; limits are enforced on the mimicked parent above.
+      continue;
     }
 
     switch (info.type) {
@@ -363,30 +360,6 @@ bool Scene::isValidPose(const Eigen::VectorXd& q) const {
   return true;
 }
 
-void Scene::applyMimics(Eigen::VectorXd& q) const {
-  for (const auto& [joint_name, joint_info] : joint_info_map_) {
-    if (!joint_info.mimic_info) {
-      continue;
-    }
-    const auto& mimic_info = joint_info.mimic_info.value();
-
-    const auto mimicking_idx = model_.getJointId(joint_name);
-    const auto mimicking_idx_q = model_.idx_qs[mimicking_idx];
-
-    const auto mimicked_idx = model_.getJointId(mimic_info.mimicked_joint_name);
-    const auto mimicked_idx_q = model_.idx_qs[mimicked_idx];
-
-    if (joint_info.type == JointType::CONTINUOUS) {
-      const auto mimicked_angle = std::atan2(q(mimicked_idx_q + 1), q(mimicked_idx_q));
-      const auto mimicking_angle = mimicked_angle * mimic_info.scaling + mimic_info.offset;
-      q(mimicking_idx_q) = std::cos(mimicking_angle);
-      q(mimicking_idx_q + 1) = std::sin(mimicking_angle);
-    } else {  // Prismatic or revolute, which are single-DOF.
-      q(mimicking_idx_q) = q(mimicked_idx_q) * mimic_info.scaling + mimic_info.offset;
-    }
-  }
-}
-
 Eigen::VectorXd Scene::toFullJointPositions(const std::string& group_name,
                                             const Eigen::VectorXd& q) const {
   Eigen::VectorXd q_out = cur_state_.positions;
@@ -404,7 +377,6 @@ Eigen::VectorXd Scene::toFullJointPositions(const std::string& group_name,
   }
 
   q_out(q_indices) = q;
-  applyMimics(q_out);
   return q_out;
 }
 
@@ -882,3 +854,4 @@ std::ostream& operator<<(std::ostream& os, const Scene& scene) {
 }
 
 }  // namespace roboplan
+

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -72,7 +72,6 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
   size_t q_idx = 0;
   size_t v_idx = 0;
   joint_names_.reserve(model_.njoints - 1);
-  actuated_joint_names_.reserve(model_.njoints - model_.mimicking_joints.size() - 1);
   for (int idx = 1; idx < model_.njoints; ++idx) {  // omits "universe" joint.
     const auto& joint_name = model_.names.at(idx);
     joint_names_.push_back(joint_name);
@@ -83,7 +82,6 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
       // The information will be extracted later.
       continue;
     }
-    actuated_joint_names_.push_back(joint_name);
 
     if (!kPinocchioJointTypeMap.contains(joint.shortname())) {
       throw std::runtime_error("Joint '" + joint_name + "' was parsed as a joint of type '" +

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -72,6 +72,7 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
   size_t q_idx = 0;
   size_t v_idx = 0;
   joint_names_.reserve(model_.njoints - 1);
+  actuated_joint_names_.reserve(model_.njoints - 1);
   for (int idx = 1; idx < model_.njoints; ++idx) {  // omits "universe" joint.
     const auto& joint_name = model_.names.at(idx);
     joint_names_.push_back(joint_name);
@@ -82,6 +83,7 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
       // The information will be extracted later.
       continue;
     }
+    actuated_joint_names_.push_back(joint_name);
 
     if (!kPinocchioJointTypeMap.contains(joint.shortname())) {
       throw std::runtime_error("Joint '" + joint_name + "' was parsed as a joint of type '" +
@@ -210,10 +212,14 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
   collision_model_data_ = pinocchio::GeometryData(collision_model_);
 
   // Initialize the current state of the scene.
-  cur_state_ = JointConfiguration{.joint_names = joint_names_,
+  cur_state_ = JointConfiguration{.joint_names = actuated_joint_names_,
                                   .positions = pinocchio::neutral(model_),
                                   .velocities = Eigen::VectorXd::Zero(model_.nv),
                                   .accelerations = Eigen::VectorXd::Zero(model_.nv)};
+}
+
+Eigen::VectorXd Scene::getCurrentJointPositionsWithMimics() const {
+  return jointPositionsWithMimicsFromPinocchio(*this, cur_state_.positions);
 }
 
 tl::expected<JointInfo, std::string> Scene::getJointInfo(const std::string& joint_name) const {

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -115,10 +115,20 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
     }
     q_idx += info.num_position_dofs;
 
+    std::optional<YAML::Node> maybe_vel_limits;  // overrides URDF if supplied
     std::optional<YAML::Node> maybe_acc_limits;
     std::optional<YAML::Node> maybe_jerk_limits;
     if (yaml_config["joint_limits"] && yaml_config["joint_limits"][joint_name]) {
       const auto& limits_config = yaml_config["joint_limits"][joint_name];
+      if (limits_config["max_velocity"]) {
+        maybe_vel_limits = limits_config["max_velocity"];
+        if (!maybe_vel_limits->IsSequence() ||
+            (maybe_vel_limits->size() != static_cast<size_t>(joint.nv()))) {
+          throw std::runtime_error("Velocity limits for joint '" + joint_name +
+                                   "' must be a sequence of size " + std::to_string(joint.nv()) +
+                                   ".");
+        }
+      }
       if (limits_config["max_acceleration"]) {
         maybe_acc_limits = limits_config["max_acceleration"];
         if (!maybe_acc_limits->IsSequence() ||
@@ -139,7 +149,11 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
       }
     }
     for (int idx = 0; idx < joint.nv(); ++idx) {
-      info.limits.max_velocity[idx] = model_.velocityLimit(v_idx);
+      if (maybe_vel_limits) {
+        info.limits.max_velocity[idx] = maybe_vel_limits.value()[idx].as<double>();
+      } else {
+        info.limits.max_velocity[idx] = model_.velocityLimit(v_idx);
+      }
       if (maybe_acc_limits) {
         info.limits.max_acceleration[idx] = maybe_acc_limits.value()[idx].as<double>();
       }

--- a/roboplan/src/core/scene_utils.cpp
+++ b/roboplan/src/core/scene_utils.cpp
@@ -218,6 +218,9 @@ collapseContinuousJointPositions(const Scene& scene, const std::string& group_na
   size_t collapsed_nq = 0;
   for (const auto& joint_name : joint_group_info.joint_names) {
     const auto joint_info = scene.getJointInfo(joint_name).value();
+    if (joint_info.mimic_info) {
+      continue;
+    }
     switch (joint_info.type) {
     case JointType::REVOLUTE:
     case JointType::PRISMATIC:
@@ -277,6 +280,9 @@ expandContinuousJointPositions(const Scene& scene, const std::string& group_name
   size_t expanded_nq = 0;
   for (const auto& joint_name : joint_group_info.joint_names) {
     const auto joint_info = scene.getJointInfo(joint_name).value();
+    if (joint_info.mimic_info) {
+      continue;
+    }
     switch (joint_info.type) {
     case JointType::REVOLUTE:
     case JointType::PRISMATIC:

--- a/roboplan/src/core/scene_utils.cpp
+++ b/roboplan/src/core/scene_utils.cpp
@@ -316,4 +316,39 @@ expandContinuousJointPositions(const Scene& scene, const std::string& group_name
   return q_expanded;
 }
 
+Eigen::VectorXd jointPositionsWithMimicsFromPinocchio(const Scene& scene,
+                                                      const Eigen::VectorXd& q) {
+  const auto& model = scene.getModel();
+  const auto& joint_names = scene.getJointNamesWithMimics();
+
+  size_t total_size = 0;
+  for (const auto& joint_name : joint_names) {
+    const auto joint_info = scene.getJointInfo(joint_name).value();
+    total_size += joint_info.num_position_dofs;
+  }
+
+  Eigen::VectorXd positions(static_cast<Eigen::Index>(total_size));
+  Eigen::Index out_idx = 0;
+  for (const auto& joint_name : joint_names) {
+    const auto joint_info = scene.getJointInfo(joint_name).value();
+    if (joint_info.mimic_info) {
+      const auto& mimic = joint_info.mimic_info.value();
+      const auto mimicked_id = model.getJointId(mimic.mimicked_joint_name);
+      const auto mimicked_q_idx = model.idx_qs[mimicked_id];
+      for (size_t dof = 0; dof < joint_info.num_position_dofs; ++dof) {
+        positions(out_idx++) =
+            mimic.scaling * q(mimicked_q_idx + static_cast<Eigen::Index>(dof)) + mimic.offset;
+      }
+    } else {
+      const auto joint_id = model.getJointId(joint_name);
+      const auto q_idx = model.idx_qs[joint_id];
+      const auto nq = model.joints[joint_id].nq();
+      for (Eigen::Index dof = 0; dof < nq; ++dof) {
+        positions(out_idx++) = q(q_idx + dof);
+      }
+    }
+  }
+  return positions;
+}
+
 }  // namespace roboplan

--- a/roboplan/test/test_joints.cpp
+++ b/roboplan/test/test_joints.cpp
@@ -63,10 +63,12 @@ public:
 };
 
 TEST_F(RoboPlanJointTest, SceneProperties) {
-  // Verify actuated joints and mimic joints are as expected
-  std::vector<std::string> expected_joint_names = {"continuous_joint", "revolute_joint",
-                                                   "mimic_joint"};
-  ASSERT_EQ(scene_->getJointNames(), expected_joint_names);
+  // Verify actuated and full joint name lists
+  ASSERT_EQ(scene_->getJointNames(),
+            (std::vector<std::string>{"continuous_joint", "revolute_joint"}));
+  const std::vector<std::string> expected_joint_names_with_mimics = {
+      "continuous_joint", "revolute_joint", "mimic_joint"};
+  ASSERT_EQ(scene_->getJointNamesWithMimics(), expected_joint_names_with_mimics);
 
   // Verify mimic joint info is as expected
   const auto mimic_joint_info = scene_->getJointInfo("mimic_joint").value();
@@ -76,19 +78,38 @@ TEST_F(RoboPlanJointTest, SceneProperties) {
 
   // Verify joint group info is as expected for both the default and sub group.
   const auto full_group_info = scene_->getJointGroupInfo("").value();
-  ASSERT_EQ(full_group_info.joint_names, expected_joint_names);
+  ASSERT_EQ(full_group_info.joint_names, expected_joint_names_with_mimics);
   ASSERT_EQ(full_group_info.q_indices.size(), 3);  // Mimic joints have nq=0 in Pinocchio
   ASSERT_EQ(full_group_info.v_indices.size(), 2);
   ASSERT_EQ(full_group_info.nq_collapsed, 2);
   ASSERT_TRUE(full_group_info.has_continuous_dofs);
 
   const auto arm_group_info = scene_->getJointGroupInfo("arm").value();
-  expected_joint_names = {"revolute_joint", "mimic_joint"};
-  ASSERT_EQ(arm_group_info.joint_names, expected_joint_names);
+  const std::vector<std::string> expected_arm_joint_names = {"revolute_joint", "mimic_joint"};
+  ASSERT_EQ(arm_group_info.joint_names, expected_arm_joint_names);
   ASSERT_EQ(arm_group_info.q_indices.size(), 1);  // Only revolute_joint has a q slot
   ASSERT_EQ(arm_group_info.v_indices.size(), 1);
   ASSERT_EQ(arm_group_info.nq_collapsed, 1);
   ASSERT_FALSE(arm_group_info.has_continuous_dofs);
+}
+
+TEST_F(RoboPlanJointTest, CurrentJointPositionsWithMimics) {
+  Eigen::VectorXd q(3);
+  q << 1.0, 0.0, 0.5;
+  scene_->setJointPositions(q);
+
+  const auto& q_current = scene_->getCurrentJointPositions();
+  ASSERT_EQ(q_current.size(), 3);
+  EXPECT_FLOAT_EQ(q_current(0), 1.0);
+  EXPECT_FLOAT_EQ(q_current(1), 0.0);
+  EXPECT_FLOAT_EQ(q_current(2), 0.5);
+
+  const auto positions_with_mimics = scene_->getCurrentJointPositionsWithMimics();
+  ASSERT_EQ(positions_with_mimics.size(), 4);
+  EXPECT_FLOAT_EQ(positions_with_mimics(0), 1.0);
+  EXPECT_FLOAT_EQ(positions_with_mimics(1), 0.0);
+  EXPECT_FLOAT_EQ(positions_with_mimics(2), 0.5);
+  EXPECT_FLOAT_EQ(positions_with_mimics(3), 0.5);
 }
 
 TEST_F(RoboPlanJointTest, VerifyMimics) {

--- a/roboplan/test/test_joints.cpp
+++ b/roboplan/test/test_joints.cpp
@@ -79,61 +79,58 @@ TEST_F(RoboPlanJointTest, SceneProperties) {
   // Verify joint group info is as expected for both the default and sub group.
   const auto full_group_info = scene_->getJointGroupInfo("").value();
   ASSERT_EQ(full_group_info.joint_names, expected_joint_names);
-  ASSERT_EQ(full_group_info.q_indices.size(), 4);
-  ASSERT_EQ(full_group_info.v_indices.size(), 3);  // Continuous joint's velocity is theta_dot
-  ASSERT_EQ(full_group_info.nq_collapsed, 3);
+  ASSERT_EQ(full_group_info.q_indices.size(), 3);  // Mimic joints have nq=0 in Pinocchio
+  ASSERT_EQ(full_group_info.v_indices.size(), 2);
+  ASSERT_EQ(full_group_info.nq_collapsed, 2);
   ASSERT_TRUE(full_group_info.has_continuous_dofs);
 
   const auto arm_group_info = scene_->getJointGroupInfo("arm").value();
   expected_joint_names = {"revolute_joint", "mimic_joint"};
   ASSERT_EQ(arm_group_info.joint_names, expected_joint_names);
-  ASSERT_EQ(arm_group_info.q_indices.size(), 2);
-  ASSERT_EQ(arm_group_info.v_indices.size(), 2);
-  ASSERT_EQ(arm_group_info.nq_collapsed, 2);
+  ASSERT_EQ(arm_group_info.q_indices.size(), 1);  // Only revolute_joint has a q slot
+  ASSERT_EQ(arm_group_info.v_indices.size(), 1);
+  ASSERT_EQ(arm_group_info.nq_collapsed, 1);
   ASSERT_FALSE(arm_group_info.has_continuous_dofs);
 }
 
 TEST_F(RoboPlanJointTest, VerifyMimics) {
-  // Given a vector with a mimc in place, apply the mimics and verify the correct
-  // index is updated.
-  Eigen::VectorXd q(4);
-  q << 0.0, 0.0, 1.0, 0.0;
-  scene_->applyMimics(q);
-  EXPECT_DOUBLE_EQ(q[3], 1.0);
+  // Pinocchio mimic joints share the mimicked q segment; FK moves link3 when revolute changes.
+  Eigen::VectorXd q(3);
+  q << 1.0, 0.0, 0.5;
+  const auto T_revolute = scene_->forwardKinematics(q, "link3");
+  q[2] = 1.0;
+  const auto T_mimicked = scene_->forwardKinematics(q, "link3");
+  EXPECT_FALSE(T_revolute.isApprox(T_mimicked));
 }
 
 TEST_F(RoboPlanJointTest, RandomPositions) {
-  // Generate a random pose for each continuous joint, which are represented as
-  // [cos(theta), sin(theta)] in Pinocchio. Ensure mimic joint is matched.
+  // Reduced q: continuous [cos, sin] + revolute; mimic has no separate entry.
   const auto random_positions = scene_->randomPositions();
-  EXPECT_EQ(random_positions.size(), 4);
-  EXPECT_FLOAT_EQ(random_positions[2], random_positions[3]);
+  EXPECT_EQ(random_positions.size(), 3);
 }
 
 TEST_F(RoboPlanJointTest, ExpandCollapse) {
-  Eigen::VectorXd pos(4);
-  pos << 0.7071067, -0.7071067, 0.5, 0.5;  // -45 degrees
+  Eigen::VectorXd pos(3);
+  pos << 0.7071067, -0.7071067, 0.5;  // -45 degrees on continuous
 
   // Collapse the continuous joint
-  Eigen::VectorXd expected_collapsed(3);
-  expected_collapsed << -0.785398, 0.5, 0.5;
+  Eigen::VectorXd expected_collapsed(2);
+  expected_collapsed << -0.785398, 0.5;
   const auto maybe_collapsed = collapseContinuousJointPositions(*scene_, "", pos);
   ASSERT_TRUE(maybe_collapsed.has_value()) << maybe_collapsed.error();
   const auto& collapsed = maybe_collapsed.value();
-  ASSERT_EQ(collapsed.size(), 3);
+  ASSERT_EQ(collapsed.size(), 2);
   EXPECT_FLOAT_EQ(collapsed(0), expected_collapsed(0));
   EXPECT_FLOAT_EQ(collapsed(1), expected_collapsed(1));
-  EXPECT_FLOAT_EQ(collapsed(2), expected_collapsed(2));
 
   // Expand and ensure we get back the original pose
   const auto maybe_expanded = expandContinuousJointPositions(*scene_, "", collapsed);
   ASSERT_TRUE(maybe_expanded.has_value()) << maybe_expanded.error();
   const auto& expanded = maybe_expanded.value();
-  ASSERT_EQ(expanded.size(), 4);
+  ASSERT_EQ(expanded.size(), 3);
   EXPECT_FLOAT_EQ(expanded(0), pos(0));
   EXPECT_FLOAT_EQ(expanded(1), pos(1));
   EXPECT_FLOAT_EQ(expanded(2), pos(2));
-  EXPECT_FLOAT_EQ(expanded(3), pos(3));
 }
 
 }  // namespace roboplan

--- a/roboplan/test/test_joints.cpp
+++ b/roboplan/test/test_joints.cpp
@@ -67,8 +67,6 @@ TEST_F(RoboPlanJointTest, SceneProperties) {
   std::vector<std::string> expected_joint_names = {"continuous_joint", "revolute_joint",
                                                    "mimic_joint"};
   ASSERT_EQ(scene_->getJointNames(), expected_joint_names);
-  std::vector<std::string> expected_actuated_names = {"continuous_joint", "revolute_joint"};
-  ASSERT_EQ(scene_->getActuatedJointNames(), expected_actuated_names);
 
   // Verify mimic joint info is as expected
   const auto mimic_joint_info = scene_->getJointInfo("mimic_joint").value();

--- a/roboplan_example_models/models/stretch4_robot_model/stretch4_sg4_config.yaml
+++ b/roboplan_example_models/models/stretch4_robot_model/stretch4_sg4_config.yaml
@@ -2,6 +2,7 @@
 
 joint_limits:
   mobile_base_planar_joint:
+    max_velocity: [0.5, 0.5, 3.0]
     max_acceleration: [0.5, 0.5, 0.5]
     max_jerk: [2.0, 2.0, 2.0]
   lift_joint:

--- a/roboplan_examples/python/CMakeLists.txt
+++ b/roboplan_examples/python/CMakeLists.txt
@@ -4,6 +4,7 @@ install(
   example_dual_arm.py
   example_ik.py
   example_rrt.py
+  example_oink.py
   example_scene.py
   example_action_chunk_tracking.py
   DESTINATION lib/roboplan_examples

--- a/roboplan_examples/python/CMakeLists.txt
+++ b/roboplan_examples/python/CMakeLists.txt
@@ -5,6 +5,7 @@ install(
   example_ik.py
   example_rrt.py
   example_oink.py
+  example_oink_with_barriers.py
   example_scene.py
   example_action_chunk_tracking.py
   DESTINATION lib/roboplan_examples

--- a/roboplan_examples/python/common.py
+++ b/roboplan_examples/python/common.py
@@ -395,27 +395,25 @@ def get_model_data():
             ee_names=["grasp_center_link"],
             base_link="base_link",
             starting_joint_config=[
-                # Planar base (x, y, cos(yaw), sin(yaw)).
+                # nq=17 with Pinocchio mimic joints (arm_l2/l3/l4 collapsed into arm_l1).
+                # Planar base (x, y, cos(yaw), sin(yaw)), SRDF home pose.
                 0.0,
                 0.0,
                 1.0,
                 0.0,
-                0.5,
-                0.065,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
+                0.5,  # lift_joint
+                0.065,  # arm_l1_joint
+                0.0,  # wrist_yaw_joint
+                0.0,  # wrist_pitch_joint
+                0.0,  # wrist_roll_joint
+                0.0,  # gripper_finger_left_joint
+                0.0,  # gripper_finger_right_joint
                 1.0,
-                0.0,
+                0.0,  # wheel_0_joint (cos, sin)
                 1.0,
-                0.0,
+                0.0,  # wheel_1_joint
                 1.0,
-                0.0,
+                0.0,  # wheel_2_joint
             ],
             obstacles=[
                 ObstacleConfig(

--- a/roboplan_examples/python/common.py
+++ b/roboplan_examples/python/common.py
@@ -205,6 +205,7 @@ def get_model_data():
             ee_names=["fr3_hand"],
             base_link="fr3_link0",
             starting_joint_config=[
+                # nq=8 with Pinocchio mimic joints (fr3_finger_joint2 mimics joint1 removed).
                 0.0,
                 -np.pi / 4,
                 0.0,
@@ -212,7 +213,6 @@ def get_model_data():
                 0.0,
                 np.pi / 2,
                 np.pi / 4,
-                0.04,
                 0.04,
             ],
             obstacles=[
@@ -251,6 +251,7 @@ def get_model_data():
             ee_names=["left_fr3_hand", "right_fr3_hand"],
             base_link="left_fr3_link0",
             starting_joint_config=[
+                # nq=16 with Pinocchio mimic joints (fr3_finger_joint2 mimics joint1 removed x2).
                 # Left arm
                 0.0,
                 -np.pi / 4,
@@ -260,7 +261,6 @@ def get_model_data():
                 np.pi / 2,
                 np.pi / 4,
                 0.04,
-                0.04,
                 # Right arm
                 0.0,
                 -np.pi / 4,
@@ -269,7 +269,6 @@ def get_model_data():
                 0.0,
                 np.pi / 2,
                 np.pi / 4,
-                0.04,
                 0.04,
             ],
             obstacles=[
@@ -308,24 +307,20 @@ def get_model_data():
             ee_names=["robotiq_85_base_link"],
             base_link="base_link",
             starting_joint_config=[
-                # Default home pose (17 values for nq=17 with quaternion joints)
+                # nq=12 with Pinocchio mimic joints (Robotiq finger mimics collapsed).
+                # Continuous joints use [cos(theta), sin(theta)]
                 1.0,
-                0.0,
-                0.26179938779914941,
+                0.0,  # joint_1
+                0.26179938779914941,  # joint_2
                 -1.0,
-                0.0,
-                -2.2689280275926285,
+                0.0,  # joint_3 (pi)
+                -2.2689280275926285,  # joint_4
                 1.0,
+                0.0,  # joint_5
+                0.96,  # joint_6
                 0.0,
-                1.0,
-                0.0,
-                1.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
+                1.0,  # joint_7 (pi/2)
+                0.0,  # robotiq_85_left_knuckle_joint
             ],
             obstacles=[
                 ObstacleConfig(

--- a/roboplan_examples/python/example_action_chunk_tracking.py
+++ b/roboplan_examples/python/example_action_chunk_tracking.py
@@ -162,7 +162,6 @@ def make_mock_joint_targets(
         phase = (i + 1) / float(horizon)
         direction = np.sin(np.linspace(0.0, np.pi, len(v_indices)) + np.pi * phase)
         delta_full[v_indices] = action_scale * joint_delta_scale * (i + 1) * direction
-        scene.applyMimics(delta_full)
         targets.append(scene.integrate(q_start, delta_full))
 
     return targets
@@ -360,9 +359,8 @@ def main(
     print(f"Action space: {action_space}")
     print(f"Action scale: {action_scale}")
 
-    # Create a redundant Pinocchio model for visualization and for obtaining
-    # the full velocity-space size.
-    model_pin = pin.buildModelFromXML(urdf_xml)
+    # Create a redundant Pinocchio model just for visualization with mimic joints.
+    model_pin = pin.buildModelFromXML(urdf_xml, mimic=True)
     q_start = get_starting_configuration(scene, model_data)
 
     collision_model = pin.buildGeomFromUrdfString(
@@ -514,7 +512,6 @@ def main(
                 delta_q[:] = 0.0
 
             delta_q_full[oink.v_indices] = delta_q
-            scene.applyMimics(delta_q_full)
             q_current = scene.integrate(q_current, delta_q_full)
             scene.setJointPositions(q_current)
             trajectory.append(q_current.copy())

--- a/roboplan_examples/python/example_ik.py
+++ b/roboplan_examples/python/example_ik.py
@@ -60,9 +60,9 @@ def main(
     q_full = scene.getCurrentJointPositions()
     q_indices = scene.getJointGroupInfo(model_data.default_joint_group).q_indices
 
-    # Create a redundant Pinocchio model just for visualization.
+    # Create a redundant Pinocchio model just for visualization with mimic joints.
     # When Pinocchio 4.x releases nanobind bindings, we should be able to directly grab the model from the scene instead.
-    model = pin.buildModelFromXML(urdf_xml)
+    model = pin.buildModelFromXML(urdf_xml, mimic=True)
     collision_model = pin.buildGeomFromUrdfString(
         model, urdf_xml, pin.GeometryType.COLLISION, package_dirs=package_paths
     )

--- a/roboplan_examples/python/example_oink.py
+++ b/roboplan_examples/python/example_oink.py
@@ -83,9 +83,9 @@ def main(
 
     q_full = scene.getCurrentJointPositions()
 
-    # Create a redundant Pinocchio model just for visualization.
+    # Create a redundant Pinocchio model just for visualization with mimic joints.
     # When Pinocchio 4.x releases nanobind bindings, we should be able to directly grab the model from the scene instead.
-    model_pin = pin.buildModelFromXML(urdf_xml)
+    model_pin = pin.buildModelFromXML(urdf_xml, mimic=True)
     collision_model = pin.buildGeomFromUrdfString(
         model_pin, urdf_xml, pin.GeometryType.COLLISION, package_dirs=package_paths
     )
@@ -235,7 +235,6 @@ def main(
 
                     # Integrate: delta_q is a displacement (already limited by VelocityLimit)
                     delta_q_full[oink.v_indices] = delta_q
-                    scene.applyMimics(delta_q_full)
                     q_current = scene.integrate(q_current, delta_q_full)
 
                     # Update scene state and forward kinematics after applying velocities

--- a/roboplan_examples/python/example_oink.py
+++ b/roboplan_examples/python/example_oink.py
@@ -127,7 +127,7 @@ def main(
             f"configuration space dimension ({len(q_full)}), using current scene positions instead"
         )
         with scene_lock:
-            q_canonical = scene.getCurrentJointPositions()
+            q_canonical = np.array(scene.getCurrentJointPositions())
     print(
         f"\nUsing starting pose for '{model}' (configuration space size: {len(q_canonical)})"
     )

--- a/roboplan_examples/python/example_oink.py
+++ b/roboplan_examples/python/example_oink.py
@@ -127,7 +127,7 @@ def main(
             f"configuration space dimension ({len(q_full)}), using current scene positions instead"
         )
         with scene_lock:
-            q_canonical = np.array(scene.getCurrentJointPositions())
+            q_canonical = scene.getCurrentJointPositions()
     print(
         f"\nUsing starting pose for '{model}' (configuration space size: {len(q_canonical)})"
     )

--- a/roboplan_examples/python/example_oink_with_barriers.py
+++ b/roboplan_examples/python/example_oink_with_barriers.py
@@ -108,9 +108,9 @@ def main(
 
     q_full = scene.getCurrentJointPositions()
 
-    # Create a redundant Pinocchio model just for visualization.
+    # Create a redundant Pinocchio model just for visualization with mimic joints.
     # When Pinocchio 4.x releases nanobind bindings, we should be able to directly grab the model from the scene instead.
-    model_pin = pin.buildModelFromXML(urdf_xml)
+    model_pin = pin.buildModelFromXML(urdf_xml, mimic=True)
     collision_model = pin.buildGeomFromUrdfString(
         model_pin, urdf_xml, pin.GeometryType.COLLISION, package_dirs=package_paths
     )
@@ -270,7 +270,6 @@ def main(
                         print(f"Warning: IK solver failed: {e}, using zero delta_q")
 
                     delta_q_full[oink.v_indices] = delta_q
-                    scene.applyMimics(delta_q_full)
 
                     # CRITICAL: Validate solution with enforceBarriers() using FK
                     # This catches cases where linearization error causes barrier violation

--- a/roboplan_examples/python/example_rrt.py
+++ b/roboplan_examples/python/example_rrt.py
@@ -86,9 +86,9 @@ def main(
     group_info = scene.getJointGroupInfo(model_data.default_joint_group)
     q_indices = group_info.q_indices
 
-    # Create a redundant Pinocchio model just for visualization.
+    # Create a redundant Pinocchio model just for visualization with mimic joints.
     # When Pinocchio 4.x releases nanobind bindings, we should be able to directly grab the model from the scene instead.
-    model = pin.buildModelFromXML(urdf_xml)
+    model = pin.buildModelFromXML(urdf_xml, mimic=True)
     collision_model = pin.buildGeomFromUrdfString(
         model, urdf_xml, pin.GeometryType.COLLISION, package_dirs=package_paths
     )

--- a/roboplan_rrt/src/rrt.cpp
+++ b/roboplan_rrt/src/rrt.cpp
@@ -24,15 +24,18 @@ RRT::RRT(const std::shared_ptr<Scene> scene, const RRTOptions& options)
     throw std::runtime_error("Failed to instantiate RRT planner: " + maybe_collapsed_pos.error());
   }
 
-  const auto joint_names = scene_->getJointNames();
   std::vector<std::string> state_space_names;
-  state_space_names.reserve(joint_names.size());
+  state_space_names.reserve(joint_group_info_.joint_names.size());
   for (const auto& joint_name : joint_group_info_.joint_names) {
     const auto maybe_joint_info = scene_->getJointInfo(joint_name);
     if (!maybe_joint_info) {
       throw std::runtime_error("Failed to instantiate RRT planner: " + maybe_joint_info.error());
     }
     const auto& joint_info = maybe_joint_info.value();
+    if (joint_info.mimic_info) {
+      // Mimic joints have nq=0; they are not separate entries in the collapsed state space.
+      continue;
+    }
     switch (joint_info.type) {
     case JointType::FLOATING:
       throw std::runtime_error("Floating joints not yet supported by RRT.");
@@ -58,6 +61,15 @@ RRT::RRT(const std::shared_ptr<Scene> scene, const RRTOptions& options)
 
   state_space_ = CombinedStateSpace(state_space_names);
   state_space_.set_bounds(maybe_joint_position_limits->first, maybe_joint_position_limits->second);
+
+  if (state_space_.get_runtime_dim() != static_cast<int>(maybe_collapsed_pos->size())) {
+    throw std::runtime_error(
+        "Failed to instantiate RRT planner: State space dimension (" +
+        std::to_string(state_space_.get_runtime_dim()) +
+        ") does not match collapsed configuration dimension (" +
+        std::to_string(maybe_collapsed_pos->size()) + ") for group '" + options_.group_name +
+        "'.");
+  }
 };
 
 tl::expected<JointPath, std::string> RRT::plan(const JointConfiguration& start,
@@ -219,9 +231,17 @@ std::optional<JointPath> RRT::joinTrees(const std::vector<Node>& nodes, const Kd
   const auto& last_added_node = nodes.back();
   const auto& q_last_added = last_added_node.config;
 
-  // Find the nearest node in the target tree.
+  // Find the nearest node in the target tree (search uses collapsed coordinates).
   const auto& q_indices = joint_group_info_.q_indices;
-  const auto& nn = target_tree.search(q_last_added(q_indices));
+  const auto maybe_q_collapsed =
+      collapseContinuousJointPositions(*scene_, options_.group_name, q_last_added(q_indices));
+  if (!maybe_q_collapsed) {
+    return std::nullopt;
+  }
+  const auto& nn = target_tree.search(maybe_q_collapsed.value());
+  if (nn.id < 0 || static_cast<size_t>(nn.id) >= target_nodes.size()) {
+    return std::nullopt;
+  }
   const auto& nearest_node = target_nodes.at(nn.id);
   const auto& q_nearest = nearest_node.config;
 

--- a/roboplan_rrt/src/rrt.cpp
+++ b/roboplan_rrt/src/rrt.cpp
@@ -235,11 +235,12 @@ std::optional<JointPath> RRT::joinTrees(const std::vector<Node>& nodes, const Kd
   const auto maybe_q_collapsed =
       collapseContinuousJointPositions(*scene_, options_.group_name, q_last_added(q_indices));
   if (!maybe_q_collapsed) {
-    return std::nullopt;
+    throw std::runtime_error("Failed to collapse joint positions in joinTrees: " +
+                             maybe_q_collapsed.error());
   }
   const auto& nn = target_tree.search(maybe_q_collapsed.value());
   if (nn.id < 0 || static_cast<size_t>(nn.id) >= target_nodes.size()) {
-    return std::nullopt;
+    throw std::runtime_error("K-D tree search returned invalid node id in joinTrees.");
   }
   const auto& nearest_node = target_nodes.at(nn.id);
   const auto& q_nearest = nearest_node.config;

--- a/roboplan_rrt/src/rrt.cpp
+++ b/roboplan_rrt/src/rrt.cpp
@@ -63,12 +63,11 @@ RRT::RRT(const std::shared_ptr<Scene> scene, const RRTOptions& options)
   state_space_.set_bounds(maybe_joint_position_limits->first, maybe_joint_position_limits->second);
 
   if (state_space_.get_runtime_dim() != static_cast<int>(maybe_collapsed_pos->size())) {
-    throw std::runtime_error(
-        "Failed to instantiate RRT planner: State space dimension (" +
-        std::to_string(state_space_.get_runtime_dim()) +
-        ") does not match collapsed configuration dimension (" +
-        std::to_string(maybe_collapsed_pos->size()) + ") for group '" + options_.group_name +
-        "'.");
+    throw std::runtime_error("Failed to instantiate RRT planner: State space dimension (" +
+                             std::to_string(state_space_.get_runtime_dim()) +
+                             ") does not match collapsed configuration dimension (" +
+                             std::to_string(maybe_collapsed_pos->size()) + ") for group '" +
+                             options_.group_name + "'.");
   }
 };
 

--- a/roboplan_rrt/src/rrt.cpp
+++ b/roboplan_rrt/src/rrt.cpp
@@ -122,7 +122,6 @@ tl::expected<JointPath, std::string> RRT::plan(const JointConfiguration& start,
       q_sample = grow_start_tree ? q_goal : q_start;
     } else {
       q_sample(q_indices) = scene_->randomPositions()(q_indices);
-      scene_->applyMimics(q_sample);
     }
 
     // Attempt to grow the tree towards the sampled node.

--- a/roboplan_simple_ik/src/simple_ik.cpp
+++ b/roboplan_simple_ik/src/simple_ik.cpp
@@ -106,7 +106,6 @@ bool SimpleIk::solveIk(const std::vector<CartesianConfiguration>& goals,
 
       if (converged) {
         if (!options_.check_collisions || !scene_->hasCollisions(q)) {
-          scene_->applyMimics(q);
           solution.positions = q(q_indices);
           return true;
         }
@@ -121,7 +120,6 @@ bool SimpleIk::solveIk(const std::vector<CartesianConfiguration>& goals,
 
       q = pinocchio::integrate(model, q, vel_ * options_.step_size);
       q(q_indices) = q(q_indices).cwiseMax(lower_position_limits_).cwiseMin(upper_position_limits_);
-      scene_->applyMimics(q);
       ++iter;
 
       // Check for timeouts.


### PR DESCRIPTION
addresses the OInK solver overusing the base instead of moving the telescoping arm by enabling the mimic in Pinocchio instead of having two different models.

before 

https://github.com/user-attachments/assets/fd06c7c9-477e-4b28-96c8-493bead4eac7


after 

https://github.com/user-attachments/assets/62fc427e-6196-4a29-a1a5-ab8caa50eb8d

