### PR TITLE
Allow overriding joint position limits in YAML config

### DIFF
--- a/roboplan/include/roboplan/core/scene_utils.hpp
+++ b/roboplan/include/roboplan/core/scene_utils.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include <pinocchio/multibody/model.hpp>
+#include <yaml-cpp/yaml.h>
 
 #include <roboplan/core/scene.hpp>
 #include <roboplan/core/types.hpp>
@@ -90,5 +91,22 @@ struct UrdfExtendedJointLimits {
 /// @return A map from joint name to its extended limits.
 std::unordered_map<std::string, UrdfExtendedJointLimits>
 parseUrdfExtendedJointLimits(const std::string& urdf);
+
+/// @brief Overrides a joint's limits in-place from a YAML configuration.
+/// @details Position, velocity, acceleration, and jerk limits may each be overridden via a
+/// `joint_limits/<joint_name>` entry, where every limit is a sequence sized to the joint's number
+/// of velocity DOFs. When no override is present, velocity limits fall back to the URDF values from
+/// the model and acceleration/jerk limits fall back to the extended URDF limits. Position limits
+/// for free-rotating DOFs (continuous joints and the orientation DOFs of planar/floating joints)
+/// are meaningless and are discarded with a warning unless given as '.inf' / '-.inf'.
+/// @param model The Pinocchio model, used for URDF-derived velocity limits.
+/// @param yaml_config The parsed YAML configuration node (may be empty/null).
+/// @param urdf_extended_limits Extended (acceleration, jerk) limits parsed from the URDF.
+/// @param joint_name The name of the joint to override.
+/// @param info The joint info to modify in-place.
+void overrideJointLimitsFromYaml(
+    const pinocchio::Model& model, const YAML::Node& yaml_config,
+    const std::unordered_map<std::string, UrdfExtendedJointLimits>& urdf_extended_limits,
+    const std::string& joint_name, JointInfo& info);
 
 }  // namespace roboplan

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -74,7 +75,6 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
 
   // Create additional robot information.
   size_t q_idx = 0;
-  size_t v_idx = 0;
   joint_names_.reserve(model_.njoints - 1);
   actuated_joint_names_.reserve((model_.njoints - 1) - model_.mimicking_joints.size());
   for (int idx = 1; idx < model_.njoints; ++idx) {  // omits "universe" joint.
@@ -119,60 +119,8 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
     }
     q_idx += info.num_position_dofs;
 
-    std::optional<YAML::Node> maybe_vel_limits;  // overrides URDF if supplied
-    std::optional<YAML::Node> maybe_acc_limits;
-    std::optional<YAML::Node> maybe_jerk_limits;
-    if (yaml_config["joint_limits"] && yaml_config["joint_limits"][joint_name]) {
-      const auto& limits_config = yaml_config["joint_limits"][joint_name];
-      if (limits_config["max_velocity"]) {
-        maybe_vel_limits = limits_config["max_velocity"];
-        if (!maybe_vel_limits->IsSequence() ||
-            (maybe_vel_limits->size() != static_cast<size_t>(joint.nv()))) {
-          throw std::runtime_error("Velocity limits for joint '" + joint_name +
-                                   "' must be a sequence of size " + std::to_string(joint.nv()) +
-                                   ".");
-        }
-      }
-      if (limits_config["max_acceleration"]) {
-        maybe_acc_limits = limits_config["max_acceleration"];
-        if (!maybe_acc_limits->IsSequence() ||
-            (maybe_acc_limits->size() != static_cast<size_t>(joint.nv()))) {
-          throw std::runtime_error("Acceleration limits for joint '" + joint_name +
-                                   "' must be a sequence of size " + std::to_string(joint.nv()) +
-                                   ".");
-        }
-      }
-      if (limits_config["max_jerk"]) {
-        maybe_jerk_limits = limits_config["max_jerk"];
-        if (!maybe_jerk_limits->IsSequence() ||
-            (maybe_jerk_limits->size() != static_cast<size_t>(joint.nv()))) {
-          throw std::runtime_error("Jerk limits for joint '" + joint_name +
-                                   "' must be a sequence of size " + std::to_string(joint.nv()) +
-                                   ".");
-        }
-      }
-    }
-    const auto urdf_extended_it = urdf_extended_limits.find(joint_name);
-    for (int idx = 0; idx < joint.nv(); ++idx) {
-      if (maybe_vel_limits) {
-        info.limits.max_velocity[idx] = maybe_vel_limits.value()[idx].as<double>();
-      } else {
-        info.limits.max_velocity[idx] = model_.velocityLimit(v_idx);
-      }
-      if (maybe_acc_limits) {
-        info.limits.max_acceleration[idx] = maybe_acc_limits.value()[idx].as<double>();
-      } else if (urdf_extended_it != urdf_extended_limits.end() &&
-                 urdf_extended_it->second.acceleration.has_value()) {
-        info.limits.max_acceleration[idx] = urdf_extended_it->second.acceleration.value();
-      }
-      if (maybe_jerk_limits) {
-        info.limits.max_jerk[idx] = maybe_jerk_limits.value()[idx].as<double>();
-      } else if (urdf_extended_it != urdf_extended_limits.end() &&
-                 urdf_extended_it->second.jerk.has_value()) {
-        info.limits.max_jerk[idx] = urdf_extended_it->second.jerk.value();
-      }
-      ++v_idx;
-    }
+    overrideJointLimitsFromYaml(model_, yaml_config, urdf_extended_limits, joint_name, info);
+
     joint_info_map_.emplace(joint_name, info);
   }
 

--- a/roboplan/src/core/scene_utils.cpp
+++ b/roboplan/src/core/scene_utils.cpp
@@ -1,8 +1,46 @@
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <optional>
 #include <stdexcept>
 
 #include <tinyxml2.h>
 
 #include <roboplan/core/scene_utils.hpp>
+
+namespace {
+
+/// @brief Returns whether the given velocity-space DOF index of a joint is free-rotating.
+/// @details These are the unbounded orientation DOFs for which position limits are meaningless:
+/// the single DOF of a continuous joint, the rotational DOF of a planar joint, and the three
+/// rotational DOFs of a floating joint. Position limit indices follow the velocity (tangent)
+/// space, so a continuous DOF collapses to a single index here.
+bool isFreeRotatingDof(roboplan::JointType type, int dof) {
+  switch (type) {
+  case roboplan::JointType::CONTINUOUS:
+    return dof == 0;
+  case roboplan::JointType::PLANAR:
+    return dof == 2;  // (x, y, theta) -> theta is free-rotating.
+  case roboplan::JointType::FLOATING:
+    return dof >= 3;  // (x, y, z, rx, ry, rz) -> the rotational DOFs are free-rotating.
+  default:
+    return false;
+  }
+}
+
+/// @brief Maps an infinite position limit to the finite sentinel used to denote "unbounded".
+/// @details JointInfo represents an unbounded position limit as
+/// std::numeric_limits<double>::lowest() / max() (see the JointInfo constructor), not as
+/// +/-infinity. A user-supplied '.inf' / '-.inf' is normalized to these sentinels so that an
+/// overridden unbounded limit is represented identically to the default unbounded limit.
+double sanitizePositionLimit(double value) {
+  if (std::isinf(value)) {
+    return value > 0.0 ? std::numeric_limits<double>::max() : std::numeric_limits<double>::lowest();
+  }
+  return value;
+}
+
+}  // namespace
 
 namespace roboplan {
 
@@ -403,6 +441,114 @@ parseUrdfExtendedJointLimits(const std::string& urdf) {
   }
 
   return result;
+}
+
+void overrideJointLimitsFromYaml(
+    const pinocchio::Model& model, const YAML::Node& yaml_config,
+    const std::unordered_map<std::string, UrdfExtendedJointLimits>& urdf_extended_limits,
+    const std::string& joint_name, JointInfo& info) {
+  const int nv = static_cast<int>(info.num_velocity_dofs);
+  // Starting index of this joint's DOFs in the model's velocity vector.
+  const auto v_start = model.idx_vs[model.getJointId(joint_name)];
+
+  // Override URDF limits if supplied in the YAML file.
+  std::optional<YAML::Node> maybe_min_pos_limits;
+  std::optional<YAML::Node> maybe_max_pos_limits;
+  std::optional<YAML::Node> maybe_vel_limits;
+  std::optional<YAML::Node> maybe_acc_limits;
+  std::optional<YAML::Node> maybe_jerk_limits;
+  if (yaml_config["joint_limits"] && yaml_config["joint_limits"][joint_name]) {
+    const auto& limits_config = yaml_config["joint_limits"][joint_name];
+    if (limits_config["min_position"]) {
+      maybe_min_pos_limits = limits_config["min_position"];
+      if (!maybe_min_pos_limits->IsSequence() ||
+          (maybe_min_pos_limits->size() != static_cast<size_t>(nv))) {
+        throw std::runtime_error("Minimum position limits for joint '" + joint_name +
+                                 "' must be a sequence of size " + std::to_string(nv) + ".");
+      }
+    }
+    if (limits_config["max_position"]) {
+      maybe_max_pos_limits = limits_config["max_position"];
+      if (!maybe_max_pos_limits->IsSequence() ||
+          (maybe_max_pos_limits->size() != static_cast<size_t>(nv))) {
+        throw std::runtime_error("Maximum position limits for joint '" + joint_name +
+                                 "' must be a sequence of size " + std::to_string(nv) + ".");
+      }
+    }
+    if (limits_config["max_velocity"]) {
+      maybe_vel_limits = limits_config["max_velocity"];
+      if (!maybe_vel_limits->IsSequence() ||
+          (maybe_vel_limits->size() != static_cast<size_t>(nv))) {
+        throw std::runtime_error("Velocity limits for joint '" + joint_name +
+                                 "' must be a sequence of size " + std::to_string(nv) + ".");
+      }
+    }
+    if (limits_config["max_acceleration"]) {
+      maybe_acc_limits = limits_config["max_acceleration"];
+      if (!maybe_acc_limits->IsSequence() ||
+          (maybe_acc_limits->size() != static_cast<size_t>(nv))) {
+        throw std::runtime_error("Acceleration limits for joint '" + joint_name +
+                                 "' must be a sequence of size " + std::to_string(nv) + ".");
+      }
+    }
+    if (limits_config["max_jerk"]) {
+      maybe_jerk_limits = limits_config["max_jerk"];
+      if (!maybe_jerk_limits->IsSequence() ||
+          (maybe_jerk_limits->size() != static_cast<size_t>(nv))) {
+        throw std::runtime_error("Jerk limits for joint '" + joint_name +
+                                 "' must be a sequence of size " + std::to_string(nv) + ".");
+      }
+    }
+  }
+  const auto urdf_extended_it = urdf_extended_limits.find(joint_name);
+  for (int idx = 0; idx < nv; ++idx) {
+    // Position limits are overridden per velocity-space DOF. For free-rotating DOFs (continuous
+    // joints and the orientation DOFs of planar/floating joints) a position limit is meaningless,
+    // so any finite override is discarded with a warning. Users should use '.inf' / '-.inf' to
+    // explicitly denote an unbounded position for these DOFs.
+    const bool is_free_dof = isFreeRotatingDof(info.type, idx);
+    bool discarded_pos_limit = false;
+    if (maybe_min_pos_limits) {
+      const double val = maybe_min_pos_limits.value()[idx].as<double>();
+      if (is_free_dof) {
+        discarded_pos_limit |= std::isfinite(val);
+      } else {
+        info.limits.min_position[idx] = sanitizePositionLimit(val);
+      }
+    }
+    if (maybe_max_pos_limits) {
+      const double val = maybe_max_pos_limits.value()[idx].as<double>();
+      if (is_free_dof) {
+        discarded_pos_limit |= std::isfinite(val);
+      } else {
+        info.limits.max_position[idx] = sanitizePositionLimit(val);
+      }
+    }
+    if (discarded_pos_limit) {
+      std::cout << "Warning: joint '" << joint_name
+                << "' has a free-rotating DOF (velocity-space index " << idx
+                << "); the specified position limit was discarded. Use '.inf' and '-.inf' in the "
+                   "YAML config to denote an unbounded position."
+                << std::endl;
+    }
+    if (maybe_vel_limits) {
+      info.limits.max_velocity[idx] = maybe_vel_limits.value()[idx].as<double>();
+    } else {
+      info.limits.max_velocity[idx] = model.velocityLimit(v_start + idx);
+    }
+    if (maybe_acc_limits) {
+      info.limits.max_acceleration[idx] = maybe_acc_limits.value()[idx].as<double>();
+    } else if (urdf_extended_it != urdf_extended_limits.end() &&
+               urdf_extended_it->second.acceleration.has_value()) {
+      info.limits.max_acceleration[idx] = urdf_extended_it->second.acceleration.value();
+    }
+    if (maybe_jerk_limits) {
+      info.limits.max_jerk[idx] = maybe_jerk_limits.value()[idx].as<double>();
+    } else if (urdf_extended_it != urdf_extended_limits.end() &&
+               urdf_extended_it->second.jerk.has_value()) {
+      info.limits.max_jerk[idx] = urdf_extended_it->second.jerk.value();
+    }
+  }
 }
 
 }  // namespace roboplan

--- a/roboplan/test/test_scene.cpp
+++ b/roboplan/test/test_scene.cpp
@@ -1,5 +1,8 @@
+#include <cmath>
+#include <fstream>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -515,6 +518,79 @@ TEST_F(RoboPlanSceneTest, TestJerkLimitsVector) {
   const auto& [group_lower_limits, group_upper_limits] = maybe_jerk_limits.value();
   EXPECT_TRUE(group_lower_limits.isApprox(expected_lower_limits, kTolerance));
   EXPECT_TRUE(group_upper_limits.isApprox(expected_upper_limits, kTolerance));
+}
+
+TEST_F(RoboPlanSceneTest, TestPositionLimitsOverrideFromYaml) {
+  // Write a temporary YAML config that overrides the position limits of one joint.
+  const auto tmp_config = std::filesystem::temp_directory_path() / "ur5_position_override.yaml";
+  {
+    std::ofstream out(tmp_config);
+    out << "joint_limits:\n"
+           "  shoulder_pan_joint:\n"
+           "    min_position: [-1.0]\n"
+           "    max_position: [1.0]\n";
+  }
+
+  Scene scene("override_scene", urdf_path_, srdf_path_, package_paths_, tmp_config);
+
+  const auto maybe_joint_info = scene.getJointInfo("shoulder_pan_joint");
+  ASSERT_TRUE(maybe_joint_info.has_value()) << maybe_joint_info.error();
+  const auto& limits = maybe_joint_info.value().limits;
+  ASSERT_EQ(limits.min_position.size(), 1u);
+  EXPECT_NEAR(limits.min_position[0], -1.0, kTolerance);
+  ASSERT_EQ(limits.max_position.size(), 1u);
+  EXPECT_NEAR(limits.max_position[0], 1.0, kTolerance);
+
+  // A non-overridden joint should keep its URDF limits.
+  const auto maybe_other = scene.getJointInfo("elbow_joint");
+  ASSERT_TRUE(maybe_other.has_value()) << maybe_other.error();
+  EXPECT_NEAR(maybe_other.value().limits.min_position[0], -M_PI, kTolerance);
+  EXPECT_NEAR(maybe_other.value().limits.max_position[0], M_PI, kTolerance);
+
+  std::filesystem::remove(tmp_config);
+}
+
+TEST_F(RoboPlanSceneTest, TestPositionLimitsOverrideInfinityFromYaml) {
+  // Confirm that yaml-cpp parses the YAML infinity spellings (.inf / -.inf) for an unbounded
+  // position limit, and that they are normalized to the same lowest()/max() sentinels that
+  // JointInfo uses for an unbounded limit by default.
+  const auto tmp_config = std::filesystem::temp_directory_path() / "ur5_position_inf.yaml";
+  {
+    std::ofstream out(tmp_config);
+    out << "joint_limits:\n"
+           "  shoulder_pan_joint:\n"
+           "    min_position: [-.inf]\n"
+           "    max_position: [.inf]\n";
+  }
+
+  Scene scene("inf_scene", urdf_path_, srdf_path_, package_paths_, tmp_config);
+
+  const auto maybe_joint_info = scene.getJointInfo("shoulder_pan_joint");
+  ASSERT_TRUE(maybe_joint_info.has_value()) << maybe_joint_info.error();
+  const auto& limits = maybe_joint_info.value().limits;
+  ASSERT_EQ(limits.min_position.size(), 1u);
+  EXPECT_TRUE(std::isfinite(limits.min_position[0]));
+  EXPECT_EQ(limits.min_position[0], std::numeric_limits<double>::lowest());
+  ASSERT_EQ(limits.max_position.size(), 1u);
+  EXPECT_TRUE(std::isfinite(limits.max_position[0]));
+  EXPECT_EQ(limits.max_position[0], std::numeric_limits<double>::max());
+
+  std::filesystem::remove(tmp_config);
+}
+
+TEST_F(RoboPlanSceneTest, TestPositionLimitsOverrideWrongSizeThrows) {
+  const auto tmp_config = std::filesystem::temp_directory_path() / "ur5_position_bad_size.yaml";
+  {
+    std::ofstream out(tmp_config);
+    out << "joint_limits:\n"
+           "  shoulder_pan_joint:\n"
+           "    max_position: [1.0, 2.0]\n";  // joint nv is 1, so this is invalid.
+  }
+
+  EXPECT_THROW(Scene("bad_size_scene", urdf_path_, srdf_path_, package_paths_, tmp_config),
+               std::runtime_error);
+
+  std::filesystem::remove(tmp_config);
 }
 
 }  // namespace roboplan


### PR DESCRIPTION
Been meaning to do this for a while... and in the process I also factored out the ballooning block of code.

For example, this is one way to pad the joint position limits from a URDF if -- hypothetically -- a simulator's contact model caused them to go slightly outside their range.