### PR TITLE
Scene parsing and joint configuration clamping improvements

### DIFF
--- a/roboplan/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan/bindings/python/roboplan/core/_core_ext.pyi
@@ -424,10 +424,13 @@ class Scene:
     def hasCollisions(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], debug: bool = False) -> bool:
         """Checks collisions at specified joint positions."""
 
-    def isValidPose(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> bool:
+    def isValidConfiguration(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> bool:
         """
         Checks if the specified joint positions are valid with respect to joint limits.
         """
+
+    def clampToValidConfiguration(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
+        """Clamps the specified joint positions to valid joint limits."""
 
     def toFullJointPositions(self, group_name: str, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
         """Converts partial joint positions to full joint positions."""

--- a/roboplan/bindings/src/core.cpp
+++ b/roboplan/bindings/src/core.cpp
@@ -209,8 +209,10 @@ void init_core_scene(nanobind::module_& m) {
            "Generates random collision-free positions for the robot model.", "max_samples"_a = 1000)
       .def("hasCollisions", &Scene::hasCollisions,
            "Checks collisions at specified joint positions.", "q"_a, "debug"_a = false)
-      .def("isValidPose", &Scene::isValidPose,
+      .def("isValidConfiguration", &Scene::isValidConfiguration,
            "Checks if the specified joint positions are valid with respect to joint limits.", "q"_a)
+      .def("clampToValidConfiguration", &Scene::clampToValidConfiguration,
+           "Clamps the specified joint positions to valid joint limits.", "q"_a)
       .def("toFullJointPositions", &Scene::toFullJointPositions,
            "Converts partial joint positions to full joint positions.", "group_name"_a, "q"_a)
       .def("interpolate", &Scene::interpolate, "Interpolates between two joint configurations.",

--- a/roboplan/include/roboplan/core/scene.hpp
+++ b/roboplan/include/roboplan/core/scene.hpp
@@ -122,7 +122,14 @@ public:
   /// @brief Checks if the specified joint positions are valid with respect to joint limits.
   /// @param q The joint positions.
   /// @return True if the positions respect joint limits, else false.
-  bool isValidPose(const Eigen::VectorXd& q) const;
+  bool isValidConfiguration(const Eigen::VectorXd& q) const;
+
+  /// @brief Clamps the specified joint positions to valid joint limits.
+  /// @details Bounded joints are clamped to their position limits, while continuous and planar
+  /// rotation representations are renormalized onto the unit circle.
+  /// @param q The joint positions.
+  /// @return A new vector of joint positions that respects joint limits.
+  Eigen::VectorXd clampToValidConfiguration(const Eigen::VectorXd& q) const;
 
   /// @brief Converts partial joint positions to full joint positions.
   /// @details This includes adding new joints.

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -335,7 +335,7 @@ void Scene::computeCollisionDistances(const Eigen::VectorXd& q) const {
   pinocchio::computeDistances(model_, model_data_, collision_model_, collision_model_data_, q);
 }
 
-bool Scene::isValidPose(const Eigen::VectorXd& q) const {
+bool Scene::isValidConfiguration(const Eigen::VectorXd& q) const {
   size_t q_idx = 0;
   for (const auto& joint_name : joint_names_) {
     const auto& info = joint_info_map_.at(joint_name);
@@ -346,7 +346,7 @@ bool Scene::isValidPose(const Eigen::VectorXd& q) const {
 
     switch (info.type) {
     case JointType::FLOATING:
-      throw std::runtime_error("Floating joints not yet supported by isValidPose.");
+      throw std::runtime_error("Floating joints not yet supported by isValidConfiguration.");
     case JointType::PLANAR:
       // The first 2 DOFs (translation) can be bounded, but the last (rotation) is always valid.
       // However, we still check that it is on the unit circle.
@@ -374,6 +374,10 @@ bool Scene::isValidPose(const Eigen::VectorXd& q) const {
         const auto& lo = info.limits.min_position[idx];
         const auto& hi = info.limits.max_position[idx];
         if (q(q_idx) < lo || q(q_idx) > hi) {
+          std::cout << "Joint name: " << joint_name << " dof " << idx
+                    << "out of bounds."
+                       " lo: "
+                    << lo << ", hi: " << hi << ", actual: " << q(q_idx) << std::endl;
           return false;
         }
         ++q_idx;
@@ -381,6 +385,63 @@ bool Scene::isValidPose(const Eigen::VectorXd& q) const {
     }
   }
   return true;
+}
+
+Eigen::VectorXd Scene::clampToValidConfiguration(const Eigen::VectorXd& q) const {
+  Eigen::VectorXd result = q;
+  size_t q_idx = 0;
+  for (const auto& joint_name : joint_names_) {
+    const auto& info = joint_info_map_.at(joint_name);
+    if (info.mimic_info) {
+      // Mimic joints occupy no q slots; limits are enforced on the mimicked parent above.
+      continue;
+    }
+
+    switch (info.type) {
+    case JointType::FLOATING:
+      throw std::runtime_error("Floating joints not yet supported by clampToValidConfiguration.");
+    case JointType::PLANAR: {
+      // The first 2 DOFs (translation) can be bounded, but the last (rotation) is always valid.
+      // However, we still renormalize it onto the unit circle.
+      for (size_t idx = 0; idx < 2; ++idx) {
+        const auto& lo = info.limits.min_position[idx];
+        const auto& hi = info.limits.max_position[idx];
+        result(q_idx + idx) = std::clamp(result(q_idx + idx), lo, hi);
+      }
+      const double norm = std::hypot(result(q_idx + 2), result(q_idx + 3));
+      if (norm > 0.0) {
+        result(q_idx + 2) /= norm;
+        result(q_idx + 3) /= norm;
+      } else {
+        result(q_idx + 2) = 1.0;
+        result(q_idx + 3) = 0.0;
+      }
+      q_idx += 4;
+      break;
+    }
+    case JointType::CONTINUOUS: {
+      // Unbounded so always valid, but renormalize the representation onto the unit circle.
+      const double norm = std::hypot(result(q_idx), result(q_idx + 1));
+      if (norm > 0.0) {
+        result(q_idx) /= norm;
+        result(q_idx + 1) /= norm;
+      } else {
+        result(q_idx) = 1.0;
+        result(q_idx + 1) = 0.0;
+      }
+      q_idx += 2;
+      break;
+    }
+    default:
+      for (size_t idx = 0; idx < info.num_position_dofs; ++idx) {
+        const auto& lo = info.limits.min_position[idx];
+        const auto& hi = info.limits.max_position[idx];
+        result(q_idx) = std::clamp(result(q_idx), lo, hi);
+        ++q_idx;
+      }
+    }
+  }
+  return result;
 }
 
 Eigen::VectorXd Scene::toFullJointPositions(const std::string& group_name,

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -353,32 +353,31 @@ bool Scene::isValidConfiguration(const Eigen::VectorXd& q) const {
       for (size_t idx = 0; idx < 2; ++idx) {
         const auto& lo = info.limits.min_position[idx];
         const auto& hi = info.limits.max_position[idx];
-        if (q(q_idx) < lo || q(q_idx) > hi) {
+        if (q(q_idx + idx) < lo || q(q_idx + idx) > hi) {
           return false;
         }
       }
       if (std::abs(std::pow(q(q_idx + 2), 2) + std::pow(q(q_idx + 3), 2) - 1.0) > kUnitCircleTol) {
         return false;
       }
-      q_idx += 4;
       break;
     case JointType::CONTINUOUS:
       // Unbounded so always valid, but check whether the representation is on the unit circle.
       if (std::abs(std::pow(q(q_idx), 2) + std::pow(q(q_idx + 1), 2) - 1.0) > kUnitCircleTol) {
         return false;
       }
-      q_idx += 2;
       break;
     default:
       for (size_t idx = 0; idx < info.num_position_dofs; ++idx) {
         const auto& lo = info.limits.min_position[idx];
         const auto& hi = info.limits.max_position[idx];
-        if (q(q_idx) < lo || q(q_idx) > hi) {
+        if (q(q_idx + idx) < lo || q(q_idx + idx) > hi) {
           return false;
         }
-        ++q_idx;
       }
     }
+
+    q_idx += info.num_position_dofs;
   }
   return true;
 }
@@ -412,7 +411,6 @@ Eigen::VectorXd Scene::clampToValidConfiguration(const Eigen::VectorXd& q) const
         result(q_idx + 2) = 1.0;
         result(q_idx + 3) = 0.0;
       }
-      q_idx += 4;
       break;
     }
     case JointType::CONTINUOUS: {
@@ -425,7 +423,6 @@ Eigen::VectorXd Scene::clampToValidConfiguration(const Eigen::VectorXd& q) const
         result(q_idx) = 1.0;
         result(q_idx + 1) = 0.0;
       }
-      q_idx += 2;
       break;
     }
     default:
@@ -433,9 +430,10 @@ Eigen::VectorXd Scene::clampToValidConfiguration(const Eigen::VectorXd& q) const
         const auto& lo = info.limits.min_position[idx];
         const auto& hi = info.limits.max_position[idx];
         result(q_idx) = std::clamp(result(q_idx), lo, hi);
-        ++q_idx;
       }
     }
+
+    q_idx += info.num_position_dofs;
   }
   return result;
 }
@@ -573,7 +571,6 @@ Scene::getPositionLimitVectors(const std::string& group_name, const bool collaps
           upper_limits(q_idx + dof) = joint_info.limits.max_position(dof);
         }
       }
-      q_idx += collapsed ? 6 : 7;
       break;
     case JointType::PLANAR:
       // Position limits can be finite, orientation stays unlimited.
@@ -585,11 +582,9 @@ Scene::getPositionLimitVectors(const std::string& group_name, const bool collaps
           upper_limits(q_idx + dof) = joint_info.limits.max_position(dof);
         }
       }
-      q_idx += collapsed ? 3 : 4;
       break;
     case JointType::CONTINUOUS:
       // Already has infinite limits, no action needed.
-      q_idx += collapsed ? 1 : 2;
       break;
     default:  // Prismatic or revolute.
       if (joint_info.limits.min_position.size() > 0) {
@@ -598,8 +593,9 @@ Scene::getPositionLimitVectors(const std::string& group_name, const bool collaps
       if (joint_info.limits.max_position.size() > 0) {
         upper_limits(q_idx) = joint_info.limits.max_position(0);
       }
-      ++q_idx;
     }
+
+    q_idx += collapsed ? joint_info.num_velocity_dofs : joint_info.num_position_dofs;
   }
   return std::make_pair(lower_limits, upper_limits);
 }

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -374,10 +374,6 @@ bool Scene::isValidConfiguration(const Eigen::VectorXd& q) const {
         const auto& lo = info.limits.min_position[idx];
         const auto& hi = info.limits.max_position[idx];
         if (q(q_idx) < lo || q(q_idx) > hi) {
-          std::cout << "Joint name: " << joint_name << " dof " << idx
-                    << "out of bounds."
-                       " lo: "
-                    << lo << ", hi: " << hi << ", actual: " << q(q_idx) << std::endl;
           return false;
         }
         ++q_idx;

--- a/roboplan/src/core/scene_utils.cpp
+++ b/roboplan/src/core/scene_utils.cpp
@@ -10,7 +10,14 @@ std::unordered_map<std::string, pinocchio::FrameIndex>
 createFrameMap(const pinocchio::Model& model) {
   std::unordered_map<std::string, pinocchio::FrameIndex> frame_map;
   for (const auto& frame : model.frames) {
-    frame_map[frame.name] = model.getFrameId(frame.name);
+    auto it = frame_map.find(frame.name);
+    if (it != frame_map.end()) {
+      throw std::runtime_error(
+          "Frame name '" + frame.name +
+          "' was already added to the map. Duplicate names for different frame types (body, joint, "
+          "sensor, etc.) are not supported in RoboPlan.");
+    }
+    frame_map[frame.name] = model.getFrameId(frame.name, frame.type);
   }
   return frame_map;
 }
@@ -70,10 +77,18 @@ std::unordered_map<std::string, JointGroupInfo> createJointGroupInfo(const pinoc
 
         auto cur_frame_id = model.getFrameId(tip_link);
         const auto base_frame_id = model.getFrameId(base_link);
+        const auto base_link_parent_joint_id = model.frames.at(base_frame_id).parentJoint;
         std::vector<int> joint_indices;
         while (true) {
           const auto& frame = model.frames.at(cur_frame_id);
           const auto parent_joint_id = frame.parentJoint;
+
+          // Sometimes the parent frame of a joint is rigidly attached to the chain's base link,
+          // but is not the parent frame itself, so we should check that as well.
+          if (parent_joint_id == base_link_parent_joint_id) {
+            break;
+          }
+
           const auto& parent_joint_name = model.names.at(parent_joint_id);
           joint_indices.push_back(parent_joint_id);
           cur_frame_id = model.frames.at(model.getFrameId(parent_joint_name)).parentFrame;
@@ -81,8 +96,8 @@ std::unordered_map<std::string, JointGroupInfo> createJointGroupInfo(const pinoc
             break;
           }
           if (cur_frame_id == 0) {
-            throw std::runtime_error(
-                "Recursed the whole robot model and did not find the base frame!");
+            throw std::runtime_error("Recursed the whole robot model for chain in group '" +
+                                     std::string(name) + "' and did not find the base frame!");
           }
         }
         // Add the joint information in the reverse order.

--- a/roboplan_rrt/src/rrt.cpp
+++ b/roboplan_rrt/src/rrt.cpp
@@ -81,9 +81,18 @@ tl::expected<JointPath, std::string> RRT::plan(const JointConfiguration& start,
   auto q_goal = scene_->toFullJointPositions(options_.group_name, goal.positions);
   auto q_sample = q_start;
 
-  // Ensure the start and goal poses are valid
-  if (!scene_->isValidPose(q_start) || !scene_->isValidPose(q_goal)) {
-    return tl::make_unexpected("Invalid poses requested, cannot plan!");
+  // Ensure the start and goal configurations are valid and collision-free.
+  if (!scene_->isValidConfiguration(q_start)) {
+    return tl::make_unexpected("Invalid start configuration requested, cannot plan!");
+  }
+  if (!scene_->isValidConfiguration(q_goal)) {
+    return tl::make_unexpected("Invalid goal configuration requested, cannot plan!");
+  }
+  if (scene_->hasCollisions(q_start)) {
+    return tl::make_unexpected("Start configuration is in collision, cannot plan!");
+  }
+  if (scene_->hasCollisions(q_goal)) {
+    return tl::make_unexpected("Goal configuration is in collision, cannot plan!");
   }
 
   // Check whether direct connection between the start and goal is possible.


### PR DESCRIPTION
This PR does a handful of things:

1. Throws an exception if there are duplicate frame names of different types (e.g., joint + body)
2. Fixes a bug parsing SRDF chain groups if the base link isn't directly the parent of a joint, but is rather connected via fixed joint
3. Renames `Scene::isValidPose()` to `Scene::isValidConfiguration()` to be technically correct
4. Adds a new `Scene::clampToValidConfiguration()` method to handle numerical drift from hardware or simulation drivers
5. Makes RRT planning pre-validation error messages more granular to ease debugging