### PR TITLE
Fix TOPPRA issues when using planar joints

### DIFF
--- a/roboplan_examples/python/example_rrt.py
+++ b/roboplan_examples/python/example_rrt.py
@@ -230,7 +230,7 @@ def main(
             )
         else:
             visualizeJointTrajectory(
-                viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/traj"
+                viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/path"
             )
 
         traj_queue.put(traj)

--- a/roboplan_examples/python/example_rrt.py
+++ b/roboplan_examples/python/example_rrt.py
@@ -35,7 +35,7 @@ def main(
     rrt_connect: bool = False,
     include_shortcutting: bool = False,
     max_shortcutting_iters: int = 100,
-    toppra_mode: SplineFittingMode = SplineFittingMode.Hermite,
+    toppra_mode: SplineFittingMode = SplineFittingMode.Adaptive,
     host: str = "localhost",
     port: str = "8000",
     rng_seed: int | None = None,
@@ -57,7 +57,7 @@ def main(
         rrt_connect: Whether or not to use RRT-Connect.
         include_shortcutting: Whether or not to include path shortcutting for found paths.
         max_shortcutting_iters: The maximum number of path shortcutting iterations.
-        toppra_mode: The trajectory generation mode for TOPP-RA. Can be `Hermite`, `Cubic`, or `Adaptive`.
+        toppra_mode: The trajectory generation mode for TOPP-RA. Can be `Hermite`, `Cubic`, or `Adaptive` (default).
         host: The host for the ViserVisualizer.
         port: The port for the ViserVisualizer.
         rng_seed: The seed for selecting random start and end poses and solving RRT.
@@ -230,7 +230,7 @@ def main(
             )
         else:
             visualizeJointTrajectory(
-                viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/path"
+                viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/traj"
             )
 
         traj_queue.put(traj)

--- a/roboplan_toppra/include/roboplan_toppra/toppra.hpp
+++ b/roboplan_toppra/include/roboplan_toppra/toppra.hpp
@@ -102,9 +102,18 @@ private:
   /// @brief The stored acceleration upper limits.
   toppra::Vector acc_upper_limits_;
 
+  /// @brief Position indices of the joint group within the full model configuration.
+  Eigen::VectorXi q_indices_;
+
   /// @brief A list of position indices with continuous degrees of freedom.
   /// @details This is used to figure out which joints need to be wrapped.
   std::vector<size_t> continuous_q_indices_;
+
+  /// @brief Whether the joint group contains any planar joints.
+  /// @details When true, edges between path waypoints are densely resampled using the scene's
+  /// SE(2)-aware interpolation so the spline knots track the actual Lie-group motion of the
+  /// planar joint(s).
+  bool has_planar_joints_{false};
 };
 
 }  // namespace roboplan

--- a/roboplan_toppra/include/roboplan_toppra/toppra.hpp
+++ b/roboplan_toppra/include/roboplan_toppra/toppra.hpp
@@ -102,9 +102,9 @@ private:
   /// @brief The stored acceleration upper limits.
   toppra::Vector acc_upper_limits_;
 
-  /// @brief A list of indices of joints with continuous degrees of freedom.
+  /// @brief A list of position indices with continuous degrees of freedom.
   /// @details This is used to figure out which joints need to be wrapped.
-  std::vector<size_t> continuous_joint_indices_;
+  std::vector<size_t> continuous_q_indices_;
 };
 
 }  // namespace roboplan

--- a/roboplan_toppra/src/toppra.cpp
+++ b/roboplan_toppra/src/toppra.cpp
@@ -9,6 +9,16 @@
 #include <roboplan/core/scene_utils.hpp>
 #include <roboplan_toppra/toppra.hpp>
 
+namespace {
+/// @brief Configuration-space step size for resampling edges with planar joints for spline fitting.
+/// @details This is necessary to ensure that the spline fitting doesn't produce large deviations
+/// from the original path that could lead to collisions, since the cubic spline treats (x, y,
+/// theta) as independent Euclidean scalars and produces a straight-line motion in (x, y) instead of
+/// the SE(2) screw motion that the planner used for collision checking.
+/// TODO: Make this configurable if needed.
+constexpr double kPlanarResampleStep = 0.5;
+}  // namespace
+
 namespace roboplan {
 
 PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> scene,
@@ -39,6 +49,7 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
   }
   const auto& joint_group_info = maybe_joint_group_info.value();
   joint_names_ = joint_group_info.joint_names;
+  q_indices_ = joint_group_info.q_indices;
 
   auto q_idx = 0;
   for (const auto& joint_name : joint_group_info.joint_names) {
@@ -52,6 +63,7 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
     } else if (maybe_joint_info->type == JointType::PLANAR) {
       continuous_q_indices_.push_back(q_idx + 2);
       q_idx += 3;  // increment by collapsed indices
+      has_planar_joints_ = true;
     } else {
       q_idx += maybe_joint_info->num_position_dofs;
     }
@@ -60,11 +72,35 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
 
 tl::expected<toppra::Vectors, std::string>
 PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
-  const auto num_pts = path.positions.size();
+  // If the joint group contains any planar joints, densely resample each edge using the scene's
+  // SE(2)-aware interpolation. Otherwise the cubic spline would treat (x, y, theta) as independent
+  // Euclidean scalars and produce a straight-line motion in (x, y), which diverges from the
+  // SE(2) screw motion that the planner used for collision checking.
+  std::vector<Eigen::VectorXd> resampled_positions;
+  if (has_planar_joints_) {
+    resampled_positions.reserve(path.positions.size());
+    resampled_positions.push_back(path.positions.front());
+    for (size_t idx = 1; idx < path.positions.size(); ++idx) {
+      const auto q_start_full =
+          scene_->toFullJointPositions(group_name_, path.positions.at(idx - 1));
+      const auto q_end_full = scene_->toFullJointPositions(group_name_, path.positions.at(idx));
+      const auto distance = scene_->configurationDistance(q_start_full, q_end_full);
+      const auto num_steps =
+          std::max<size_t>(1, static_cast<size_t>(std::ceil(distance / kPlanarResampleStep)));
+      for (size_t step = 1; step < num_steps; ++step) {
+        const double fraction = static_cast<double>(step) / static_cast<double>(num_steps);
+        const auto q_interp_full = scene_->interpolate(q_start_full, q_end_full, fraction);
+        resampled_positions.push_back(q_interp_full(q_indices_).eval());
+      }
+      resampled_positions.push_back(path.positions.at(idx));
+    }
+  }
+  const auto& positions = has_planar_joints_ ? resampled_positions : path.positions;
+
   toppra::Vectors path_pos_vecs;
-  path_pos_vecs.reserve(num_pts);
-  for (size_t idx = 0; idx < path.positions.size(); ++idx) {
-    const auto& pos = path.positions.at(idx);
+  path_pos_vecs.reserve(positions.size());
+  for (size_t idx = 0; idx < positions.size(); ++idx) {
+    const auto& pos = positions.at(idx);
     auto maybe_collapsed_pos = collapseContinuousJointPositions(*scene_, group_name_, pos);
     if (!maybe_collapsed_pos) {
       return tl::make_unexpected(maybe_collapsed_pos.error());

--- a/roboplan_toppra/src/toppra.cpp
+++ b/roboplan_toppra/src/toppra.cpp
@@ -31,7 +31,7 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
   acc_lower_limits_ = maybe_joint_acceleration_limits->first;
   acc_upper_limits_ = maybe_joint_acceleration_limits->second;
 
-  // Get the continuous joint indices for unwrapping positions.
+  // Get the continuous joint position indices for unwrapping positions.
   const auto maybe_joint_group_info = scene_->getJointGroupInfo(group_name_);
   if (!maybe_joint_group_info) {
     throw std::runtime_error("Could not initialize TOPP-RA path parameterizer: " +
@@ -40,14 +40,20 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
   const auto& joint_group_info = maybe_joint_group_info.value();
   joint_names_ = joint_group_info.joint_names;
 
-  for (size_t j_idx = 0; j_idx < joint_group_info.joint_names.size(); ++j_idx) {
-    const auto& joint_name = joint_group_info.joint_names.at(j_idx);
+  auto q_idx = 0;
+  for (const auto& joint_name : joint_group_info.joint_names) {
     const auto maybe_joint_info = scene_->getJointInfo(joint_name);
     if (!maybe_joint_info) {
       throw std::runtime_error("Failed to instantiate TOPP-RA: " + maybe_joint_info.error());
     }
     if (maybe_joint_info->type == JointType::CONTINUOUS) {
-      continuous_joint_indices_.push_back(j_idx);
+      continuous_q_indices_.push_back(q_idx);
+      q_idx += 1;  // increment by collapsed indices
+    } else if (maybe_joint_info->type == JointType::PLANAR) {
+      continuous_q_indices_.push_back(q_idx + 2);
+      q_idx += 3;  // increment by collapsed indices
+    } else {
+      q_idx += maybe_joint_info->num_position_dofs;
     }
   }
 }
@@ -70,12 +76,12 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
     // 2*PI to this point to ensure that we don't travel further than we need to.
     if (idx > 0) {
       const auto& prev_collapsed = path_pos_vecs.at(idx - 1);
-      for (auto j_idx : continuous_joint_indices_) {
-        const auto diff = curr_collapsed(j_idx) - prev_collapsed(j_idx);
+      for (auto q_idx : continuous_q_indices_) {
+        const auto diff = curr_collapsed(q_idx) - prev_collapsed(q_idx);
         if (diff > M_PI) {
-          curr_collapsed(j_idx) -= 2.0 * M_PI;
+          curr_collapsed(q_idx) -= 2.0 * M_PI;
         } else if (diff < -M_PI) {
-          curr_collapsed(j_idx) += 2.0 * M_PI;
+          curr_collapsed(q_idx) += 2.0 * M_PI;
         }
       }
     }

--- a/roboplan_toppra/src/toppra.cpp
+++ b/roboplan_toppra/src/toppra.cpp
@@ -206,7 +206,7 @@ tl::expected<JointTrajectory, std::string> PathParameterizerTOPPRA::generate(
   // - If Hermite mode is enabled, we don't need to iterate or check collisions.
   // - If cubic mode is enabled, we just do one iteration with collision checking.
   // - If adaptive mode is enabled, we do need to iterate by checking collisisions.
-  int max_collision_iterations;
+  int max_collision_iterations = 0;
   switch (mode) {
   case SplineFittingMode::Hermite:
     max_collision_iterations = 0;


### PR DESCRIPTION
Found an issue in which TOPPRA wasn't doing the right thing with planar joints because of Lie group (SE2) interpolation in Pinocchio/dynotree vs. individual DOF in toppra. So we can "fix" it by more densely sampling in the planar joint case.

This looks bad if you use the Hermite TOPPRA mode (lots of stop and go knots), so I changed the default mode to Adaptive which is generally good to do anyway.

Additionally, it fixes a bug in which the continuous joint wraparounds were being done using joints, and not position DOFs, as indices.

<img width="1112" height="553" alt="image" src="https://github.com/user-attachments/assets/3b119829-3c0e-42d3-9ba1-02834118750f" />
