### PR TITLE
Improve TOPP-RA behavior for planar joints without discretizing path

### DIFF
--- a/roboplan/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan/bindings/python/roboplan/core/_core_ext.pyi
@@ -440,6 +440,11 @@ class Scene:
         Integrates a velocity vector from a configuration using Lie group operations.
         """
 
+    def difference(self, q_start: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], q_end: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
+        """
+        Computes the Lie group difference (log map) between two configurations.
+        """
+
     def forwardKinematics(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], frame_name: str) -> Annotated[NDArray[numpy.float64], dict(shape=(4, 4), order='F')]:
         """Calculates forward kinematics for a specific frame."""
 

--- a/roboplan/bindings/src/core.cpp
+++ b/roboplan/bindings/src/core.cpp
@@ -218,6 +218,9 @@ void init_core_scene(nanobind::module_& m) {
       .def("integrate", &Scene::integrate,
            "Integrates a velocity vector from a configuration using Lie group operations.", "q"_a,
            "v"_a)
+      .def("difference", &Scene::difference,
+           "Computes the Lie group difference (log map) between two configurations.", "q_start"_a,
+           "q_end"_a)
       .def("forwardKinematics", &Scene::forwardKinematics,
            "Calculates forward kinematics for a specific frame.", "q"_a, "frame_name"_a)
       .def(

--- a/roboplan/include/roboplan/core/scene.hpp
+++ b/roboplan/include/roboplan/core/scene.hpp
@@ -145,6 +145,15 @@ public:
   /// @return The resulting joint configuration after integration.
   Eigen::VectorXd integrate(const Eigen::VectorXd& q, const Eigen::VectorXd& v) const;
 
+  /// @brief Computes the Lie group difference (log map) between two configurations.
+  /// @details Returns the tangent vector @p v such that `integrate(q_start, v)` yields @p q_end.
+  /// For Lie-group joints the result is expressed in the body frame and is constant along the
+  /// geodesic (the screw / shortest-rotation motion that @ref interpolate follows).
+  /// @param q_start The starting joint configuration (size model.nq).
+  /// @param q_end The ending joint configuration (size model.nq).
+  /// @return The tangent / displacement vector (size model.nv).
+  Eigen::VectorXd difference(const Eigen::VectorXd& q_start, const Eigen::VectorXd& q_end) const;
+
   /// @brief Calculates forward kinematics for a specific frame.
   /// @param q The joint configuration.
   /// @param frame_name The name of the frame for which to perform forward kinematics.

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -423,6 +423,11 @@ Eigen::VectorXd Scene::integrate(const Eigen::VectorXd& q, const Eigen::VectorXd
   return pinocchio::integrate(model_, q, v);
 }
 
+Eigen::VectorXd Scene::difference(const Eigen::VectorXd& q_start,
+                                  const Eigen::VectorXd& q_end) const {
+  return pinocchio::difference(model_, q_start, q_end);
+}
+
 Eigen::Matrix4d Scene::forwardKinematics(const Eigen::VectorXd& q,
                                          const std::string& frame_name) const {
   // TODO: Need to add all sorts of validation here.

--- a/roboplan_examples/python/example_rrt.py
+++ b/roboplan_examples/python/example_rrt.py
@@ -215,25 +215,22 @@ def main(
                 position=scene.forwardKinematics(q_goal_full, ee_name)[:3, 3],
             )
 
+        visualizePath(
+            viz, scene, path, model_data.ee_names, 0.05, (0, 0, 200), "/rrt/path"
+        )
         if include_shortcutting:
             visualizePath(
-                viz, scene, path, model_data.ee_names, 0.05, (100, 0, 0), "/rrt/path"
-            )
-            visualizeJointTrajectory(
                 viz,
                 scene,
-                traj,
+                shortened_path,
                 model_data.ee_names,
+                0.05,
                 (0, 100, 0),
                 "/rrt/shortcut_path",
             )
-        else:
-            visualizePath(
-                viz, scene, path, model_data.ee_names, 0.05, (0, 0, 200), "/rrt/path"
-            )
-            visualizeJointTrajectory(
-                viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/traj"
-            )
+        visualizeJointTrajectory(
+            viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/trajectory"
+        )
 
         traj_queue.put(traj)
         plan_button.disabled = False

--- a/roboplan_examples/python/example_rrt.py
+++ b/roboplan_examples/python/example_rrt.py
@@ -228,8 +228,11 @@ def main(
                 "/rrt/shortcut_path",
             )
         else:
+            visualizePath(
+                viz, scene, path, model_data.ee_names, 0.05, (0, 0, 200), "/rrt/path"
+            )
             visualizeJointTrajectory(
-                viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/path"
+                viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/traj"
             )
 
         traj_queue.put(traj)

--- a/roboplan_toppra/include/roboplan_toppra/toppra.hpp
+++ b/roboplan_toppra/include/roboplan_toppra/toppra.hpp
@@ -59,10 +59,57 @@ public:
 
 private:
   /// @brief Helper function to convert the raw joint path to TOPP-RA compatible position vectors.
+  /// @details If the joint group contains non-standard (Lie-group) joints -- continuous, planar, or
+  /// floating -- each such joint is represented by a single normalized arc-length coordinate
+  /// instead of its individual degrees of freedom. The normalized coordinate accumulates, per path
+  /// segment, the minimum time to traverse that segment subject to the joint's velocity limits,
+  /// computed from per-component configuration distances. Because the joint moves along the scene's
+  /// geodesic (SE(2)/SE(3) screw, shortest rotation) the spline tracks the true Lie-group motion
+  /// exactly without dense resampling. As a side effect, this populates the reconstruction state
+  /// (`full_waypoints_`, `nonstandard_cumulative_`) and the normalized limit vectors.
   /// @param path The joint path to convert.
-  /// @return The TOPP-RA compatible vectors of collapsed joint paths if successful, else a string
-  /// describing the error.
+  /// @return The TOPP-RA compatible position vectors if successful, else a string describing the
+  /// error.
   tl::expected<toppra::Vectors, std::string> getPathPositionVectors(const JointPath& path);
+
+  /// @brief Returns whether a joint type is "non-standard" (a Lie group where the number of
+  /// position DOFs differs from the number of velocity DOFs, so a Euclidean spline would not track
+  /// it).
+  static bool isNonstandardJoint(JointType type);
+
+  /// @brief Finds the path segment containing a normalized coordinate value and the fraction
+  /// within.
+  /// @param cumulative The cumulative normalized coordinate at each waypoint (monotonic
+  /// increasing).
+  /// @param value The normalized coordinate value to look up.
+  /// @return A pair of {segment index (clamped to a valid segment), fraction within segment [0,
+  /// 1]}.
+  static std::pair<size_t, double> locateSegment(const std::vector<double>& cumulative,
+                                                 double value);
+
+  /// @brief Reconstructs the expanded group positions from a normalized position vector.
+  /// @details Standard joints are copied through; non-standard joints are reconstructed onto their
+  /// geodesic via `Scene::interpolate` at the fraction implied by the normalized coordinate.
+  /// @param q_norm The normalized position vector.
+  /// @return The expanded group position vector (the representation used by
+  /// `toFullJointPositions`).
+  Eigen::VectorXd normalizedToGroupPositions(const Eigen::VectorXd& q_norm) const;
+
+  /// @brief Reconstructs collapsed-space velocities (and accelerations) from a normalized solution.
+  /// @details Standard joints copy their normalized derivatives through. For non-standard joints,
+  /// the geodesic is finite-differenced with respect to the path fraction and combined via the
+  /// chain rule with the normalized first/second time derivatives. Outputs are in the same
+  /// collapsed velocity representation as the non-planar code path.
+  /// @param q_norm The normalized positions at the sample.
+  /// @param dq_norm The normalized first time derivatives at the sample.
+  /// @param ddq_norm The normalized second time derivatives at the sample.
+  /// @param[out] velocities The reconstructed velocity vector.
+  /// @param[out] accelerations The reconstructed acceleration vector.
+  void normalizedToVelocitiesAndAccelerations(const Eigen::VectorXd& q_norm,
+                                              const Eigen::VectorXd& dq_norm,
+                                              const Eigen::VectorXd& ddq_norm,
+                                              Eigen::VectorXd& velocities,
+                                              Eigen::VectorXd& accelerations) const;
 
   /// @brief Helper function to extract a natural cubic spline from a joint path.
   /// @details This defines zero velocity and acceleration at the endpoints only, meaning that
@@ -105,15 +152,33 @@ private:
   /// @brief Position indices of the joint group within the full model configuration.
   Eigen::VectorXi q_indices_;
 
-  /// @brief A list of position indices with continuous degrees of freedom.
-  /// @details This is used to figure out which joints need to be wrapped.
-  std::vector<size_t> continuous_q_indices_;
+  /// @brief Whether the joint group contains any non-standard (continuous/planar/floating) joints.
+  /// @details When true, each such joint is represented in the TOPP-RA problem by a single
+  /// normalized arc-length coordinate rather than its individual degrees of freedom, so the spline
+  /// tracks the Lie-group motion exactly without dense resampling.
+  bool has_nonstandard_joints_{false};
 
-  /// @brief Whether the joint group contains any planar joints.
-  /// @details When true, edges between path waypoints are densely resampled using the scene's
-  /// SE(2)-aware interpolation so the spline knots track the actual Lie-group motion of the
-  /// planar joint(s).
-  bool has_planar_joints_{false};
+  /// @brief Dimension of the normalized representation used for the TOPP-RA problem.
+  /// @details Equals the number of velocity DOFs in the group, but with each non-standard joint
+  /// contributing a single normalized coordinate.
+  size_t norm_dim_{0};
+
+  /// @brief Velocity limit vectors in the normalized representation.
+  toppra::Vector norm_vel_lower_limits_;
+  toppra::Vector norm_vel_upper_limits_;
+
+  /// @brief Acceleration limit vectors in the normalized representation.
+  toppra::Vector norm_acc_lower_limits_;
+  toppra::Vector norm_acc_upper_limits_;
+
+  /// @brief Full model configurations at each path waypoint, used to reconstruct geodesics.
+  /// @details Populated by getPathPositionVectors for the non-standard code path.
+  std::vector<Eigen::VectorXd> full_waypoints_;
+
+  /// @brief Cumulative normalized coordinate at each waypoint, one entry per non-standard joint.
+  /// @details Indexed by the order in which non-standard joints appear in the group. Each inner
+  /// vector is monotonically increasing and has one element per waypoint.
+  std::vector<std::vector<double>> nonstandard_cumulative_;
 };
 
 }  // namespace roboplan

--- a/roboplan_toppra/include/roboplan_toppra/toppra.hpp
+++ b/roboplan_toppra/include/roboplan_toppra/toppra.hpp
@@ -65,16 +65,14 @@ private:
   /// segment, the minimum time to traverse that segment subject to the joint's velocity limits,
   /// computed from per-component configuration distances. Because the joint moves along the scene's
   /// geodesic (SE(2)/SE(3) screw, shortest rotation) the spline tracks the true Lie-group motion
-  /// exactly without dense resampling. As a side effect, this populates the reconstruction state
-  /// (`full_waypoints_`, `nonstandard_cumulative_`) and the normalized limit vectors.
+  /// exactly without dense resampling.
   /// @param path The joint path to convert.
   /// @return The TOPP-RA compatible position vectors if successful, else a string describing the
   /// error.
   tl::expected<toppra::Vectors, std::string> getPathPositionVectors(const JointPath& path);
 
   /// @brief Returns whether a joint type is "non-standard" (a Lie group where the number of
-  /// position DOFs differs from the number of velocity DOFs, so a Euclidean spline would not track
-  /// it).
+  /// position DOFs and velocity DOFs differ, so a Euclidean spline would not track it).
   static bool isNonstandardJoint(JointType type);
 
   /// @brief Finds the path segment containing a normalized coordinate value and the fraction
@@ -82,8 +80,7 @@ private:
   /// @param cumulative The cumulative normalized coordinate at each waypoint (monotonic
   /// increasing).
   /// @param value The normalized coordinate value to look up.
-  /// @return A pair of {segment index (clamped to a valid segment), fraction within segment [0,
-  /// 1]}.
+  /// @return A pair of {segment index (clamped), fraction within segment [0, 1]}.
   static std::pair<size_t, double> locateSegment(const std::vector<double>& cumulative,
                                                  double value);
 
@@ -97,9 +94,9 @@ private:
 
   /// @brief Reconstructs collapsed-space velocities (and accelerations) from a normalized solution.
   /// @details Standard joints copy their normalized derivatives through. For non-standard joints,
-  /// the geodesic is finite-differenced with respect to the path fraction and combined via the
-  /// chain rule with the normalized first/second time derivatives. Outputs are in the same
-  /// collapsed velocity representation as the non-planar code path.
+  /// the geodesic's body-frame tangent (the Lie group log, constant along the segment) is scaled by
+  /// the normalized coordinate's first/second time derivatives via the chain rule. Outputs are in
+  /// the same collapsed velocity representation as the non-planar code path.
   /// @param q_norm The normalized positions at the sample.
   /// @param dq_norm The normalized first time derivatives at the sample.
   /// @param ddq_norm The normalized second time derivatives at the sample.
@@ -152,6 +149,28 @@ private:
   /// @brief Position indices of the joint group within the full model configuration.
   Eigen::VectorXi q_indices_;
 
+  /// @brief Precomputed placement of one (non-mimic) joint across the several representations used
+  /// while parameterizing. Computed once in the constructor so the position, reconstruction, and
+  /// velocity routines can share a single iteration instead of each re-querying joint info and
+  /// re-deriving the parallel column offsets.
+  struct JointLayout {
+    std::string joint_name;    ///< The joint name (for re-querying limits).
+    JointType type;            ///< The joint type.
+    bool is_nonstandard;       ///< Whether the joint collapses to a normalized arc-length coord.
+    size_t num_position_dofs;  ///< Number of position DOFs in the expanded representation.
+    size_t num_velocity_dofs;  ///< Number of velocity DOFs in the expanded representation.
+    size_t normalized_col;     ///< First column in the normalized (TOPP-RA) representation.
+    size_t collapsed_col;      ///< First column in the collapsed representation.
+    size_t velocity_col;       ///< First column in the velocity/acceleration representation.
+    size_t expanded_col;       ///< First column in the expanded group representation.
+    Eigen::Index q_offset;     ///< Offset of the joint within the full model configuration.
+    Eigen::Index v_offset;     ///< Offset of the joint within the full model tangent (velocity).
+    int nonstandard_idx;       ///< Index into the cumulative-coordinate list, or -1 if standard.
+  };
+
+  /// @brief The layout of every non-mimic joint in the group, in joint order.
+  std::vector<JointLayout> joint_layouts_;
+
   /// @brief Whether the joint group contains any non-standard (continuous/planar/floating) joints.
   /// @details When true, each such joint is represented in the TOPP-RA problem by a single
   /// normalized arc-length coordinate rather than its individual degrees of freedom, so the spline
@@ -178,7 +197,7 @@ private:
   /// @brief Cumulative normalized coordinate at each waypoint, one entry per non-standard joint.
   /// @details Indexed by the order in which non-standard joints appear in the group. Each inner
   /// vector is monotonically increasing and has one element per waypoint.
-  std::vector<std::vector<double>> nonstandard_cumulative_;
+  std::vector<std::vector<double>> nonstandard_joint_cumulative_coordinates_;
 };
 
 }  // namespace roboplan

--- a/roboplan_toppra/src/toppra.cpp
+++ b/roboplan_toppra/src/toppra.cpp
@@ -1,5 +1,9 @@
+#include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <stdexcept>
+#include <utility>
 
 #include <toppra/constraint/linear_joint_acceleration.hpp>
 #include <toppra/constraint/linear_joint_velocity.hpp>
@@ -10,13 +14,16 @@
 #include <roboplan_toppra/toppra.hpp>
 
 namespace {
-/// @brief Configuration-space step size for resampling edges with planar joints for spline fitting.
-/// @details This is necessary to ensure that the spline fitting doesn't produce large deviations
-/// from the original path that could lead to collisions, since the cubic spline treats (x, y,
-/// theta) as independent Euclidean scalars and produces a straight-line motion in (x, y) instead of
-/// the SE(2) screw motion that the planner used for collision checking.
-/// TODO: Make this configurable if needed.
-constexpr double kPlanarResampleStep = 0.5;
+/// @brief Floor on a path segment's normalized length, to keep the normalized coordinate strictly
+/// increasing (and avoid division by zero) when two waypoints coincide for a non-standard joint.
+constexpr double kMinSegmentLength = 1.0e-9;
+
+/// @brief Step (in path-fraction units) used to finite-difference geodesics when reconstructing
+/// translational velocities and accelerations for non-standard joints.
+constexpr double kFractionEpsilon = 1.0e-6;
+
+/// @brief Wraps an angle to the interval (-pi, pi].
+double wrapAngle(double angle) { return std::atan2(std::sin(angle), std::cos(angle)); }
 }  // namespace
 
 namespace roboplan {
@@ -51,79 +58,319 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
   joint_names_ = joint_group_info.joint_names;
   q_indices_ = joint_group_info.q_indices;
 
-  auto q_idx = 0;
+  // Determine the dimension of the normalized representation and which joints are non-standard.
+  // Standard joints contribute their velocity DOFs directly; non-standard (Lie-group) joints each
+  // contribute a single normalized arc-length coordinate.
   for (const auto& joint_name : joint_group_info.joint_names) {
     const auto maybe_joint_info = scene_->getJointInfo(joint_name);
     if (!maybe_joint_info) {
       throw std::runtime_error("Failed to instantiate TOPP-RA: " + maybe_joint_info.error());
     }
-    if (maybe_joint_info->type == JointType::CONTINUOUS) {
-      continuous_q_indices_.push_back(q_idx);
-      q_idx += 1;  // increment by collapsed indices
-    } else if (maybe_joint_info->type == JointType::PLANAR) {
-      continuous_q_indices_.push_back(q_idx + 2);
-      q_idx += 3;  // increment by collapsed indices
-      has_planar_joints_ = true;
+    const auto& joint_info = maybe_joint_info.value();
+    if (joint_info.mimic_info) {
+      continue;  // Mimic joints occupy no degrees of freedom.
+    }
+
+    if (isNonstandardJoint(joint_info.type)) {
+      has_nonstandard_joints_ = true;
+      norm_dim_ += 1;
     } else {
-      q_idx += maybe_joint_info->num_position_dofs;
+      norm_dim_ += joint_info.num_velocity_dofs;
     }
   }
 }
 
+bool PathParameterizerTOPPRA::isNonstandardJoint(JointType type) {
+  return type == JointType::CONTINUOUS || type == JointType::PLANAR || type == JointType::FLOATING;
+}
+
+std::pair<size_t, double>
+PathParameterizerTOPPRA::locateSegment(const std::vector<double>& cumulative, double value) {
+  const size_t num_segments = cumulative.size() - 1;
+  // Find the segment [k, k+1) such that cumulative[k] <= value < cumulative[k+1].
+  const auto it = std::upper_bound(cumulative.begin(), cumulative.end(), value);
+  size_t seg = (it == cumulative.begin())
+                   ? 0
+                   : static_cast<size_t>(std::distance(cumulative.begin(), it)) - 1;
+  seg = std::min(seg, num_segments - 1);
+  const double length = cumulative[seg + 1] - cumulative[seg];
+  const double fraction =
+      (length > 0.0) ? std::clamp((value - cumulative[seg]) / length, 0.0, 1.0) : 0.0;
+  return {seg, fraction};
+}
+
 tl::expected<toppra::Vectors, std::string>
 PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
-  // If the joint group contains any planar joints, densely resample each edge using the scene's
-  // SE(2)-aware interpolation. Otherwise the cubic spline would treat (x, y, theta) as independent
-  // Euclidean scalars and produce a straight-line motion in (x, y), which diverges from the
-  // SE(2) screw motion that the planner used for collision checking.
-  std::vector<Eigen::VectorXd> resampled_positions;
-  if (has_planar_joints_) {
-    resampled_positions.reserve(path.positions.size());
-    resampled_positions.push_back(path.positions.front());
-    for (size_t idx = 1; idx < path.positions.size(); ++idx) {
-      const auto q_start_full =
-          scene_->toFullJointPositions(group_name_, path.positions.at(idx - 1));
-      const auto q_end_full = scene_->toFullJointPositions(group_name_, path.positions.at(idx));
-      const auto distance = scene_->configurationDistance(q_start_full, q_end_full);
-      const auto num_steps =
-          std::max<size_t>(1, static_cast<size_t>(std::ceil(distance / kPlanarResampleStep)));
-      for (size_t step = 1; step < num_steps; ++step) {
-        const double fraction = static_cast<double>(step) / static_cast<double>(num_steps);
-        const auto q_interp_full = scene_->interpolate(q_start_full, q_end_full, fraction);
-        resampled_positions.push_back(q_interp_full(q_indices_).eval());
+  // Standard code path: with no non-standard joints, the collapsed representation is already a
+  // valid Euclidean parameterization, so we simply collapse each waypoint.
+  if (!has_nonstandard_joints_) {
+    toppra::Vectors path_pos_vecs;
+    path_pos_vecs.reserve(path.positions.size());
+    for (const auto& pos : path.positions) {
+      auto maybe_collapsed_pos = collapseContinuousJointPositions(*scene_, group_name_, pos);
+      if (!maybe_collapsed_pos) {
+        return tl::make_unexpected(maybe_collapsed_pos.error());
       }
-      resampled_positions.push_back(path.positions.at(idx));
+      path_pos_vecs.push_back(maybe_collapsed_pos.value());
     }
+    return path_pos_vecs;
   }
-  const auto& positions = has_planar_joints_ ? resampled_positions : path.positions;
 
-  toppra::Vectors path_pos_vecs;
-  path_pos_vecs.reserve(positions.size());
-  for (size_t idx = 0; idx < positions.size(); ++idx) {
-    const auto& pos = positions.at(idx);
-    auto maybe_collapsed_pos = collapseContinuousJointPositions(*scene_, group_name_, pos);
-    if (!maybe_collapsed_pos) {
-      return tl::make_unexpected(maybe_collapsed_pos.error());
+  // Normalized code path: represent each non-standard joint by a single normalized arc-length
+  // coordinate so the spline tracks the Lie-group geodesic exactly without dense resampling.
+  const size_t num_waypoints = path.positions.size();
+  const auto& model = scene_->getModel();
+
+  // Precompute the full-model and collapsed configurations at each waypoint.
+  full_waypoints_.clear();
+  full_waypoints_.reserve(num_waypoints);
+  std::vector<Eigen::VectorXd> collapsed(num_waypoints);
+  for (size_t k = 0; k < num_waypoints; ++k) {
+    full_waypoints_.push_back(scene_->toFullJointPositions(group_name_, path.positions.at(k)));
+    auto maybe_collapsed =
+        collapseContinuousJointPositions(*scene_, group_name_, path.positions.at(k));
+    if (!maybe_collapsed) {
+      return tl::make_unexpected(maybe_collapsed.error());
     }
-    auto curr_collapsed = maybe_collapsed_pos.value();
+    collapsed.at(k) = maybe_collapsed.value();
+  }
 
-    // For continuous joints we have to ensure that we take "the short way around" in the spline.
-    // If the distance to the preview point is greater than PI, then we either add or subtract
-    // 2*PI to this point to ensure that we don't travel further than we need to.
-    if (idx > 0) {
-      const auto& prev_collapsed = path_pos_vecs.at(idx - 1);
-      for (auto q_idx : continuous_q_indices_) {
-        const auto diff = curr_collapsed(q_idx) - prev_collapsed(q_idx);
-        if (diff > M_PI) {
-          curr_collapsed(q_idx) -= 2.0 * M_PI;
-        } else if (diff < -M_PI) {
-          curr_collapsed(q_idx) += 2.0 * M_PI;
+  nonstandard_cumulative_.clear();
+  norm_vel_lower_limits_ = Eigen::VectorXd::Zero(norm_dim_);
+  norm_vel_upper_limits_ = Eigen::VectorXd::Zero(norm_dim_);
+  norm_acc_lower_limits_ = Eigen::VectorXd::Zero(norm_dim_);
+  norm_acc_upper_limits_ = Eigen::VectorXd::Zero(norm_dim_);
+
+  toppra::Vectors path_pos_vecs(num_waypoints, Eigen::VectorXd::Zero(norm_dim_));
+
+  // Computes the geodesic distance between two waypoints restricted to a subset of full-config
+  // position indices, by copying waypoint k and overwriting only those indices with waypoint k+1.
+  const auto masked_distance = [&](size_t k, const std::vector<Eigen::Index>& indices) {
+    Eigen::VectorXd q_masked = full_waypoints_.at(k);
+    for (const auto idx : indices) {
+      q_masked(idx) = full_waypoints_.at(k + 1)(idx);
+    }
+    return scene_->configurationDistance(full_waypoints_.at(k), q_masked);
+  };
+
+  size_t norm_col = 0;       // Column in the normalized representation.
+  size_t collapsed_col = 0;  // Column in the collapsed representation.
+  size_t vel_col = 0;        // Column in the velocity/acceleration representation.
+  for (const auto& joint_name : joint_names_) {
+    const auto joint_info = scene_->getJointInfo(joint_name).value();
+    if (joint_info.mimic_info) {
+      continue;
+    }
+
+    if (!isNonstandardJoint(joint_info.type)) {
+      // Copy the joint's collapsed positions and limits straight through.
+      for (size_t d = 0; d < joint_info.num_velocity_dofs; ++d) {
+        for (size_t k = 0; k < num_waypoints; ++k) {
+          path_pos_vecs.at(k)(norm_col + d) = collapsed.at(k)(collapsed_col + d);
         }
+        norm_vel_lower_limits_(norm_col + d) = vel_lower_limits_(vel_col + d);
+        norm_vel_upper_limits_(norm_col + d) = vel_upper_limits_(vel_col + d);
+        norm_acc_lower_limits_(norm_col + d) = acc_lower_limits_(vel_col + d);
+        norm_acc_upper_limits_(norm_col + d) = acc_upper_limits_(vel_col + d);
+      }
+      norm_col += joint_info.num_velocity_dofs;
+      collapsed_col += joint_info.num_position_dofs;
+      vel_col += joint_info.num_velocity_dofs;
+      continue;
+    }
+
+    // Identify the joint's rotational and full position-index blocks, and the linear/angular
+    // limits. Splitting the geodesic this way recovers the true body-frame linear distance (the arc
+    // length), since the SE(2)/SE(3) log decomposes orthogonally: L^2 = d_linear^2 + d_angular^2.
+    // The world chord between waypoints would underestimate the arc on curving (translating +
+    // rotating) segments, so we use d_linear = sqrt(L^2 - d_angular^2) instead.
+    const auto q_off = static_cast<Eigen::Index>(model.idx_qs[model.getJointId(joint_name)]);
+    std::vector<Eigen::Index> all_indices, rotation_indices;
+    double max_linear_velocity = std::numeric_limits<double>::infinity();
+    double max_linear_acceleration = std::numeric_limits<double>::infinity();
+    double max_angular_velocity = std::numeric_limits<double>::infinity();
+    double max_angular_acceleration = std::numeric_limits<double>::infinity();
+    switch (joint_info.type) {
+    case JointType::CONTINUOUS:
+      all_indices = {q_off, q_off + 1};
+      rotation_indices = all_indices;
+      max_angular_velocity = joint_info.limits.max_velocity(0);
+      max_angular_acceleration = joint_info.limits.max_acceleration(0);
+      break;
+    case JointType::PLANAR:
+      all_indices = {q_off, q_off + 1, q_off + 2, q_off + 3};
+      rotation_indices = {q_off + 2, q_off + 3};
+      max_linear_velocity =
+          std::min(joint_info.limits.max_velocity(0), joint_info.limits.max_velocity(1));
+      max_linear_acceleration =
+          std::min(joint_info.limits.max_acceleration(0), joint_info.limits.max_acceleration(1));
+      max_angular_velocity = joint_info.limits.max_velocity(2);
+      max_angular_acceleration = joint_info.limits.max_acceleration(2);
+      break;
+    default:
+      return tl::make_unexpected("Floating joints are not yet supported by TOPP-RA.");
+    }
+
+    // Accumulate the normalized coordinate as the per-segment minimum traversal time, and derive a
+    // single (conservative) acceleration limit for the normalized coordinate.
+    std::vector<double> cumulative(num_waypoints, 0.0);
+    double accel_limit = std::numeric_limits<double>::infinity();
+    for (size_t k = 0; k + 1 < num_waypoints; ++k) {
+      const double total = masked_distance(k, all_indices);
+      const double angular = masked_distance(k, rotation_indices);
+      const double linear = std::sqrt(std::max(0.0, total * total - angular * angular));
+
+      double segment_length = 0.0;
+      if (std::isfinite(max_linear_velocity) && max_linear_velocity > 0.0) {
+        segment_length = std::max(segment_length, linear / max_linear_velocity);
+      }
+      if (std::isfinite(max_angular_velocity) && max_angular_velocity > 0.0) {
+        segment_length = std::max(segment_length, angular / max_angular_velocity);
+      }
+      segment_length = std::max(segment_length, kMinSegmentLength);
+      cumulative[k + 1] = cumulative[k] + segment_length;
+
+      if (linear > kMinSegmentLength && std::isfinite(max_linear_acceleration) &&
+          max_linear_acceleration > 0.0) {
+        accel_limit = std::min(accel_limit, max_linear_acceleration * segment_length / linear);
+      }
+      if (angular > kMinSegmentLength && std::isfinite(max_angular_acceleration) &&
+          max_angular_acceleration > 0.0) {
+        accel_limit = std::min(accel_limit, max_angular_acceleration * segment_length / angular);
       }
     }
-    path_pos_vecs.push_back(curr_collapsed);
+
+    for (size_t k = 0; k < num_waypoints; ++k) {
+      path_pos_vecs.at(k)(norm_col) = cumulative[k];
+    }
+    norm_vel_lower_limits_(norm_col) = -1.0;
+    norm_vel_upper_limits_(norm_col) = 1.0;
+    norm_acc_lower_limits_(norm_col) = -accel_limit;
+    norm_acc_upper_limits_(norm_col) = accel_limit;
+    nonstandard_cumulative_.push_back(std::move(cumulative));
+
+    norm_col += 1;
+    collapsed_col += static_cast<size_t>(joint_info.type == JointType::PLANAR ? 3 : 1);
+    vel_col += joint_info.num_velocity_dofs;
   }
+
   return path_pos_vecs;
+}
+
+Eigen::VectorXd
+PathParameterizerTOPPRA::normalizedToGroupPositions(const Eigen::VectorXd& q_norm) const {
+  Eigen::VectorXd group_pos(q_indices_.size());
+  const auto& model = scene_->getModel();
+
+  size_t norm_col = 0;
+  Eigen::Index expanded_col = 0;
+  int nonstandard_idx = 0;
+  for (const auto& joint_name : joint_names_) {
+    const auto joint_info = scene_->getJointInfo(joint_name).value();
+    if (joint_info.mimic_info) {
+      continue;
+    }
+
+    if (!isNonstandardJoint(joint_info.type)) {
+      for (size_t d = 0; d < joint_info.num_velocity_dofs; ++d) {
+        group_pos(expanded_col + static_cast<Eigen::Index>(d)) = q_norm(norm_col + d);
+      }
+      norm_col += joint_info.num_velocity_dofs;
+      expanded_col += static_cast<Eigen::Index>(joint_info.num_position_dofs);
+      continue;
+    }
+
+    const auto& cumulative = nonstandard_cumulative_.at(nonstandard_idx);
+    const auto [segment, fraction] = locateSegment(cumulative, q_norm(norm_col));
+    const Eigen::VectorXd interpolated =
+        scene_->interpolate(full_waypoints_.at(segment), full_waypoints_.at(segment + 1), fraction);
+    const auto q_off = static_cast<Eigen::Index>(model.idx_qs[model.getJointId(joint_name)]);
+    for (size_t d = 0; d < joint_info.num_position_dofs; ++d) {
+      group_pos(expanded_col + static_cast<Eigen::Index>(d)) =
+          interpolated(q_off + static_cast<Eigen::Index>(d));
+    }
+    norm_col += 1;
+    expanded_col += static_cast<Eigen::Index>(joint_info.num_position_dofs);
+    ++nonstandard_idx;
+  }
+
+  return group_pos;
+}
+
+void PathParameterizerTOPPRA::normalizedToVelocitiesAndAccelerations(
+    const Eigen::VectorXd& q_norm, const Eigen::VectorXd& dq_norm, const Eigen::VectorXd& ddq_norm,
+    Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) const {
+  velocities = Eigen::VectorXd::Zero(vel_lower_limits_.size());
+  accelerations = Eigen::VectorXd::Zero(vel_lower_limits_.size());
+  const auto& model = scene_->getModel();
+
+  size_t norm_col = 0;
+  size_t vel_col = 0;
+  int nonstandard_idx = 0;
+  for (const auto& joint_name : joint_names_) {
+    const auto joint_info = scene_->getJointInfo(joint_name).value();
+    if (joint_info.mimic_info) {
+      continue;
+    }
+
+    if (!isNonstandardJoint(joint_info.type)) {
+      for (size_t d = 0; d < joint_info.num_velocity_dofs; ++d) {
+        velocities(vel_col + d) = dq_norm(norm_col + d);
+        accelerations(vel_col + d) = ddq_norm(norm_col + d);
+      }
+      norm_col += joint_info.num_velocity_dofs;
+      vel_col += joint_info.num_velocity_dofs;
+      continue;
+    }
+
+    // Reconstruct body-relative velocities/accelerations on the segment geodesic. The normalized
+    // coordinate maps to a fraction f along the segment, with df/dt = norm_velocity /
+    // segment_length and d2f/dt2 = norm_acceleration / segment_length. Translational components are
+    // obtained by finite-differencing the geodesic; rotational components vary linearly with f, so
+    // their slope is the (constant) wrapped angular difference and their curvature is zero.
+    const auto& cumulative = nonstandard_cumulative_.at(nonstandard_idx);
+    const auto [segment, fraction] = locateSegment(cumulative, q_norm(norm_col));
+    const double segment_length = cumulative[segment + 1] - cumulative[segment];
+    const double df_dt = dq_norm(norm_col) / segment_length;
+    const double d2f_dt2 = ddq_norm(norm_col) / segment_length;
+    const auto q_off = static_cast<Eigen::Index>(model.idx_qs[model.getJointId(joint_name)]);
+
+    const auto& q_start = full_waypoints_.at(segment);
+    const auto& q_end = full_waypoints_.at(segment + 1);
+
+    // Indices of the rotation representation within the joint's full-config block.
+    const Eigen::Index cos_idx = q_off + (joint_info.type == JointType::PLANAR ? 2 : 0);
+    const double theta_start = std::atan2(q_start(cos_idx + 1), q_start(cos_idx));
+    const double theta_end = std::atan2(q_end(cos_idx + 1), q_end(cos_idx));
+    const double dtheta_df = wrapAngle(theta_end - theta_start);
+
+    if (joint_info.type == JointType::PLANAR) {
+      const Eigen::VectorXd interp_minus =
+          scene_->interpolate(q_start, q_end, fraction - kFractionEpsilon);
+      const Eigen::VectorXd interp_center = scene_->interpolate(q_start, q_end, fraction);
+      const Eigen::VectorXd interp_plus =
+          scene_->interpolate(q_start, q_end, fraction + kFractionEpsilon);
+      for (Eigen::Index t = 0; t < 2; ++t) {  // Translational x and y.
+        const double minus = interp_minus(q_off + t);
+        const double center = interp_center(q_off + t);
+        const double plus = interp_plus(q_off + t);
+        const double dq_df = (plus - minus) / (2.0 * kFractionEpsilon);
+        const double d2q_df2 =
+            (plus - 2.0 * center + minus) / (kFractionEpsilon * kFractionEpsilon);
+        velocities(vel_col + static_cast<size_t>(t)) = dq_df * df_dt;
+        accelerations(vel_col + static_cast<size_t>(t)) = d2q_df2 * df_dt * df_dt + dq_df * d2f_dt2;
+      }
+      velocities(vel_col + 2) = dtheta_df * df_dt;
+      accelerations(vel_col + 2) = dtheta_df * d2f_dt2;
+    } else {  // Continuous: a single rotational component.
+      velocities(vel_col) = dtheta_df * df_dt;
+      accelerations(vel_col) = dtheta_df * d2f_dt2;
+    }
+
+    norm_col += 1;
+    vel_col += joint_info.num_velocity_dofs;
+    ++nonstandard_idx;
+  }
 }
 
 std::shared_ptr<toppra::PiecewisePolyPath>
@@ -185,21 +432,29 @@ tl::expected<JointTrajectory, std::string> PathParameterizerTOPPRA::generate(
         "Acceleration scale must be greater than 0.0 and less than or equal to 1.0.");
   }
 
-  // Create scaled velocity and acceleration constraints.
-  toppra::LinearConstraintPtr vel_constraint, acc_constraint;
-  vel_constraint = std::make_shared<toppra::constraint::LinearJointVelocity>(
-      vel_lower_limits_ * velocity_scale, vel_upper_limits_ * velocity_scale);
-  acc_constraint = std::make_shared<toppra::constraint::LinearJointAcceleration>(
-      acc_lower_limits_ * acceleration_scale, acc_upper_limits_ * acceleration_scale);
-  acc_constraint->discretizationType(toppra::DiscretizationType::Interpolation);
-  toppra::LinearConstraintPtrs constraints = {vel_constraint, acc_constraint};
-
+  // Build the position vectors first, since for non-standard joints this also computes the
+  // normalized velocity/acceleration limits used by the constraints below.
   auto maybe_path_pos_vecs = getPathPositionVectors(path);
   if (!maybe_path_pos_vecs) {
     return tl::make_unexpected("Failed to extract position vectors from path: " +
                                maybe_path_pos_vecs.error());
   }
   auto path_pos_vecs = maybe_path_pos_vecs.value();
+
+  // Create scaled velocity and acceleration constraints. With non-standard joints the limits are
+  // expressed in the normalized representation (planar/continuous/floating joints collapse to a
+  // single coordinate with a unit velocity limit and a derived acceleration limit).
+  const auto& vel_lower = has_nonstandard_joints_ ? norm_vel_lower_limits_ : vel_lower_limits_;
+  const auto& vel_upper = has_nonstandard_joints_ ? norm_vel_upper_limits_ : vel_upper_limits_;
+  const auto& acc_lower = has_nonstandard_joints_ ? norm_acc_lower_limits_ : acc_lower_limits_;
+  const auto& acc_upper = has_nonstandard_joints_ ? norm_acc_upper_limits_ : acc_upper_limits_;
+  toppra::LinearConstraintPtr vel_constraint, acc_constraint;
+  vel_constraint = std::make_shared<toppra::constraint::LinearJointVelocity>(
+      vel_lower * velocity_scale, vel_upper * velocity_scale);
+  acc_constraint = std::make_shared<toppra::constraint::LinearJointAcceleration>(
+      acc_lower * acceleration_scale, acc_upper * acceleration_scale);
+  acc_constraint->discretizationType(toppra::DiscretizationType::Interpolation);
+  toppra::LinearConstraintPtrs constraints = {vel_constraint, acc_constraint};
 
   // Parse the spline fitting mode and set the options accordingly.
   // The basic rules are:
@@ -240,12 +495,17 @@ tl::expected<JointTrajectory, std::string> PathParameterizerTOPPRA::generate(
       }
 
       const auto q = geom_path->eval_single(t, 0);
-      const auto maybe_q_expanded = expandContinuousJointPositions(*scene_, group_name_, q);
-      if (!maybe_q_expanded) {
-        return tl::make_unexpected("Failed to collision check geometric path: " +
-                                   maybe_q_expanded.error());
+      Eigen::VectorXd q_full;
+      if (has_nonstandard_joints_) {
+        q_full = scene_->toFullJointPositions(group_name_, normalizedToGroupPositions(q));
+      } else {
+        const auto maybe_q_expanded = expandContinuousJointPositions(*scene_, group_name_, q);
+        if (!maybe_q_expanded) {
+          return tl::make_unexpected("Failed to collision check geometric path: " +
+                                     maybe_q_expanded.error());
+        }
+        q_full = scene_->toFullJointPositions(group_name_, maybe_q_expanded.value());
       }
-      const auto q_full = scene_->toFullJointPositions(group_name_, maybe_q_expanded.value());
 
       // If a collision is found, add a waypoint in the middle of the current and next point.
       // Don't add points in the final iteration, as it is not needed.
@@ -301,19 +561,30 @@ tl::expected<JointTrajectory, std::string> PathParameterizerTOPPRA::generate(
     traj.times.push_back(t);
   }
   Eigen::Map<Eigen::VectorXd> times_vec(traj.times.data(), traj.times.size());
-  for (const auto& pos : const_acc->eval(times_vec, 0)) {
-    const auto maybe_expanded_pos = expandContinuousJointPositions(*scene_, group_name_, pos);
-    if (!maybe_expanded_pos) {
-      return tl::make_unexpected("Failed to compute path parameterization: " +
-                                 maybe_expanded_pos.error());
+  const auto positions = const_acc->eval(times_vec, 0);
+  const auto velocities = const_acc->eval(times_vec, 1);
+  const auto accelerations = const_acc->eval(times_vec, 2);
+  for (size_t i = 0; i < positions.size(); ++i) {
+    if (has_nonstandard_joints_) {
+      // Reconstruct the expanded positions and the collapsed velocities/accelerations from the
+      // normalized solution.
+      traj.positions.push_back(normalizedToGroupPositions(positions.at(i)));
+      Eigen::VectorXd vel, acc;
+      normalizedToVelocitiesAndAccelerations(positions.at(i), velocities.at(i), accelerations.at(i),
+                                             vel, acc);
+      traj.velocities.push_back(std::move(vel));
+      traj.accelerations.push_back(std::move(acc));
+    } else {
+      const auto maybe_expanded_pos =
+          expandContinuousJointPositions(*scene_, group_name_, positions.at(i));
+      if (!maybe_expanded_pos) {
+        return tl::make_unexpected("Failed to compute path parameterization: " +
+                                   maybe_expanded_pos.error());
+      }
+      traj.positions.push_back(maybe_expanded_pos.value());
+      traj.velocities.push_back(velocities.at(i));
+      traj.accelerations.push_back(accelerations.at(i));
     }
-    traj.positions.push_back(maybe_expanded_pos.value());
-  }
-  for (const auto& vel : const_acc->eval(times_vec, 1)) {
-    traj.velocities.push_back(vel);
-  }
-  for (const auto& acc : const_acc->eval(times_vec, 2)) {
-    traj.accelerations.push_back(acc);
   }
 
   return traj;

--- a/roboplan_toppra/src/toppra.cpp
+++ b/roboplan_toppra/src/toppra.cpp
@@ -17,13 +17,6 @@ namespace {
 /// @brief Floor on a path segment's normalized length, to keep the normalized coordinate strictly
 /// increasing (and avoid division by zero) when two waypoints coincide for a non-standard joint.
 constexpr double kMinSegmentLength = 1.0e-9;
-
-/// @brief Step (in path-fraction units) used to finite-difference geodesics when reconstructing
-/// translational velocities and accelerations for non-standard joints.
-constexpr double kFractionEpsilon = 1.0e-6;
-
-/// @brief Wraps an angle to the interval (-pi, pi].
-double wrapAngle(double angle) { return std::atan2(std::sin(angle), std::cos(angle)); }
 }  // namespace
 
 namespace roboplan {
@@ -58,9 +51,14 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
   joint_names_ = joint_group_info.joint_names;
   q_indices_ = joint_group_info.q_indices;
 
-  // Determine the dimension of the normalized representation and which joints are non-standard.
-  // Standard joints contribute their velocity DOFs directly; non-standard (Lie-group) joints each
-  // contribute a single normalized arc-length coordinate.
+  // Determine the dimension of the normalized representation and which joints are non-standard, and
+  // precompute each joint's placement across every representation. Standard joints contribute their
+  // velocity DOFs directly; non-standard (Lie-group) joints each contribute a single normalized
+  // arc-length coordinate. The collapsed representation replaces each non-standard joint's rotation
+  // (cos, sin) with a single angle, so it occupies one fewer DOF than the expanded representation.
+  const auto& model = scene_->getModel();
+  size_t normalized_col = 0, collapsed_col = 0, velocity_col = 0, expanded_col = 0;
+  int nonstandard_count = 0;
   for (const auto& joint_name : joint_group_info.joint_names) {
     const auto maybe_joint_info = scene_->getJointInfo(joint_name);
     if (!maybe_joint_info) {
@@ -71,12 +69,36 @@ PathParameterizerTOPPRA::PathParameterizerTOPPRA(const std::shared_ptr<Scene> sc
       continue;  // Mimic joints occupy no degrees of freedom.
     }
 
-    if (isNonstandardJoint(joint_info.type)) {
+    const bool is_nonstandard = isNonstandardJoint(joint_info.type);
+    const auto joint_id = model.getJointId(joint_name);
+    JointLayout layout;
+    layout.joint_name = joint_name;
+    layout.type = joint_info.type;
+    layout.is_nonstandard = is_nonstandard;
+    layout.num_position_dofs = joint_info.num_position_dofs;
+    layout.num_velocity_dofs = joint_info.num_velocity_dofs;
+    layout.normalized_col = normalized_col;
+    layout.collapsed_col = collapsed_col;
+    layout.velocity_col = velocity_col;
+    layout.expanded_col = expanded_col;
+    layout.q_offset = static_cast<Eigen::Index>(model.idx_qs[joint_id]);
+    layout.v_offset = static_cast<Eigen::Index>(model.idx_vs[joint_id]);
+    layout.nonstandard_idx = is_nonstandard ? nonstandard_count : -1;
+    joint_layouts_.push_back(layout);
+
+    if (is_nonstandard) {
       has_nonstandard_joints_ = true;
+      ++nonstandard_count;
       norm_dim_ += 1;
+      normalized_col += 1;
+      collapsed_col += joint_info.num_position_dofs - 1;
     } else {
       norm_dim_ += joint_info.num_velocity_dofs;
+      normalized_col += joint_info.num_velocity_dofs;
+      collapsed_col += joint_info.num_position_dofs;
     }
+    velocity_col += joint_info.num_velocity_dofs;
+    expanded_col += joint_info.num_position_dofs;
   }
 }
 
@@ -85,17 +107,21 @@ bool PathParameterizerTOPPRA::isNonstandardJoint(JointType type) {
 }
 
 std::pair<size_t, double>
-PathParameterizerTOPPRA::locateSegment(const std::vector<double>& cumulative, double value) {
-  const size_t num_segments = cumulative.size() - 1;
-  // Find the segment [k, k+1) such that cumulative[k] <= value < cumulative[k+1].
-  const auto it = std::upper_bound(cumulative.begin(), cumulative.end(), value);
-  size_t seg = (it == cumulative.begin())
+PathParameterizerTOPPRA::locateSegment(const std::vector<double>& cumulative_coordinates,
+                                       double value) {
+  const size_t num_segments = cumulative_coordinates.size() - 1;
+  // Find the segment [k, k+1) such that cumulative_coordinates[k] <= value <
+  // cumulative_coordinates[k+1].
+  const auto it =
+      std::upper_bound(cumulative_coordinates.begin(), cumulative_coordinates.end(), value);
+  size_t seg = (it == cumulative_coordinates.begin())
                    ? 0
-                   : static_cast<size_t>(std::distance(cumulative.begin(), it)) - 1;
+                   : static_cast<size_t>(std::distance(cumulative_coordinates.begin(), it)) - 1;
   seg = std::min(seg, num_segments - 1);
-  const double length = cumulative[seg + 1] - cumulative[seg];
+  const double length = cumulative_coordinates.at(seg + 1) - cumulative_coordinates.at(seg);
   const double fraction =
-      (length > 0.0) ? std::clamp((value - cumulative[seg]) / length, 0.0, 1.0) : 0.0;
+      (length > 0.0) ? std::clamp((value - cumulative_coordinates.at(seg)) / length, 0.0, 1.0)
+                     : 0.0;
   return {seg, fraction};
 }
 
@@ -119,7 +145,6 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
   // Normalized code path: represent each non-standard joint by a single normalized arc-length
   // coordinate so the spline tracks the Lie-group geodesic exactly without dense resampling.
   const size_t num_waypoints = path.positions.size();
-  const auto& model = scene_->getModel();
 
   // Precompute the full-model and collapsed configurations at each waypoint.
   full_waypoints_.clear();
@@ -135,7 +160,7 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
     collapsed.at(k) = maybe_collapsed.value();
   }
 
-  nonstandard_cumulative_.clear();
+  nonstandard_joint_cumulative_coordinates_.clear();
   norm_vel_lower_limits_ = Eigen::VectorXd::Zero(norm_dim_);
   norm_vel_upper_limits_ = Eigen::VectorXd::Zero(norm_dim_);
   norm_acc_lower_limits_ = Eigen::VectorXd::Zero(norm_dim_);
@@ -153,29 +178,23 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
     return scene_->configurationDistance(full_waypoints_.at(k), q_masked);
   };
 
-  size_t norm_col = 0;       // Column in the normalized representation.
-  size_t collapsed_col = 0;  // Column in the collapsed representation.
-  size_t vel_col = 0;        // Column in the velocity/acceleration representation.
-  for (const auto& joint_name : joint_names_) {
-    const auto joint_info = scene_->getJointInfo(joint_name).value();
-    if (joint_info.mimic_info) {
-      continue;
-    }
-
-    if (!isNonstandardJoint(joint_info.type)) {
+  for (const auto& layout : joint_layouts_) {
+    if (!layout.is_nonstandard) {
       // Copy the joint's collapsed positions and limits straight through.
-      for (size_t d = 0; d < joint_info.num_velocity_dofs; ++d) {
+      for (size_t d = 0; d < layout.num_velocity_dofs; ++d) {
         for (size_t k = 0; k < num_waypoints; ++k) {
-          path_pos_vecs.at(k)(norm_col + d) = collapsed.at(k)(collapsed_col + d);
+          path_pos_vecs.at(k)(layout.normalized_col + d) =
+              collapsed.at(k)(layout.collapsed_col + d);
         }
-        norm_vel_lower_limits_(norm_col + d) = vel_lower_limits_(vel_col + d);
-        norm_vel_upper_limits_(norm_col + d) = vel_upper_limits_(vel_col + d);
-        norm_acc_lower_limits_(norm_col + d) = acc_lower_limits_(vel_col + d);
-        norm_acc_upper_limits_(norm_col + d) = acc_upper_limits_(vel_col + d);
+        norm_vel_lower_limits_(layout.normalized_col + d) =
+            vel_lower_limits_(layout.velocity_col + d);
+        norm_vel_upper_limits_(layout.normalized_col + d) =
+            vel_upper_limits_(layout.velocity_col + d);
+        norm_acc_lower_limits_(layout.normalized_col + d) =
+            acc_lower_limits_(layout.velocity_col + d);
+        norm_acc_upper_limits_(layout.normalized_col + d) =
+            acc_upper_limits_(layout.velocity_col + d);
       }
-      norm_col += joint_info.num_velocity_dofs;
-      collapsed_col += joint_info.num_position_dofs;
-      vel_col += joint_info.num_velocity_dofs;
       continue;
     }
 
@@ -184,7 +203,8 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
     // length), since the SE(2)/SE(3) log decomposes orthogonally: L^2 = d_linear^2 + d_angular^2.
     // The world chord between waypoints would underestimate the arc on curving (translating +
     // rotating) segments, so we use d_linear = sqrt(L^2 - d_angular^2) instead.
-    const auto q_off = static_cast<Eigen::Index>(model.idx_qs[model.getJointId(joint_name)]);
+    const auto joint_info = scene_->getJointInfo(layout.joint_name).value();
+    const Eigen::Index q_off = layout.q_offset;
     std::vector<Eigen::Index> all_indices, rotation_indices;
     double max_linear_velocity = std::numeric_limits<double>::infinity();
     double max_linear_acceleration = std::numeric_limits<double>::infinity();
@@ -213,7 +233,7 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
 
     // Accumulate the normalized coordinate as the per-segment minimum traversal time, and derive a
     // single (conservative) acceleration limit for the normalized coordinate.
-    std::vector<double> cumulative(num_waypoints, 0.0);
+    std::vector<double> cumulative_coordinates(num_waypoints, 0.0);
     double accel_limit = std::numeric_limits<double>::infinity();
     for (size_t k = 0; k + 1 < num_waypoints; ++k) {
       const double total = masked_distance(k, all_indices);
@@ -228,7 +248,7 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
         segment_length = std::max(segment_length, angular / max_angular_velocity);
       }
       segment_length = std::max(segment_length, kMinSegmentLength);
-      cumulative[k + 1] = cumulative[k] + segment_length;
+      cumulative_coordinates[k + 1] = cumulative_coordinates[k] + segment_length;
 
       if (linear > kMinSegmentLength && std::isfinite(max_linear_acceleration) &&
           max_linear_acceleration > 0.0) {
@@ -241,17 +261,13 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
     }
 
     for (size_t k = 0; k < num_waypoints; ++k) {
-      path_pos_vecs.at(k)(norm_col) = cumulative[k];
+      path_pos_vecs.at(k)(layout.normalized_col) = cumulative_coordinates[k];
     }
-    norm_vel_lower_limits_(norm_col) = -1.0;
-    norm_vel_upper_limits_(norm_col) = 1.0;
-    norm_acc_lower_limits_(norm_col) = -accel_limit;
-    norm_acc_upper_limits_(norm_col) = accel_limit;
-    nonstandard_cumulative_.push_back(std::move(cumulative));
-
-    norm_col += 1;
-    collapsed_col += static_cast<size_t>(joint_info.type == JointType::PLANAR ? 3 : 1);
-    vel_col += joint_info.num_velocity_dofs;
+    norm_vel_lower_limits_(layout.normalized_col) = -1.0;
+    norm_vel_upper_limits_(layout.normalized_col) = 1.0;
+    norm_acc_lower_limits_(layout.normalized_col) = -accel_limit;
+    norm_acc_upper_limits_(layout.normalized_col) = accel_limit;
+    nonstandard_joint_cumulative_coordinates_.push_back(std::move(cumulative_coordinates));
   }
 
   return path_pos_vecs;
@@ -260,38 +276,27 @@ PathParameterizerTOPPRA::getPathPositionVectors(const JointPath& path) {
 Eigen::VectorXd
 PathParameterizerTOPPRA::normalizedToGroupPositions(const Eigen::VectorXd& q_norm) const {
   Eigen::VectorXd group_pos(q_indices_.size());
-  const auto& model = scene_->getModel();
 
-  size_t norm_col = 0;
-  Eigen::Index expanded_col = 0;
-  int nonstandard_idx = 0;
-  for (const auto& joint_name : joint_names_) {
-    const auto joint_info = scene_->getJointInfo(joint_name).value();
-    if (joint_info.mimic_info) {
-      continue;
-    }
-
-    if (!isNonstandardJoint(joint_info.type)) {
-      for (size_t d = 0; d < joint_info.num_velocity_dofs; ++d) {
-        group_pos(expanded_col + static_cast<Eigen::Index>(d)) = q_norm(norm_col + d);
+  for (const auto& layout : joint_layouts_) {
+    const auto expanded_col = static_cast<Eigen::Index>(layout.expanded_col);
+    if (!layout.is_nonstandard) {
+      for (size_t dof = 0; dof < layout.num_velocity_dofs; ++dof) {
+        group_pos(expanded_col + static_cast<Eigen::Index>(dof)) =
+            q_norm(layout.normalized_col + dof);
       }
-      norm_col += joint_info.num_velocity_dofs;
-      expanded_col += static_cast<Eigen::Index>(joint_info.num_position_dofs);
       continue;
     }
 
-    const auto& cumulative = nonstandard_cumulative_.at(nonstandard_idx);
-    const auto [segment, fraction] = locateSegment(cumulative, q_norm(norm_col));
+    const auto& cumulative_coordinates =
+        nonstandard_joint_cumulative_coordinates_.at(layout.nonstandard_idx);
+    const auto [segment, fraction] =
+        locateSegment(cumulative_coordinates, q_norm(layout.normalized_col));
     const Eigen::VectorXd interpolated =
         scene_->interpolate(full_waypoints_.at(segment), full_waypoints_.at(segment + 1), fraction);
-    const auto q_off = static_cast<Eigen::Index>(model.idx_qs[model.getJointId(joint_name)]);
-    for (size_t d = 0; d < joint_info.num_position_dofs; ++d) {
-      group_pos(expanded_col + static_cast<Eigen::Index>(d)) =
-          interpolated(q_off + static_cast<Eigen::Index>(d));
+    for (size_t dof = 0; dof < layout.num_position_dofs; ++dof) {
+      group_pos(expanded_col + static_cast<Eigen::Index>(dof)) =
+          interpolated(layout.q_offset + static_cast<Eigen::Index>(dof));
     }
-    norm_col += 1;
-    expanded_col += static_cast<Eigen::Index>(joint_info.num_position_dofs);
-    ++nonstandard_idx;
   }
 
   return group_pos;
@@ -302,74 +307,38 @@ void PathParameterizerTOPPRA::normalizedToVelocitiesAndAccelerations(
     Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) const {
   velocities = Eigen::VectorXd::Zero(vel_lower_limits_.size());
   accelerations = Eigen::VectorXd::Zero(vel_lower_limits_.size());
-  const auto& model = scene_->getModel();
 
-  size_t norm_col = 0;
-  size_t vel_col = 0;
-  int nonstandard_idx = 0;
-  for (const auto& joint_name : joint_names_) {
-    const auto joint_info = scene_->getJointInfo(joint_name).value();
-    if (joint_info.mimic_info) {
+  for (const auto& layout : joint_layouts_) {
+    if (!layout.is_nonstandard) {
+      for (size_t dof = 0; dof < layout.num_velocity_dofs; ++dof) {
+        velocities(layout.velocity_col + dof) = dq_norm(layout.normalized_col + dof);
+        accelerations(layout.velocity_col + dof) = ddq_norm(layout.normalized_col + dof);
+      }
       continue;
     }
 
-    if (!isNonstandardJoint(joint_info.type)) {
-      for (size_t d = 0; d < joint_info.num_velocity_dofs; ++d) {
-        velocities(vel_col + d) = dq_norm(norm_col + d);
-        accelerations(vel_col + d) = ddq_norm(norm_col + d);
-      }
-      norm_col += joint_info.num_velocity_dofs;
-      vel_col += joint_info.num_velocity_dofs;
-      continue;
+    // The non-standard joint follows the scene geodesic, whose body-frame tangent (the Lie group
+    // log) is constant along the segment. The normalized coordinate maps to a fraction f with
+    // df/dt = norm_velocity / segment_length and d2f/dt2 = norm_acceleration / segment_length, so
+    // by the chain rule the body velocity is twist * df/dt and the body acceleration is twist *
+    // d2f/dt2 (the geodesic is "straight" in the Lie algebra, so the df/dt^2 curvature term
+    // vanishes).
+    const auto& cumulative_coordinates =
+        nonstandard_joint_cumulative_coordinates_.at(layout.nonstandard_idx);
+    const size_t segment =
+        locateSegment(cumulative_coordinates, q_norm(layout.normalized_col)).first;
+    const double segment_length =
+        cumulative_coordinates[segment + 1] - cumulative_coordinates[segment];
+    const double df_dt = dq_norm(layout.normalized_col) / segment_length;
+    const double d2f_dt2 = ddq_norm(layout.normalized_col) / segment_length;
+
+    const Eigen::VectorXd twist =
+        scene_->difference(full_waypoints_.at(segment), full_waypoints_.at(segment + 1));
+    for (size_t dof = 0; dof < layout.num_velocity_dofs; ++dof) {
+      const double tangent = twist(layout.v_offset + static_cast<Eigen::Index>(dof));
+      velocities(layout.velocity_col + dof) = tangent * df_dt;
+      accelerations(layout.velocity_col + dof) = tangent * d2f_dt2;
     }
-
-    // Reconstruct body-relative velocities/accelerations on the segment geodesic. The normalized
-    // coordinate maps to a fraction f along the segment, with df/dt = norm_velocity /
-    // segment_length and d2f/dt2 = norm_acceleration / segment_length. Translational components are
-    // obtained by finite-differencing the geodesic; rotational components vary linearly with f, so
-    // their slope is the (constant) wrapped angular difference and their curvature is zero.
-    const auto& cumulative = nonstandard_cumulative_.at(nonstandard_idx);
-    const auto [segment, fraction] = locateSegment(cumulative, q_norm(norm_col));
-    const double segment_length = cumulative[segment + 1] - cumulative[segment];
-    const double df_dt = dq_norm(norm_col) / segment_length;
-    const double d2f_dt2 = ddq_norm(norm_col) / segment_length;
-    const auto q_off = static_cast<Eigen::Index>(model.idx_qs[model.getJointId(joint_name)]);
-
-    const auto& q_start = full_waypoints_.at(segment);
-    const auto& q_end = full_waypoints_.at(segment + 1);
-
-    // Indices of the rotation representation within the joint's full-config block.
-    const Eigen::Index cos_idx = q_off + (joint_info.type == JointType::PLANAR ? 2 : 0);
-    const double theta_start = std::atan2(q_start(cos_idx + 1), q_start(cos_idx));
-    const double theta_end = std::atan2(q_end(cos_idx + 1), q_end(cos_idx));
-    const double dtheta_df = wrapAngle(theta_end - theta_start);
-
-    if (joint_info.type == JointType::PLANAR) {
-      const Eigen::VectorXd interp_minus =
-          scene_->interpolate(q_start, q_end, fraction - kFractionEpsilon);
-      const Eigen::VectorXd interp_center = scene_->interpolate(q_start, q_end, fraction);
-      const Eigen::VectorXd interp_plus =
-          scene_->interpolate(q_start, q_end, fraction + kFractionEpsilon);
-      for (Eigen::Index t = 0; t < 2; ++t) {  // Translational x and y.
-        const double minus = interp_minus(q_off + t);
-        const double center = interp_center(q_off + t);
-        const double plus = interp_plus(q_off + t);
-        const double dq_df = (plus - minus) / (2.0 * kFractionEpsilon);
-        const double d2q_df2 =
-            (plus - 2.0 * center + minus) / (kFractionEpsilon * kFractionEpsilon);
-        velocities(vel_col + static_cast<size_t>(t)) = dq_df * df_dt;
-        accelerations(vel_col + static_cast<size_t>(t)) = d2q_df2 * df_dt * df_dt + dq_df * d2f_dt2;
-      }
-      velocities(vel_col + 2) = dtheta_df * df_dt;
-      accelerations(vel_col + 2) = dtheta_df * d2f_dt2;
-    } else {  // Continuous: a single rotational component.
-      velocities(vel_col) = dtheta_df * df_dt;
-      accelerations(vel_col) = dtheta_df * d2f_dt2;
-    }
-
-    norm_col += 1;
-    vel_col += joint_info.num_velocity_dofs;
-    ++nonstandard_idx;
   }
 }
 

--- a/roboplan_toppra/test/test_toppra.cpp
+++ b/roboplan_toppra/test/test_toppra.cpp
@@ -354,4 +354,28 @@ TEST_F(RoboPlanToppraPlanarTest, RespectsVelocityLimits) {
   }
 }
 
+// Verifies that velocity limits are respected on "curved" segments that translate and rotate at the
+// same time. The reconstructed planar velocities are body-frame (matching the limits and the
+// arc-length normalization), so they must stay bounded even where the body and world frames differ.
+TEST_F(RoboPlanToppraPlanarTest, RespectsVelocityLimitsOnCurvedPath) {
+  JointPath path;
+  path.joint_names = joint_names_;
+  path.positions = {makePoint(0.0, 0.0, 0.0), makePoint(0.6, 0.4, 0.8), makePoint(1.3, 0.9, 1.5),
+                    makePoint(2.0, 0.3, 0.6)};
+
+  auto toppra = PathParameterizerTOPPRA(scene_, "stretch4_arm");
+  auto result = toppra.generate(path, /* dt */ 0.01, SplineFittingMode::Cubic);
+  ASSERT_TRUE(result.has_value()) << result.error();
+
+  const auto vel_limits = scene_->getVelocityLimitVectors("stretch4_arm");
+  ASSERT_TRUE(vel_limits.has_value());
+  const auto& upper = vel_limits->second;
+  for (const auto& vel : result.value().velocities) {
+    ASSERT_EQ(vel.size(), upper.size());
+    for (Eigen::Index d = 0; d < vel.size(); ++d) {
+      EXPECT_LE(std::abs(vel(d)), upper(d) + 1.0e-2) << "DOF " << d << " exceeds velocity limit.";
+    }
+  }
+}
+
 }  // namespace roboplan

--- a/roboplan_toppra/test/test_toppra.cpp
+++ b/roboplan_toppra/test/test_toppra.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <gtest/gtest.h>
 #include <memory>
 #include <vector>
@@ -247,6 +248,110 @@ TEST_F(RoboPlanToppraTest, Adaptive) {
   auto toppra = PathParameterizerTOPPRA(scene_, "arm");
   auto result = toppra.generate(path, dt, SplineFittingMode::Adaptive);
   ASSERT_TRUE(result.has_value());
+}
+
+// Tests for joint groups containing a planar (mobile base) joint. These exercise the normalized
+// arc-length representation that replaces the dense SE(2) resampling.
+class RoboPlanToppraPlanarTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    const auto model_prefix = example_models::get_package_models_dir();
+    const auto urdf_path = model_prefix / "stretch4_robot_model" / "stretch4_sg4.urdf";
+    const auto srdf_path = model_prefix / "stretch4_robot_model" / "stretch4_sg4.srdf";
+    const auto config_path = model_prefix / "stretch4_robot_model" / "stretch4_sg4_config.yaml";
+    const std::vector<std::filesystem::path> package_paths = {
+        example_models::get_package_share_dir()};
+    scene_ =
+        std::make_shared<Scene>("stretch_scene", urdf_path, srdf_path, package_paths, config_path);
+  }
+
+  // Builds an expanded group configuration: planar (x, y, cos, sin) followed by the arm joints
+  // held at their home configuration.
+  static Eigen::VectorXd makePoint(double x, double y, double theta) {
+    Eigen::VectorXd point(9);
+    point << x, y, std::cos(theta), std::sin(theta), 0.5, 0.065, 0.0, 0.0, 0.0;
+    return point;
+  }
+
+public:
+  std::shared_ptr<Scene> scene_;
+  const std::vector<std::string> joint_names_{
+      "mobile_base_planar_joint", "lift_joint",        "arm_l1_joint",
+      "wrist_yaw_joint",          "wrist_pitch_joint", "wrist_roll_joint"};
+};
+
+TEST_F(RoboPlanToppraPlanarTest, GeneratesInAllModes) {
+  JointPath path;
+  path.joint_names = joint_names_;
+  path.positions = {makePoint(0.0, 0.0, 0.0), makePoint(0.6, 0.2, 0.4), makePoint(1.0, 0.0, -0.3),
+                    makePoint(1.4, 0.5, 0.2)};
+
+  auto toppra = PathParameterizerTOPPRA(scene_, "stretch4_arm");
+  for (const auto mode :
+       {SplineFittingMode::Hermite, SplineFittingMode::Cubic, SplineFittingMode::Adaptive}) {
+    auto result = toppra.generate(path, /* dt */ 0.01, mode);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    const auto& traj = result.value();
+    ASSERT_GT(traj.positions.size(), 1u);
+    EXPECT_EQ(traj.positions.size(), traj.velocities.size());
+    EXPECT_EQ(traj.positions.size(), traj.accelerations.size());
+    // The planar position representation must remain on the unit circle.
+    for (const auto& pos : traj.positions) {
+      EXPECT_NEAR(pos(2) * pos(2) + pos(3) * pos(3), 1.0, 1.0e-6);
+    }
+    // Endpoints must match the path.
+    EXPECT_TRUE(traj.positions.front().isApprox(path.positions.front(), 1.0e-6));
+    EXPECT_TRUE(traj.positions.back().isApprox(path.positions.back(), 1.0e-6));
+  }
+}
+
+// Verifies that the reconstructed base poses lie exactly on the SE(2) geodesic that the planner
+// uses, which is the whole point of the normalized representation.
+TEST_F(RoboPlanToppraPlanarTest, TracksSE2Geodesic) {
+  JointPath path;
+  path.joint_names = joint_names_;
+  const double theta_end = 0.8;
+  path.positions = {makePoint(0.0, 0.0, 0.0), makePoint(1.0, 0.5, theta_end)};
+
+  auto toppra = PathParameterizerTOPPRA(scene_, "stretch4_arm");
+  auto result = toppra.generate(path, /* dt */ 0.01, SplineFittingMode::Hermite);
+  ASSERT_TRUE(result.has_value()) << result.error();
+
+  const auto q_start_full = scene_->toFullJointPositions("stretch4_arm", path.positions.front());
+  const auto q_end_full = scene_->toFullJointPositions("stretch4_arm", path.positions.back());
+  const auto& model = scene_->getModel();
+  const auto base_q = model.idx_qs[model.getJointId("mobile_base_planar_joint")];
+
+  for (const auto& pos : result.value().positions) {
+    const double theta = std::atan2(pos(3), pos(2));
+    const double fraction = theta / theta_end;  // theta is linear along a single segment.
+    const auto expected = scene_->interpolate(q_start_full, q_end_full, fraction);
+    EXPECT_NEAR(pos(0), expected(base_q), 1.0e-6);      // x
+    EXPECT_NEAR(pos(1), expected(base_q + 1), 1.0e-6);  // y
+  }
+}
+
+// Verifies that velocity limits are respected. Uses "clean" segments (either pure translation or
+// pure rotation) where the world-frame distances used for normalization are exact.
+TEST_F(RoboPlanToppraPlanarTest, RespectsVelocityLimits) {
+  JointPath path;
+  path.joint_names = joint_names_;
+  path.positions = {makePoint(0.0, 0.0, 0.0), makePoint(0.8, 0.0, 0.0), makePoint(0.8, 0.0, 0.9),
+                    makePoint(0.8, 0.6, 0.9), makePoint(1.4, 0.6, 0.9)};
+
+  auto toppra = PathParameterizerTOPPRA(scene_, "stretch4_arm");
+  auto result = toppra.generate(path, /* dt */ 0.01, SplineFittingMode::Cubic);
+  ASSERT_TRUE(result.has_value()) << result.error();
+
+  const auto vel_limits = scene_->getVelocityLimitVectors("stretch4_arm");
+  ASSERT_TRUE(vel_limits.has_value());
+  const auto& upper = vel_limits->second;
+  for (const auto& vel : result.value().velocities) {
+    ASSERT_EQ(vel.size(), upper.size());
+    for (Eigen::Index d = 0; d < vel.size(); ++d) {
+      EXPECT_LE(std::abs(vel(d)), upper(d) + 1.0e-2) << "DOF " << d << " exceeds velocity limit.";
+    }
+  }
 }
 
 }  // namespace roboplan


### PR DESCRIPTION
Improves https://github.com/open-planning/roboplan/pull/216 without having to discretize the path, which was causing some slowness and also lots of stop-and-go behavior in pathological cases.

Effectively, for non-standard joints (i.e., the ones with more than 1 position DOF), we simply do the TOPP-RA time parameterization in normalized coordinates, so that joints are interpolated correctly on their respective geodesics. This approach appears to work well, as shown by additional tests and overlaying paths + trajectories for the RRT example.

<img width="2175" height="1257" alt="image" src="https://github.com/user-attachments/assets/4cedd7b0-5292-43ab-860b-6da59d4a16c5" />
