### PR TITLE
Add toppra and nanobind-dev rosdep keys

### DIFF
--- a/.docker/ros/Dockerfile
+++ b/.docker/ros/Dockerfile
@@ -16,7 +16,6 @@ RUN apt update -y \
 # non-ROS workflows, so we cannot put these as requirements in the `pyproject.toml`.
 # As/if this package matures, a possible solution is to apply patches for ROS release.
 RUN pip3 install \
-    nanobind \
     matplotlib \
     "numpy<2.0.0" \
     opencv-contrib-python-headless \

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -179,7 +179,16 @@ else()
 endif()
 
 # Generate Python stub files from the bindings.
-if(GENERATE_PYTHON_STUBS)
+# Older nanobind versions (which can come from rosdep on certain distros) do not provide
+# nanobind_add_stub, so skip generation rather than failing the configure step.
+# See https://github.com/ros/rosdistro/pull/49894 for more details.
+if(GENERATE_PYTHON_STUBS AND NOT COMMAND nanobind_add_stub)
+  message(WARNING
+    "Skipping Python stub generation: the installed nanobind version does not "
+    "provide nanobind_add_stub. Upgrade nanobind to generate stubs.")
+endif()
+
+if(GENERATE_PYTHON_STUBS AND COMMAND nanobind_add_stub)
   nanobind_add_stub(
     roboplan_ext_stub
     MODULE roboplan_ext

--- a/bindings/package.xml
+++ b/bindings/package.xml
@@ -12,9 +12,9 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <!-- While nanobind-dev is available from rosdistro the apt package is very out of date. -->
-  <!-- Nanobind should only be installed manually from pip until this is released in a sync: -->
-  <!-- https://github.com/ros/rosdistro/pull/49894 -->
-  <!-- <depend>nanobind-dev</depend> -->
+  <!-- Nanobind should only be installed via pip, which has a separate rosdep entry. -->
+  <!-- See https://github.com/ros/rosdistro/pull/49894 for more details. -->
+  <depend>python3-nanobind-pip</depend>
   <depend>roboplan</depend>
   <depend>roboplan_example_models</depend>
   <depend>roboplan_oink</depend>

--- a/bindings/package.xml
+++ b/bindings/package.xml
@@ -11,10 +11,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <!-- While nanobind-dev is available from rosdistro the apt package is very out of date. -->
-  <!-- Nanobind should only be installed via pip, which has a separate rosdep entry. -->
+  <!-- While nanobind-dev is available from rosdistro the apt package is very out of date on some distros. -->
   <!-- See https://github.com/ros/rosdistro/pull/49894 for more details. -->
-  <depend>python3-nanobind-pip</depend>
+  <depend condition="$ROS_DISTRO != humble">nanobind-dev</depend>
   <depend>roboplan</depend>
   <depend>roboplan_example_models</depend>
   <depend>roboplan_oink</depend>

--- a/bindings/package.xml
+++ b/bindings/package.xml
@@ -11,9 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <!-- While nanobind-dev is available from rosdistro the apt package is very out of date on some distros. -->
-  <!-- See https://github.com/ros/rosdistro/pull/49894 for more details. -->
-  <depend condition="$ROS_DISTRO != humble">nanobind-dev</depend>
+  <depend>nanobind-dev</depend>
   <depend>roboplan</depend>
   <depend>roboplan_example_models</depend>
   <depend>roboplan_oink</depend>

--- a/roboplan_toppra/package.xml
+++ b/roboplan_toppra/package.xml
@@ -10,7 +10,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>roboplan</depend>
-  <depend>toppra</depend>
+
+  <!-- TODO: Update this as toppra gets released on more ROS distros. -->
+  <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == lyrical">toppra</depend>
 
   <test_depend>roboplan_example_models</test_depend>
 

--- a/roboplan_toppra/package.xml
+++ b/roboplan_toppra/package.xml
@@ -12,6 +12,7 @@
   <depend>roboplan</depend>
 
   <!-- TODO: Update this as toppra gets released on more ROS distros. -->
+  <!-- If not yet available, there is a source build fallback via FetchContent. -->
   <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == lyrical">toppra</depend>
 
   <test_depend>roboplan_example_models</test_depend>

--- a/roboplan_toppra/package.xml
+++ b/roboplan_toppra/package.xml
@@ -10,8 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>roboplan</depend>
-  <!-- uncomment when toppra is on the ROS buildfarm for all distros -->
-  <!-- <depend>toppra</depend> -->
+  <depend>toppra</depend>
 
   <test_depend>roboplan_example_models</test_depend>
 


### PR DESCRIPTION
On some ROS distros (really, Ubuntu versions), the `nanobind-dev` dependency is too old to have stub generation. But we can simply skip it with a warning if that's the case to allow for buildfarm release, at least.

`toppra` is already on the buildfarm, though at the time of creating this PR has only been released on Humble/Lyrical since other distros haven't had syncs yet.