### PR TITLE
support accel + jerk limits in urdf>=1.2 

### DIFF
--- a/roboplan/include/roboplan/core/scene_utils.hpp
+++ b/roboplan/include/roboplan/core/scene_utils.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <string>
+#include <unordered_map>
 
 #include <pinocchio/multibody/model.hpp>
 
@@ -70,5 +72,23 @@ expandContinuousJointPositions(const Scene& scene, const std::string& group_name
 /// @param q The Pinocchio configuration vector (model.nq).
 /// @return Position vector aligned with getJointNamesWithMimics().
 Eigen::VectorXd jointPositionsWithMimicsFromPinocchio(const Scene& scene, const Eigen::VectorXd& q);
+
+/// @brief Holds extended joint limits (acceleration, jerk) parsed from a URDF <limit> tag.
+/// @details This is a temporary holdover until Pinocchio properly supports URDF 1.2 extended
+/// limits in its own parsers. See https://github.com/stack-of-tasks/pinocchio/issues/2893
+struct UrdfExtendedJointLimits {
+  std::optional<double> acceleration;
+  std::optional<double> jerk;
+};
+
+/// @brief Parses extended joint limits (acceleration, jerk) from URDF <limit> tags.
+/// @details Reads acceleration and jerk attributes if present, regardless of URDF version.
+/// Returns an empty map only if parsing fails.
+/// This is a temporary holdover until Pinocchio properly supports URDF 1.2 extended limits.
+/// See https://github.com/stack-of-tasks/pinocchio/issues/2893
+/// @param urdf The URDF XML string.
+/// @return A map from joint name to its extended limits.
+std::unordered_map<std::string, UrdfExtendedJointLimits>
+parseUrdfExtendedJointLimits(const std::string& urdf);
 
 }  // namespace roboplan

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
 
 #include <tl/expected.hpp>
 
@@ -59,6 +61,7 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
 
   // Single model with Pinocchio native mimics
   pinocchio::urdf::buildModelFromXML(urdf, model_, /*verbose*/ false, /*mimic*/ true);
+  const auto urdf_extended_limits = parseUrdfExtendedJointLimits(urdf);
 
   YAML::Node yaml_config;
   if (!yaml_config_path.empty() && !std::filesystem::is_directory(yaml_config_path)) {
@@ -149,6 +152,7 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
         }
       }
     }
+    const auto urdf_extended_it = urdf_extended_limits.find(joint_name);
     for (int idx = 0; idx < joint.nv(); ++idx) {
       if (maybe_vel_limits) {
         info.limits.max_velocity[idx] = maybe_vel_limits.value()[idx].as<double>();
@@ -157,9 +161,15 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
       }
       if (maybe_acc_limits) {
         info.limits.max_acceleration[idx] = maybe_acc_limits.value()[idx].as<double>();
+      } else if (urdf_extended_it != urdf_extended_limits.end() &&
+                 urdf_extended_it->second.acceleration.has_value()) {
+        info.limits.max_acceleration[idx] = urdf_extended_it->second.acceleration.value();
       }
       if (maybe_jerk_limits) {
         info.limits.max_jerk[idx] = maybe_jerk_limits.value()[idx].as<double>();
+      } else if (urdf_extended_it != urdf_extended_limits.end() &&
+                 urdf_extended_it->second.jerk.has_value()) {
+        info.limits.max_jerk[idx] = urdf_extended_it->second.jerk.value();
       }
       ++v_idx;
     }

--- a/roboplan/src/core/scene_utils.cpp
+++ b/roboplan/src/core/scene_utils.cpp
@@ -366,4 +366,43 @@ Eigen::VectorXd jointPositionsWithMimicsFromPinocchio(const Scene& scene,
   return positions;
 }
 
+std::unordered_map<std::string, UrdfExtendedJointLimits>
+parseUrdfExtendedJointLimits(const std::string& urdf) {
+  std::unordered_map<std::string, UrdfExtendedJointLimits> result;
+
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(urdf.c_str()) != tinyxml2::XML_SUCCESS) {
+    return result;
+  }
+
+  const tinyxml2::XMLElement* robot = doc.FirstChildElement("robot");
+  if (!robot) {
+    return result;
+  }
+
+  for (const tinyxml2::XMLElement* joint = robot->FirstChildElement("joint"); joint;
+       joint = joint->NextSiblingElement("joint")) {
+    const char* name = joint->Attribute("name");
+    if (!name) {
+      continue;
+    }
+    const tinyxml2::XMLElement* limit = joint->FirstChildElement("limit");
+    if (!limit) {
+      continue;
+    }
+
+    UrdfExtendedJointLimits limits;
+    double val = 0.0;
+    if (limit->QueryDoubleAttribute("acceleration", &val) == tinyxml2::XML_SUCCESS) {
+      limits.acceleration = val;
+    }
+    if (limit->QueryDoubleAttribute("jerk", &val) == tinyxml2::XML_SUCCESS) {
+      limits.jerk = val;
+    }
+    result.emplace(name, limits);
+  }
+
+  return result;
+}
+
 }  // namespace roboplan

--- a/roboplan/test/CMakeLists.txt
+++ b/roboplan/test/CMakeLists.txt
@@ -46,6 +46,14 @@ target_link_libraries(
   GTest::gtest_main
 )
 
+add_executable(test_urdf_extended_limits test_urdf_extended_limits.cpp)
+set_property(TARGET test_urdf_extended_limits PROPERTY CXX_STANDARD 20)
+target_link_libraries(
+  test_urdf_extended_limits
+  roboplan
+  GTest::gtest_main
+)
+
 # TODO: Define tests as a variable
 
 # If ament_gtest is detected, make the tests visible in ROS 2.
@@ -56,6 +64,7 @@ if ( ament_cmake_gtest_FOUND )
     ament_add_gtest_test(test_joints)
     ament_add_gtest_test(test_path_utils)
     ament_add_gtest_test(test_se3_low_pass_filter)
+    ament_add_gtest_test(test_urdf_extended_limits)
 else()
     include(GoogleTest)
     gtest_discover_tests(test_types)
@@ -63,4 +72,5 @@ else()
     gtest_discover_tests(test_joints)
     gtest_discover_tests(test_path_utils)
     gtest_discover_tests(test_se3_low_pass_filter)
+    gtest_discover_tests(test_urdf_extended_limits)
 endif()

--- a/roboplan/test/test_urdf_extended_limits.cpp
+++ b/roboplan/test/test_urdf_extended_limits.cpp
@@ -1,0 +1,188 @@
+#include <fstream>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+
+#include <roboplan/core/scene.hpp>
+
+namespace {
+constexpr double kTolerance = 1e-6;
+constexpr double kUnlimited = std::numeric_limits<double>::max();
+}  // namespace
+
+const std::string kSrdf = R"(
+<robot name="robot">
+  <disable_collisions link1="base_link" link2="link1" reason="Adjacent"/>
+</robot>
+)";
+
+// All three extended limit attributes explicitly set.
+const std::string kUrdfAllLimits = R"(
+<robot name="robot">
+  <link name="base_link"/>
+  <link name="link1"/>
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="100" velocity="1.0"
+           acceleration="5.0" jerk="50.0"/>
+  </joint>
+</robot>
+)";
+
+// Only acceleration set; jerk should stay unlimited.
+const std::string kUrdfAccelOnly = R"(
+<robot name="robot">
+  <link name="base_link"/>
+  <link name="link1"/>
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="100" velocity="1.0"
+           acceleration="5.0"/>
+  </joint>
+</robot>
+)";
+
+// No extended attributes — both should stay unlimited.
+const std::string kUrdfNoExtendedLimits = R"(
+<robot name="robot">
+  <link name="base_link"/>
+  <link name="link1"/>
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="100" velocity="1.0"/>
+  </joint>
+</robot>
+)";
+
+// For YAML override test: URDF has 5.0/50.0, YAML overrides to 10.0/100.0.
+const std::string kUrdfForYamlOverride = R"(
+<robot name="robot">
+  <link name="base_link"/>
+  <link name="link1"/>
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="100" velocity="1.0"
+           acceleration="5.0" jerk="50.0"/>
+  </joint>
+</robot>
+)";
+
+// Mimic joint test.
+const std::string kUrdfWithMimic = R"(
+<robot name="robot">
+  <link name="base_link"/>
+  <link name="link1"/>
+  <link name="link2"/>
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="100" velocity="1.0"
+           acceleration="6.0" jerk="60.0"/>
+  </joint>
+  <joint name="mimic_joint" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="100" velocity="1.0"/>
+    <mimic joint="joint1" multiplier="2.0" offset="0.0"/>
+  </joint>
+</robot>
+)";
+
+const std::string kSrdfWithMimic = R"(
+<robot name="robot">
+  <disable_collisions link1="base_link" link2="link1" reason="Adjacent"/>
+  <disable_collisions link1="link1" link2="link2" reason="Adjacent"/>
+</robot>
+)";
+
+namespace roboplan {
+
+// ──────────────────────────────────────────────────────────────
+// All extended limits explicitly set
+// ──────────────────────────────────────────────────────────────
+TEST(UrdfExtendedLimits, AllLimitsSet) {
+  Scene scene("test", kUrdfAllLimits, kSrdf);
+
+  const auto info = scene.getJointInfo("joint1").value();
+  EXPECT_NEAR(info.limits.max_acceleration[0], 5.0, kTolerance);
+  EXPECT_NEAR(info.limits.max_jerk[0], 50.0, kTolerance);
+}
+
+// ──────────────────────────────────────────────────────────────
+// Only acceleration set; jerk should stay unlimited
+// ──────────────────────────────────────────────────────────────
+TEST(UrdfExtendedLimits, AccelerationOnlyJerkUnlimited) {
+  Scene scene("test", kUrdfAccelOnly, kSrdf);
+
+  const auto info = scene.getJointInfo("joint1").value();
+  EXPECT_NEAR(info.limits.max_acceleration[0], 5.0, kTolerance);
+  EXPECT_DOUBLE_EQ(info.limits.max_jerk[0], kUnlimited);
+}
+
+// ──────────────────────────────────────────────────────────────
+// No extended attributes — both should stay unlimited
+// ──────────────────────────────────────────────────────────────
+TEST(UrdfExtendedLimits, NoExtendedLimitsStayUnlimited) {
+  Scene scene("test", kUrdfNoExtendedLimits, kSrdf);
+
+  const auto info = scene.getJointInfo("joint1").value();
+  EXPECT_DOUBLE_EQ(info.limits.max_acceleration[0], kUnlimited);
+  EXPECT_DOUBLE_EQ(info.limits.max_jerk[0], kUnlimited);
+}
+
+// ──────────────────────────────────────────────────────────────
+// YAML overrides URDF values
+// ──────────────────────────────────────────────────────────────
+TEST(UrdfExtendedLimits, YamlOverridesUrdf) {
+  const auto tmp_yaml = std::filesystem::temp_directory_path() / "test_urdf_override.yaml";
+  {
+    std::ofstream f(tmp_yaml);
+    f << "joint_limits:\n"
+      << "  joint1:\n"
+      << "    max_acceleration: [10.0]\n"
+      << "    max_jerk: [100.0]\n";
+  }
+
+  Scene scene("test", kUrdfForYamlOverride, kSrdf, {}, tmp_yaml);
+
+  const auto info = scene.getJointInfo("joint1").value();
+  EXPECT_NEAR(info.limits.max_acceleration[0], 10.0, kTolerance);
+  EXPECT_NEAR(info.limits.max_jerk[0], 100.0, kTolerance);
+
+  std::filesystem::remove(tmp_yaml);
+}
+
+// ──────────────────────────────────────────────────────────────
+// Mimic joint inherits scaled limits
+// ──────────────────────────────────────────────────────────────
+TEST(UrdfExtendedLimits, MimicJointInheritsScaledLimits) {
+  Scene scene("test", kUrdfWithMimic, kSrdfWithMimic);
+
+  const auto joint1_info = scene.getJointInfo("joint1").value();
+  EXPECT_NEAR(joint1_info.limits.max_acceleration[0], 6.0, kTolerance);
+  EXPECT_NEAR(joint1_info.limits.max_jerk[0], 60.0, kTolerance);
+
+  // mimic multiplier=2.0, so limits scale by |2.0|.
+  const auto mimic_info = scene.getJointInfo("mimic_joint").value();
+  EXPECT_NEAR(mimic_info.limits.max_acceleration[0], 12.0, kTolerance);
+  EXPECT_NEAR(mimic_info.limits.max_jerk[0], 120.0, kTolerance);
+}
+
+}  // namespace roboplan


### PR DESCRIPTION
PR intended to fix #217 

Our current urdfdom only supports up to 1.1 and rejects version 1.2 so acceleration and jerk are read from limit tags regardless of version. Present means used, absent means unlimited and YAML still wins when both are set. TinyXML2 is used directly, same as the SRDF parsing