### PR TITLE
Speed up path shortcutting

### DIFF
--- a/roboplan/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan/bindings/python/roboplan/core/_core_ext.pyi
@@ -529,12 +529,56 @@ def hasCollisionsAlongPath(scene: Scene, q_start: Annotated[NDArray[numpy.float6
     Checks collisions along a specified configuration space path. Uses the Scene's own collision scratch, so it is not safe to call concurrently with other queries on the same Scene.
     """
 
+class PathShortcuttingOptions:
+    """Options struct for path shortcutting."""
+
+    def __init__(self, group_name: str = '', max_step_size: float = 0.05, max_iters: int = 100, seed: int = 0, max_convergence_iters: int = 20) -> None: ...
+
+    @property
+    def group_name(self) -> str:
+        """The joint group name to be used for path shortcutting."""
+
+    @group_name.setter
+    def group_name(self, arg: str, /) -> None: ...
+
+    @property
+    def max_step_size(self) -> float:
+        """
+        Maximum step size used in collision checking, and the minimum separable distance between points in a shortcut.
+        """
+
+    @max_step_size.setter
+    def max_step_size(self, arg: float, /) -> None: ...
+
+    @property
+    def max_iters(self) -> int:
+        """Maximum number of iterations of random sampling."""
+
+    @max_iters.setter
+    def max_iters(self, arg: int, /) -> None: ...
+
+    @property
+    def seed(self) -> int:
+        """Seed for the random generator. If < 0, a random seed is used."""
+
+    @seed.setter
+    def seed(self, arg: int, /) -> None: ...
+
+    @property
+    def max_convergence_iters(self) -> int:
+        """
+        Stop early once this many consecutive iterations fail to apply a shortcut. A value of 0 disables early stopping.
+        """
+
+    @max_convergence_iters.setter
+    def max_convergence_iters(self, arg: int, /) -> None: ...
+
 class PathShortcutter:
     """Shortcuts joint paths with random sampling and checking connections."""
 
-    def __init__(self, scene: Scene, group_name: str) -> None: ...
+    def __init__(self, scene: Scene, options: PathShortcuttingOptions) -> None: ...
 
-    def shortcut(self, path: JointPath, max_step_size: float, max_iters: int = 100, seed: int = 0) -> JointPath:
+    def shortcut(self, path: JointPath) -> JointPath:
         """Attempts to shortcut a specified path."""
 
     def getPathLengths(self, path: JointPath) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:

--- a/roboplan/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan/bindings/python/roboplan/core/_core_ext.pyi
@@ -532,7 +532,7 @@ def hasCollisionsAlongPath(scene: Scene, q_start: Annotated[NDArray[numpy.float6
 class PathShortcuttingOptions:
     """Options struct for path shortcutting."""
 
-    def __init__(self, group_name: str = '', max_step_size: float = 0.05, max_iters: int = 100, seed: int = 0, max_convergence_iters: int = 20) -> None: ...
+    def __init__(self, group_name: str = '', max_step_size: float = 0.05, max_iters: int = 100, seed: int = 0, max_convergence_iters: int = 20, redundant_removal_iters: int = 20) -> None: ...
 
     @property
     def group_name(self) -> str:
@@ -572,6 +572,15 @@ class PathShortcuttingOptions:
 
     @max_convergence_iters.setter
     def max_convergence_iters(self, arg: int, /) -> None: ...
+
+    @property
+    def redundant_removal_iters(self) -> int:
+        """
+        Cadence (in iterations) at which to interleave the redundant-vertex removal pass that cleans up the micro-segments introduced by shortcutting.
+        """
+
+    @redundant_removal_iters.setter
+    def redundant_removal_iters(self, arg: int, /) -> None: ...
 
 class PathShortcutter:
     """Shortcuts joint paths with random sampling and checking connections."""

--- a/roboplan/bindings/src/core.cpp
+++ b/roboplan/bindings/src/core.cpp
@@ -316,9 +316,10 @@ void init_core_path_utils(nanobind::module_& m) {
 
   nanobind::class_<PathShortcuttingOptions>(m, "PathShortcuttingOptions",
                                             "Options struct for path shortcutting.")
-      .def(nanobind::init<const std::string&, double, unsigned int, int, unsigned int>(),
+      .def(nanobind::init<const std::string&, double, unsigned int, int, unsigned int,
+                          unsigned int>(),
            "group_name"_a = "", "max_step_size"_a = 0.05, "max_iters"_a = 100, "seed"_a = 0,
-           "max_convergence_iters"_a = 20)
+           "max_convergence_iters"_a = 20, "redundant_removal_iters"_a = 20)
       .def_rw("group_name", &PathShortcuttingOptions::group_name,
               "The joint group name to be used for path shortcutting.")
       .def_rw("max_step_size", &PathShortcuttingOptions::max_step_size,
@@ -330,7 +331,11 @@ void init_core_path_utils(nanobind::module_& m) {
               "Seed for the random generator. If < 0, a random seed is used.")
       .def_rw("max_convergence_iters", &PathShortcuttingOptions::max_convergence_iters,
               "Stop early once this many consecutive iterations fail to apply a shortcut. A value "
-              "of 0 disables early stopping.");
+              "of 0 disables early stopping.")
+      .def_rw(
+          "redundant_removal_iters", &PathShortcuttingOptions::redundant_removal_iters,
+          "Cadence (in iterations) at which to interleave the redundant-vertex removal pass that "
+          "cleans up the micro-segments introduced by shortcutting.");
 
   nanobind::class_<PathShortcutter>(
       m, "PathShortcutter", "Shortcuts joint paths with random sampling and checking connections.")

--- a/roboplan/bindings/src/core.cpp
+++ b/roboplan/bindings/src/core.cpp
@@ -314,12 +314,30 @@ void init_core_path_utils(nanobind::module_& m) {
         "scene"_a, "q_start"_a, "q_end"_a, "max_step_size"_a, "bisection"_a = false,
         "check_endpoints"_a = true);
 
+  nanobind::class_<PathShortcuttingOptions>(m, "PathShortcuttingOptions",
+                                            "Options struct for path shortcutting.")
+      .def(nanobind::init<const std::string&, double, unsigned int, int, unsigned int>(),
+           "group_name"_a = "", "max_step_size"_a = 0.05, "max_iters"_a = 100, "seed"_a = 0,
+           "max_convergence_iters"_a = 20)
+      .def_rw("group_name", &PathShortcuttingOptions::group_name,
+              "The joint group name to be used for path shortcutting.")
+      .def_rw("max_step_size", &PathShortcuttingOptions::max_step_size,
+              "Maximum step size used in collision checking, and the minimum separable distance "
+              "between points in a shortcut.")
+      .def_rw("max_iters", &PathShortcuttingOptions::max_iters,
+              "Maximum number of iterations of random sampling.")
+      .def_rw("seed", &PathShortcuttingOptions::seed,
+              "Seed for the random generator. If < 0, a random seed is used.")
+      .def_rw("max_convergence_iters", &PathShortcuttingOptions::max_convergence_iters,
+              "Stop early once this many consecutive iterations fail to apply a shortcut. A value "
+              "of 0 disables early stopping.");
+
   nanobind::class_<PathShortcutter>(
       m, "PathShortcutter", "Shortcuts joint paths with random sampling and checking connections.")
-      .def(nanobind::init<const std::shared_ptr<Scene>, const std::string&>(), "scene"_a,
-           "group_name"_a)
+      .def(nanobind::init<const std::shared_ptr<Scene>, const PathShortcuttingOptions&>(),
+           "scene"_a, "options"_a)
       .def("shortcut", &PathShortcutter::shortcut, "Attempts to shortcut a specified path.",
-           "path"_a, "max_step_size"_a, "max_iters"_a = 100, "seed"_a = 0)
+           "path"_a)
       .def("getPathLengths", unwrap_expected(&PathShortcutter::getPathLengths),
            "Computes configuration distances from the start to each pose in a path.", "path"_a)
       .def("getNormalizedPathScaling", unwrap_expected(&PathShortcutter::getNormalizedPathScaling),

--- a/roboplan/include/roboplan/core/path_utils.hpp
+++ b/roboplan/include/roboplan/core/path_utils.hpp
@@ -77,6 +77,27 @@ bool hasCollisionsAlongPath(const Scene& scene, const Eigen::VectorXd& q_start,
                             const Eigen::VectorXd& q_end, const double max_step_size,
                             const bool bisection = false, const bool check_endpoints = true);
 
+/// @brief Options struct for path shortcutting.
+struct PathShortcuttingOptions {
+  /// @brief The joint group name to be used for path shortcutting.
+  std::string group_name = "";
+
+  /// @brief Maximum step size used in collision checking, and the minimum separable distance
+  /// between points in a shortcut.
+  double max_step_size = 0.05;
+
+  /// @brief Maximum number of iterations of random sampling.
+  unsigned int max_iters = 100;
+
+  /// @brief Seed for the random generator. If < 0, a random seed is used.
+  int seed = 0;
+
+  /// @brief Stop early once this many consecutive iterations fail to apply a shortcut
+  /// (i.e., the path has converged), instead of always running the full `max_iters`.
+  /// A value of 0 disables early stopping.
+  unsigned int max_convergence_iters = 20;
+};
+
 /// @brief Shortcuts joint paths with random sampling and checking connections.
 /// @details This implementation is based on section 3.5.3 of:
 /// https://motion.cs.illinois.edu/RoboticSystems/MotionPlanningHigherDimensions.html
@@ -84,18 +105,18 @@ class PathShortcutter {
 public:
   /// @brief Construct a new path shortcutter instance.
   /// @param scene The scene for checking connectability between joint positions.
-  /// @param group_name The name of the group to use for path shortcutting.
-  PathShortcutter(const std::shared_ptr<Scene> scene, const std::string& group_name);
+  /// @param options A struct containing path shortcutting options.
+  PathShortcutter(const std::shared_ptr<Scene> scene, const PathShortcuttingOptions& options);
 
   /// @brief Attempts to shortcut a specified path.
+  /// @details Each iteration samples two configurations along the path and, if they connect
+  ///   collision-free, splices in the straight connection. Because successful corner-cutting
+  ///   shortcuts introduce new interpolated vertices, a deterministic redundant-vertex removal
+  ///   pass is interleaved periodically and run once more at the end to collapse vertices whose
+  ///   neighbors became directly connectable, preventing accumulation of unhelpful micro-segments.
   /// @param path The JointPath to try to shorten.
-  /// @param max_step_size Maximum step size to use in collision checking, and the minimum
-  /// separable distance between points in a shortcut.
-  /// @param max_iters Maximum number of iterations of random sampling (default 100).
-  /// @param seed Seed for the random generator, if < 0 then use a random seed (default -1).
   /// @return A shortcutted JointPath, if available.
-  JointPath shortcut(const JointPath& path, double max_step_size, unsigned int max_iters = 100,
-                     int seed = 0);
+  JointPath shortcut(const JointPath& path);
 
   /// @brief Computes configuration distances from the start to each pose in a path.
   /// @param path The JointPath to evaluate.
@@ -120,8 +141,23 @@ public:
                                             const Eigen::VectorXd& path_scalings, double value);
 
 private:
+  /// @brief Removes interior vertices whose neighbors are directly connectable.
+  /// @details Sweeps the path and deletes any interior vertex whose preceding and following
+  ///   vertices can be connected by a collision-free straight segment, repeating until a full
+  ///   sweep removes nothing. The endpoints are never removed. This collapses the redundant,
+  ///   nearly-collinear vertices left behind by corner-cutting shortcuts. Endpoint collision
+  ///   checks are skipped because every vertex is already an existing (collision-free) path node.
+  /// @param path_configs The path configurations to prune in place.
+  /// @param collision_context The collision context whose scratch backs the connection checks.
+  /// @return The number of vertices removed.
+  size_t removeRedundantVertices(std::vector<Eigen::VectorXd>& path_configs,
+                                 const CollisionContext& collision_context);
+
   /// @brief A pointer to the scene.
   std::shared_ptr<Scene> scene_;
+
+  /// @brief The path shortcutting options.
+  PathShortcuttingOptions options_;
 
   /// @brief The joint group info for the path shortcutter.
   JointGroupInfo joint_group_info_;

--- a/roboplan/include/roboplan/core/path_utils.hpp
+++ b/roboplan/include/roboplan/core/path_utils.hpp
@@ -96,6 +96,10 @@ struct PathShortcuttingOptions {
   /// (i.e., the path has converged), instead of always running the full `max_iters`.
   /// A value of 0 disables early stopping.
   unsigned int max_convergence_iters = 20;
+
+  /// @brief Cadence (in iterations) at which to interleave the redundant-vertex
+  /// removal pass that cleans up the micro-segments introduced by shortcutting.
+  unsigned int redundant_removal_iters = 20;
 };
 
 /// @brief Shortcuts joint paths with random sampling and checking connections.

--- a/roboplan/include/roboplan/core/types.hpp
+++ b/roboplan/include/roboplan/core/types.hpp
@@ -20,13 +20,13 @@ struct JointConfiguration {
   std::vector<std::string> joint_names;
 
   /// @brief The joint positions, in the same order as the names.
-  Eigen::VectorXd positions;
+  Eigen::VectorXd positions = Eigen::VectorXd();
 
   /// @brief The joint velocities, in the same order as the names.
-  Eigen::VectorXd velocities;
+  Eigen::VectorXd velocities = Eigen::VectorXd();
 
   /// @brief The joint accelerations, in the same order as the names.
-  Eigen::VectorXd accelerations;
+  Eigen::VectorXd accelerations = Eigen::VectorXd();
 };
 
 /// @brief Represents a robot Cartesian configuration.

--- a/roboplan/src/core/path_utils.cpp
+++ b/roboplan/src/core/path_utils.cpp
@@ -119,11 +119,12 @@ bool hasCollisionsAlongPath(const Scene& scene, const Eigen::VectorXd& q_start,
       max_step_size, bisection, check_endpoints);
 }
 
-PathShortcutter::PathShortcutter(const std::shared_ptr<Scene> scene, const std::string& group_name)
-    : scene_{scene} {
+PathShortcutter::PathShortcutter(const std::shared_ptr<Scene> scene,
+                                 const PathShortcuttingOptions& options)
+    : scene_{scene}, options_{options} {
 
   // Validate the joint group.
-  const auto maybe_joint_group_info = scene_->getJointGroupInfo(group_name);
+  const auto maybe_joint_group_info = scene_->getJointGroupInfo(options_.group_name);
   if (!maybe_joint_group_info) {
     throw std::runtime_error("Could not initialize path shortcutter: " +
                              maybe_joint_group_info.error());
@@ -133,8 +134,10 @@ PathShortcutter::PathShortcutter(const std::shared_ptr<Scene> scene, const std::
   q_full_ = scene_->getCurrentJointPositions();
 }
 
-JointPath PathShortcutter::shortcut(const JointPath& path, double max_step_size,
-                                    unsigned int max_iters, int seed) {
+JointPath PathShortcutter::shortcut(const JointPath& path) {
+
+  const double max_step_size = options_.max_step_size;
+  const unsigned int max_convergence_iters = options_.max_convergence_iters;
 
   // Make a copy of the provided path's configurations.
   JointPath shortened_path = path;
@@ -142,7 +145,7 @@ JointPath PathShortcutter::shortcut(const JointPath& path, double max_step_size,
 
   // We sample in the range (0, 1] to prevent modification of the starting configuration.
   std::random_device rd;
-  std::mt19937 gen(seed < 0 ? seed : rd());
+  std::mt19937 gen(options_.seed < 0 ? rd() : static_cast<unsigned int>(options_.seed));
   std::uniform_real_distribution<double> dis(std::numeric_limits<double>::epsilon(), 1.0);
 
   // Snapshot the scene geometry into a private collision context for this shortcutting pass, so all
@@ -153,18 +156,35 @@ JointPath PathShortcutter::shortcut(const JointPath& path, double max_step_size,
   auto q_start = q_full_;
   auto q_end = q_full_;
 
+  // Cadence (in iterations) at which to interleave the deterministic redundant-vertex removal pass
+  // that cleans up the micro-segments introduced by corner-cutting shortcuts.
+  constexpr unsigned int kRedundantRemovalCadence = 20;
+
+  // Count of consecutive iterations that failed to apply a shortcut. Once this reaches
+  // `max_convergence_iters` the path is considered converged and we stop early.
+  unsigned int empty_iters = 0;
+
   const auto& q_indices = joint_group_info_.q_indices;
-  for (unsigned int i = 0; i < max_iters; ++i) {
+  for (unsigned int i = 0; i < options_.max_iters; ++i) {
     if (path_configs.size() < 3) {
       // The path is at maximum shortcutted-ness
-      return shortened_path;
+      break;
+    }
+
+    // Periodically collapse redundant vertices left behind by corner-cutting shortcuts, so the
+    // working path stays compact rather than accumulating unhelpful micro-segments.
+    if (i > 0 && i % kRedundantRemovalCadence == 0) {
+      removeRedundantVertices(path_configs, collision_context);
+      if (path_configs.size() < 3) {
+        break;
+      }
     }
 
     // Recompute the path scalings every iteration. If we can't compute these we can
     // assume we are done (the path is at maximum shortness).
     const auto path_scalings_maybe = getNormalizedPathScaling(shortened_path);
     if (!path_scalings_maybe.has_value()) {
-      return shortened_path;
+      break;
     }
     const auto path_scalings = path_scalings_maybe.value();
 
@@ -181,6 +201,9 @@ JointPath PathShortcutter::shortcut(const JointPath& path, double max_step_size,
 
     // Samples are on the same segment so shortening would have no effect.
     if (idx_high == idx_low) {
+      if (max_convergence_iters > 0 && ++empty_iters >= max_convergence_iters) {
+        break;
+      }
       continue;
     }
 
@@ -209,6 +232,9 @@ JointPath PathShortcutter::shortcut(const JointPath& path, double max_step_size,
 
     // Ensure the new connection is valid. If not, try again.
     if (hasCollisionsAlongPath(*scene_, collision_context, q_low, q_high, max_step_size)) {
+      if (max_convergence_iters > 0 && ++empty_iters >= max_convergence_iters) {
+        break;
+      }
       continue;
     }
 
@@ -216,9 +242,47 @@ JointPath PathShortcutter::shortcut(const JointPath& path, double max_step_size,
     path_configs.erase(path_configs.begin() + idx_low, path_configs.begin() + idx_high);
     path_configs.insert(path_configs.begin() + idx_low, q_high(q_indices).eval());
     path_configs.insert(path_configs.begin() + idx_low, q_low(q_indices).eval());
+
+    // A shortcut was applied, so the path made progress; reset the convergence counter.
+    empty_iters = 0;
   }
 
+  // Final cleanup pass to collapse any redundant vertices remaining at convergence.
+  removeRedundantVertices(path_configs, collision_context);
+
   return shortened_path;
+}
+
+size_t PathShortcutter::removeRedundantVertices(std::vector<Eigen::VectorXd>& path_configs,
+                                                const CollisionContext& collision_context) {
+  const auto& q_indices = joint_group_info_.q_indices;
+  auto q_prev = q_full_;
+  auto q_next = q_full_;
+
+  size_t total_removed = 0;
+  bool removed_any = true;
+  while (removed_any) {
+    removed_any = false;
+    // Walk the interior vertices, deleting any whose neighbors connect directly. When a vertex is
+    // removed we do not advance, so the new adjacency (i-1, i+1) is re-evaluated immediately.
+    size_t i = 1;
+    while (i + 1 < path_configs.size()) {
+      q_prev(q_indices) = path_configs[i - 1];
+      q_next(q_indices) = path_configs[i + 1];
+      // The neighbors are existing collision-free path nodes, so skip the endpoint checks.
+      if (!hasCollisionsAlongPath(*scene_, collision_context, q_prev, q_next,
+                                  options_.max_step_size,
+                                  /* bisection */ false, /* check_endpoints */ false)) {
+        path_configs.erase(path_configs.begin() + i);
+        ++total_removed;
+        removed_any = true;
+      } else {
+        ++i;
+      }
+    }
+  }
+
+  return total_removed;
 }
 
 tl::expected<Eigen::VectorXd, std::string> PathShortcutter::getPathLengths(const JointPath& path) {

--- a/roboplan/src/core/path_utils.cpp
+++ b/roboplan/src/core/path_utils.cpp
@@ -156,10 +156,6 @@ JointPath PathShortcutter::shortcut(const JointPath& path) {
   auto q_start = q_full_;
   auto q_end = q_full_;
 
-  // Cadence (in iterations) at which to interleave the deterministic redundant-vertex removal pass
-  // that cleans up the micro-segments introduced by corner-cutting shortcuts.
-  constexpr unsigned int kRedundantRemovalCadence = 20;
-
   // Count of consecutive iterations that failed to apply a shortcut. Once this reaches
   // `max_convergence_iters` the path is considered converged and we stop early.
   unsigned int empty_iters = 0;
@@ -173,7 +169,7 @@ JointPath PathShortcutter::shortcut(const JointPath& path) {
 
     // Periodically collapse redundant vertices left behind by corner-cutting shortcuts, so the
     // working path stays compact rather than accumulating unhelpful micro-segments.
-    if (i > 0 && i % kRedundantRemovalCadence == 0) {
+    if (i > 0 && i % options_.redundant_removal_iters == 0) {
       removeRedundantVertices(path_configs, collision_context);
       if (path_configs.size() < 3) {
         break;

--- a/roboplan/test/test_path_utils.cpp
+++ b/roboplan/test/test_path_utils.cpp
@@ -79,7 +79,9 @@ TEST_F(RoboPlanPathUtilsTest, testHasCollisionsAlongPath) {
 }
 
 TEST_F(RoboPlanPathUtilsTest, testGetPathLengths) {
-  auto shortcutter = PathShortcutter(scene_, "arm");
+  PathShortcuttingOptions options;
+  options.group_name = "arm";
+  auto shortcutter = PathShortcutter(scene_, options);
 
   JointPath path = getTestPath(2);
   const auto path_lengths_maybe = shortcutter.getPathLengths(path);
@@ -91,7 +93,9 @@ TEST_F(RoboPlanPathUtilsTest, testGetPathLengths) {
 }
 
 TEST_F(RoboPlanPathUtilsTest, testGetNormalizedPathScaling) {
-  auto shortcutter = PathShortcutter(scene_, "arm");
+  PathShortcuttingOptions options;
+  options.group_name = "arm";
+  auto shortcutter = PathShortcutter(scene_, options);
 
   JointPath empty_path = getTestPath(0);
   auto empty_scalings_maybe = shortcutter.getNormalizedPathScaling(empty_path);
@@ -114,7 +118,9 @@ TEST_F(RoboPlanPathUtilsTest, testGetNormalizedPathScaling) {
 }
 
 TEST_F(RoboPlanPathUtilsTest, testGetConfigurationFromNormalizedPathScaling) {
-  auto shortcutter = PathShortcutter(scene_, "arm");
+  PathShortcuttingOptions options;
+  options.group_name = "arm";
+  auto shortcutter = PathShortcutter(scene_, options);
 
   auto test_path = getTestPath(3);
   auto path_scalings = shortcutter.getNormalizedPathScaling(test_path).value();
@@ -136,17 +142,64 @@ TEST_F(RoboPlanPathUtilsTest, testGetConfigurationFromNormalizedPathScaling) {
 }
 
 TEST_F(RoboPlanPathUtilsTest, testShortcutPath) {
-  auto shortcutter = PathShortcutter(scene_, "arm");
+  PathShortcuttingOptions options;
+  options.group_name = "arm";
+  options.max_step_size = 0.25;
+  options.seed = 11235;
+  auto shortcutter = PathShortcutter(scene_, options);
 
   // This path can actually be made shorter
   auto test_path = getTestPath(4);
-  auto shortened_path =
-      shortcutter.shortcut(test_path, 0.25, /* max_iters */ 100, /* seed */ 11235);
+  auto shortened_path = shortcutter.shortcut(test_path);
 
   // Verify the shortcut path length is strictly less than the original.
   const auto orig_path_lengths = shortcutter.getPathLengths(test_path).value();
   const auto new_path_lengths = shortcutter.getPathLengths(shortened_path).value();
   ASSERT_GT(orig_path_lengths.tail(1)(0), new_path_lengths.tail(1)(0));
+}
+
+TEST_F(RoboPlanPathUtilsTest, testShortcutRemovesRedundantVertices) {
+  PathShortcuttingOptions options;
+  options.group_name = "arm";
+  options.max_step_size = 0.25;
+  options.seed = 11235;
+  auto shortcutter = PathShortcutter(scene_, options);
+
+  // A straight, collision-free path with several collinear interior waypoints. Every interior
+  // vertex is redundant, so the redundant-vertex removal pass should collapse the path down to
+  // just its two endpoints regardless of the random sampling.
+  JointPath collinear_path;
+  collinear_path.joint_names = scene_->getJointNames();
+  for (double value : {0.0, 0.2, 0.4, 0.6, 0.8, 1.0}) {
+    Eigen::VectorXd q = Eigen::VectorXd::Zero(6);
+    q(0) = value;
+    collinear_path.positions.push_back(q);
+  }
+
+  auto shortened_path = shortcutter.shortcut(collinear_path);
+
+  ASSERT_EQ(shortened_path.positions.size(), 2u);
+  EXPECT_DOUBLE_EQ(shortened_path.positions.front()(0), 0.0);
+  EXPECT_DOUBLE_EQ(shortened_path.positions.back()(0), 1.0);
+}
+
+TEST_F(RoboPlanPathUtilsTest, testShortcutConvergenceStopsEarly) {
+  PathShortcuttingOptions options;
+  options.group_name = "arm";
+  options.max_step_size = 0.25;
+  options.max_iters = 1000;
+  options.seed = 11235;
+  options.max_convergence_iters = 5;
+  auto shortcutter = PathShortcutter(scene_, options);
+
+  // With a small convergence window, an already-straight path (no possible improvement) should
+  // return quickly without error, still preserving its endpoints.
+  auto test_path = getTestPath(4);
+  auto shortened_path = shortcutter.shortcut(test_path);
+
+  ASSERT_GE(shortened_path.positions.size(), 2u);
+  EXPECT_DOUBLE_EQ(shortened_path.positions.front()(0), test_path.positions.front()(0));
+  EXPECT_DOUBLE_EQ(shortened_path.positions.back()(0), test_path.positions.back()(0));
 }
 
 }  // namespace roboplan

--- a/roboplan_examples/cpp/example_rrt.cpp
+++ b/roboplan_examples/cpp/example_rrt.cpp
@@ -59,9 +59,12 @@ int main(int /*argc*/, char* /*argv*/[]) {
   // Optionally include path shortcutting
   const auto include_shortcutting = true;
   if (include_shortcutting) {
-    const auto max_iters = 1000;
-    auto shortcutter = PathShortcutter(scene, "arm");
-    path = shortcutter.shortcut(path, options.collision_check_step_size, max_iters);
+    PathShortcuttingOptions shortcutting_options;
+    shortcutting_options.group_name = "arm";
+    shortcutting_options.max_step_size = options.collision_check_step_size;
+    shortcutting_options.max_iters = 1000;
+    auto shortcutter = PathShortcutter(scene, shortcutting_options);
+    path = shortcutter.shortcut(path);
     std::cout << "Shortcutted path:\n" << path << std::endl;
   }
 

--- a/roboplan_examples/python/example_rrt.py
+++ b/roboplan_examples/python/example_rrt.py
@@ -11,7 +11,12 @@ import pinocchio as pin
 from pinocchio.visualize import ViserVisualizer
 
 from common import get_model_data, get_octree
-from roboplan.core import JointConfiguration, PathShortcutter, Scene
+from roboplan.core import (
+    JointConfiguration,
+    PathShortcutter,
+    PathShortcuttingOptions,
+    Scene,
+)
 from roboplan.example_models import get_package_share_dir
 from roboplan.rrt import RRTOptions, RRT, visualizeTree
 from roboplan.toppra import PathParameterizerTOPPRA, SplineFittingMode
@@ -130,7 +135,12 @@ def main(
     traj_dt = 0.01
 
     if include_shortcutting:
-        shortcutter = PathShortcutter(scene, model_data.default_joint_group)
+        shortcutting_options = PathShortcuttingOptions(
+            group_name=model_data.default_joint_group,
+            max_step_size=options.collision_check_step_size,
+            max_iters=max_shortcutting_iters,
+        )
+        shortcutter = PathShortcutter(scene, shortcutting_options)
 
     traj_queue = queue.Queue()
     cur_traj = None
@@ -175,11 +185,7 @@ def main(
         if include_shortcutting:
             print("Shortcutting path...")
             t_start = time.time()
-            shortened_path = shortcutter.shortcut(
-                path,
-                max_step_size=options.collision_check_step_size,
-                max_iters=max_shortcutting_iters,
-            )
+            shortened_path = shortcutter.shortcut(path)
             print(f"Shortcutted path in {time.time() - t_start:.3f} s")
 
         # Set up TOPP-RA to time-parameterize the path


### PR DESCRIPTION
This PR takes a similar scalpel to path shortcutting as #232 did with RRT, and does the following:

1. Adds a method to remove colinear points which largely contributes to "micro-segments" that trip up trajectory timing.
2. Adds a parameter for early stopping after a number of no-progress iterations. Somehow we didn't have this, which is wild.
3. In the wake of more options, formally extracts out a `PathShortcuttingOptions` struct.
4. Caught and fixed a bug with the random seed logic being applied backwards.