### PR TITLE
Add missing gtest and gmock deps in package.xmls

### DIFF
--- a/.docker/ros/Dockerfile
+++ b/.docker/ros/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-c"]
 # Install core dependencies.
 RUN apt update -y \
     && apt upgrade -y \
-    && apt install -y libgmock-dev python3-pip
+    && apt install -y python3-pip
 
 # Install Python dependencies needed for bindings.
 # Note that since Pinocchio in ROS is built with Numpy 1.x, we must preserve this by

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -136,12 +136,6 @@ Source your favorite ROS distro and build the workspace.
     rosdep install --from-paths src -y --ignore-src
     colcon build
 
-**NOTE:** To compile tests, you may also need to install GTest and GMock:
-
-::
-
-    sudo apt install libgtest-dev libgmock-dev
-
 Now you should be able to run a basic example.
 
 ::

--- a/roboplan/package.xml
+++ b/roboplan/package.xml
@@ -19,6 +19,7 @@
   <depend>tl_expected</depend>
   <depend>yaml_cpp_vendor</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>roboplan_example_models</test_depend>
 

--- a/roboplan/package.xml
+++ b/roboplan/package.xml
@@ -21,6 +21,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>libgmock-dev</test_depend>
   <test_depend>roboplan_example_models</test_depend>
 
   <export>

--- a/roboplan_oink/package.xml
+++ b/roboplan_oink/package.xml
@@ -15,6 +15,7 @@
   <depend>roboplan</depend>
   <depend>osqp_vendor</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>roboplan_example_models</test_depend>
 
   <export>

--- a/roboplan_oink/package.xml
+++ b/roboplan_oink/package.xml
@@ -16,6 +16,7 @@
   <depend>osqp_vendor</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>libgmock-dev</test_depend>
   <test_depend>roboplan_example_models</test_depend>
 
   <export>

--- a/roboplan_rrt/package.xml
+++ b/roboplan_rrt/package.xml
@@ -13,6 +13,7 @@
   <depend>nanobind-dev</depend>
   <depend>roboplan</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>roboplan_example_models</test_depend>
 

--- a/roboplan_toppra/package.xml
+++ b/roboplan_toppra/package.xml
@@ -16,6 +16,7 @@
   <!-- If not yet available, there is a source build fallback via FetchContent. -->
   <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == lyrical">toppra</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>roboplan_example_models</test_depend>
 
   <export>


### PR DESCRIPTION
Started getting feedback from the buildfarm, and these were missing