### PR TITLE
Make `ConfigurationTask` runtime tunable and add `AccelerationLimit`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -152,6 +152,8 @@ jobs:
           fi
           echo "✅ .pyi stub files look good!"
       # TODO: Decide on a method for automated benchmark performance testing.
+      # TODO: These are currently running in debug mode due to `-e ci`. We should fix this.
       - name: Run benchmarks
+        if: matrix.ubuntu_version != '24.04'  # Just to not share time with clang-tidy
         run: |
           pixi run -e ci test_benchmarks

--- a/docs/source/concepts/inverse_kinematics.rst
+++ b/docs/source/concepts/inverse_kinematics.rst
@@ -244,7 +244,7 @@ Tracks a target 6-DOF pose (position + orientation).
 ConfigurationTask
 """""""""""""""""
 
-Drives toward a target joint configuration (null-space regularization).
+Drives toward a target joint configuration, or use as null-space regularization towards a nominal configuration.
 
 **Error:** Manifold-aware difference: :math:`e = \text{difference}(q, q_{\text{target}})`
 
@@ -346,6 +346,33 @@ Restricts motion based on distance to joint limits:
    -\gamma (q - q_{\min}) \leq \Delta q \leq \gamma (q_{\max} - q)
 
 The gain :math:`\gamma \in (0, 1]` controls aggressiveness. As :math:`q \to q_{\max}`, the upper bound :math:`\to 0`.
+
+AccelerationLimit
+"""""""""""""""""
+
+Bounds how fast the joint velocity may change between successive control steps, so the executed motion does not snap/jerk (unbounded acceleration). Inspired by `pink.limits.AccelerationLimit <https://github.com/stephane-caron/pink/blob/main/pink/limits/acceleration_limit.py>`_.
+
+It combines two box bounds on :math:`\Delta q` and takes the tighter per joint:
+
+**1. Finite-difference acceleration bound**, centered on the previous step's displacement :math:`\Delta q_{\text{prev}}`:
+
+.. math::
+
+   -a_{\max} \leq \frac{\Delta q / \Delta t - \Delta q_{\text{prev}} / \Delta t}{\Delta t} \leq a_{\max}
+   \quad \Longleftrightarrow \quad
+   \Delta q_{\text{prev}} - a_{\max} \Delta t^2 \leq \Delta q \leq \Delta q_{\text{prev}} + a_{\max} \Delta t^2
+
+**2. "Braking distance" toward the joint position limits**, so the velocity can always be brought to zero before reaching a limit (Flacco et al. 2015; Del Prete 2018):
+
+.. math::
+
+   -\Delta t \sqrt{2 a_{\max} (q - q_{\min})} \leq \Delta q \leq \Delta t \sqrt{2 a_{\max} (q_{\max} - q)}
+
+The previous displacement is :math:`\Delta q_{\text{prev}} = v_{\text{prev}} \cdot \Delta t`; call ``setLastVelocity(v_prev)`` once per control step (before solving) with the velocity that was just integrated, so the bound is centered on the latest velocity. An infinite ``a_max`` entry leaves that joint unconstrained.
+
+.. note::
+
+   This limit brakes toward joint **position limits**, not toward the **task target**. Because the IK is a reactive controller, a task that commands a velocity which cannot be decelerated within the remaining distance to its target will **overshoot**. Keep the commanded motion acceleration-feasible (e.g. smaller task gains, gentler references) when this matters.
 
 Barrier Details
 ^^^^^^^^^^^^^^^
@@ -510,6 +537,7 @@ Usage Example
    import numpy as np
    from roboplan.core import Scene, CartesianConfiguration
    from roboplan.optimal_ik import (
+       AccelerationLimit,
        ConfigurationTask, ConfigurationTaskOptions,
        FrameTask, FrameTaskOptions,
        Oink, PositionLimit, VelocityLimit,
@@ -550,6 +578,9 @@ Usage Example
    constraints = [
        PositionLimit(oink, gain=1.0),
        VelocityLimit(oink, dt, v_max=np.ones(nv)),
+       # Optional: bound joint acceleration. Call accel_limit.setLastVelocity(delta_q / dt)
+       # at the top of every control step (before solveIk) so the bound tracks the last velocity.
+       AccelerationLimit(oink, dt, a_max=np.full(nv, 5.0)),
    ]
 
    # Barriers (smooth safety).

--- a/roboplan/bindings/test/test_scene.py
+++ b/roboplan/bindings/test/test_scene.py
@@ -99,7 +99,7 @@ def test_scene_properties(test_scene: Scene) -> None:
     assert np.allclose(joint_info.limits.min_position, np.array([-np.pi]))
     assert np.allclose(joint_info.limits.max_position, np.array([np.pi]))
     assert np.allclose(joint_info.limits.max_velocity, np.array([3.15]))
-    assert np.allclose(joint_info.limits.max_acceleration, np.array([2.0]))
+    assert np.allclose(joint_info.limits.max_acceleration, np.array([5.0]))
     assert np.allclose(joint_info.limits.max_jerk, np.array([10.0]))
 
     print(test_scene)  # Test printing for good measure
@@ -310,8 +310,8 @@ def test_velocity_limits_vector(test_scene: Scene) -> None:
 
 
 def test_acceleration_limits_vector(test_scene: Scene) -> None:
-    expected_lower_limits = np.array([-2.0, -2.0, -2.0, -2.0, -2.0, -2.0])
-    expected_upper_limits = np.array([2.0, 2.0, 2.0, 2.0, 2.0, 2.0])
+    expected_lower_limits = np.array([-5.0, -5.0, -5.0, -5.0, -5.0, -5.0])
+    expected_upper_limits = np.array([5.0, 5.0, 5.0, 5.0, 5.0, 5.0])
 
     # Default group (all joints)
     lower_limits, upper_limits = test_scene.getAccelerationLimitVectors()

--- a/roboplan/test/test_scene.cpp
+++ b/roboplan/test/test_scene.cpp
@@ -78,7 +78,7 @@ TEST_F(RoboPlanSceneTest, SceneProperties) {
   ASSERT_EQ(joint_info.limits.max_velocity.size(), 1u);
   EXPECT_NEAR(joint_info.limits.max_velocity[0], 3.15, kTolerance);
   ASSERT_EQ(joint_info.limits.max_acceleration.size(), 1u);
-  EXPECT_NEAR(joint_info.limits.max_acceleration[0], 2.0, kTolerance);
+  EXPECT_NEAR(joint_info.limits.max_acceleration[0], 5.0, kTolerance);
   ASSERT_EQ(joint_info.limits.max_jerk.size(), 1u);
   EXPECT_NEAR(joint_info.limits.max_jerk[0], 10.0, kTolerance);
 
@@ -542,9 +542,9 @@ TEST_F(RoboPlanSceneTest, TestVelocityLimitsVector) {
 
 TEST_F(RoboPlanSceneTest, TestAccelerationLimitsVector) {
   Eigen::VectorXd expected_lower_limits(6);
-  expected_lower_limits << -2.0, -2.0, -2.0, -2.0, -2.0, -2.0;
+  expected_lower_limits << -5.0, -5.0, -5.0, -5.0, -5.0, -5.0;
   Eigen::VectorXd expected_upper_limits(6);
-  expected_upper_limits << 2.0, 2.0, 2.0, 2.0, 2.0, 2.0;
+  expected_upper_limits << 5.0, 5.0, 5.0, 5.0, 5.0, 5.0;
 
   // Default group (all joints)
   auto maybe_acceleration_limits = scene_->getAccelerationLimitVectors();

--- a/roboplan_example_models/models/franka_robot_model/dual_fr3_config.yaml
+++ b/roboplan_example_models/models/franka_robot_model/dual_fr3_config.yaml
@@ -2,44 +2,44 @@
 
 joint_limits:
   left_fr3_joint1:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   left_fr3_joint2:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   left_fr3_joint3:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   left_fr3_joint4:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   left_fr3_joint5:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   left_fr3_joint6:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   left_fr3_joint7:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   right_fr3_joint1:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   right_fr3_joint2:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   right_fr3_joint3:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   right_fr3_joint4:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   right_fr3_joint5:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   right_fr3_joint6:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   right_fr3_joint7:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]

--- a/roboplan_example_models/models/franka_robot_model/fr3_config.yaml
+++ b/roboplan_example_models/models/franka_robot_model/fr3_config.yaml
@@ -2,23 +2,23 @@
 
 joint_limits:
   fr3_joint1:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   fr3_joint2:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   fr3_joint3:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   fr3_joint4:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   fr3_joint5:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   fr3_joint6:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   fr3_joint7:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]

--- a/roboplan_example_models/models/kinova_robot_model/kinova_robotiq_config.yaml
+++ b/roboplan_example_models/models/kinova_robot_model/kinova_robotiq_config.yaml
@@ -2,23 +2,23 @@
 
 joint_limits:
   joint_1:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   joint_2:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   joint_3:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   joint_4:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   joint_5:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   joint_6:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   joint_7:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]

--- a/roboplan_example_models/models/reachback_robot_model/reachback_config.yaml
+++ b/roboplan_example_models/models/reachback_robot_model/reachback_config.yaml
@@ -6,22 +6,22 @@ joint_limits:
     max_acceleration: [1.0, 1.0, 2.0]
     max_jerk: [2.0, 2.0, 2.0]
   arm_joint_1:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   arm_joint_2:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   arm_joint_3:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   arm_joint_4:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   arm_joint_5:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   arm_joint_6:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   arm_finger_b_joint:
     max_acceleration: [1.0]

--- a/roboplan_example_models/models/so101_robot_model/so101_config.yaml
+++ b/roboplan_example_models/models/so101_robot_model/so101_config.yaml
@@ -2,20 +2,20 @@
 
 joint_limits:
   shoulder_pan:
-    max_acceleration: [1.0]
+    max_acceleration: [5.0]
     max_jerk: [5.0]
   shoulder_lift:
-    max_acceleration: [1.0]
+    max_acceleration: [5.0]
     max_jerk: [5.0]
   elbow_flex:
-    max_acceleration: [1.0]
+    max_acceleration: [5.0]
     max_jerk: [5.0]
   wrist_flex:
-    max_acceleration: [1.0]
+    max_acceleration: [5.0]
     max_jerk: [5.0]
   wrist_roll:
-    max_acceleration: [1.0]
+    max_acceleration: [5.0]
     max_jerk: [5.0]
   gripper:
-    max_acceleration: [1.0]
+    max_acceleration: [5.0]
     max_jerk: [5.0]

--- a/roboplan_example_models/models/ur_robot_model/ur5_config.yaml
+++ b/roboplan_example_models/models/ur_robot_model/ur5_config.yaml
@@ -2,20 +2,20 @@
 
 joint_limits:
   shoulder_pan_joint:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   shoulder_lift_joint:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   elbow_joint:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   wrist_1_joint:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   wrist_2_joint:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]
   wrist_3_joint:
-    max_acceleration: [2.0]
+    max_acceleration: [5.0]
     max_jerk: [10.0]

--- a/roboplan_examples/python/example_action_chunk_tracking.py
+++ b/roboplan_examples/python/example_action_chunk_tracking.py
@@ -2,7 +2,7 @@
 Track mock learned policy action chunks.
 This example demonstrates how a learned policy action chunk can be treated as a
 short-horizon command sequence, interpolated at a smaller control timestep, and
-tracked through OInK for Cartesian actions or directly integrated for joint-space actions.
+tracked through the OInK solver to respect position and velocity limits.
 
 Supported chunk types:
   1. Cartesian/end-effector targets: sparse absolute SE(3) target poses
@@ -12,8 +12,9 @@ The main idea is:
   sparse policy-like action chunk
       -> sparse target poses/configurations
       -> dense interpolated targets at control_dt
-      -> Cartesian actions: OInK tracking with PositionLimit + VelocityLimit
-      -> joint-space actions: direct interpolated configuration trajectory
+      -> Cartesian actions: OInK FrameTasks tracking with PositionLimit + VelocityLimit
+      -> joint-space actions: OInK ConfigurationTask tracking with PositionLimit +
+         VelocityLimit
       -> visualization
 
 For multi-arm models such as "dual", Cartesian chunks create one frame task per
@@ -208,7 +209,7 @@ def compute_end_effector_positions(
 
 
 def visualize_ee_traces(
-    viz,
+    viz: ViserVisualizer,
     ee_frame_name: str,
     sparse_pos: np.ndarray,
     dense_pos: np.ndarray,
@@ -290,9 +291,9 @@ def main(
         action_scale: Scale applied to the mock target chunk to make the motion shorter or longer.
         segment_time: Duration between consecutive sparse action waypoints, in seconds.
         control_freq: Dense interpolation/tracking frequency, in Hz.
-        task_gain: Cartesian OInK task gain.
-        lm_damping: Cartesian frame-task Levenberg-Marquardt damping.
-        regularization: Tikhonov regularization passed to OInK in Cartesian mode.
+        task_gain: OInK task gain (FrameTask in Cartesian mode, ConfigurationTask in joint mode).
+        lm_damping: OInK task Levenberg-Marquardt damping.
+        regularization: Tikhonov regularization passed to OInK.
         sleep: If true, sleep between dense tracking steps while initially generating the trajectory.
         playback_speed: Playback speed multiplier for GUI animation.
         host: Viser host.
@@ -370,22 +371,29 @@ def main(
         raise ValueError(f"Model '{model}' has no configured end-effectors.")
     print(f"End-effectors: {ee_frame_names}")
 
+    # Both action spaces feed their dense targets through the same OInK solver so the
+    # executed motion respects joint position and velocity limits. The solver and these
+    # limit constraints are shared; each action space only adds its own tracking tasks.
+    oink = Oink(scene, joint_group)
+    num_variables = len(oink.v_indices)
+    print(f"Velocity variables: {num_variables}")
+
+    v_max = np.hstack(
+        [scene.getJointInfo(name).limits.max_velocity for name in joint_names]
+    )
+    constraints = [
+        PositionLimit(oink, gain=1.0),
+        VelocityLimit(oink, dt, v_max),
+    ]
+
     if action_space == "cartesian":
-        oink = Oink(scene, joint_group)
-        num_variables = len(oink.v_indices)
-
-        v_max = np.hstack(
-            [scene.getJointInfo(name).limits.max_velocity for name in joint_names]
-        )
-        constraints = [
-            PositionLimit(oink, gain=1.0),
-            VelocityLimit(oink, dt, v_max),
-        ]
-
-        print(f"Velocity variables: {num_variables}")
-
+        # Regularize toward the start configuration at priority 2 so it is projected into
+        # the nullspace of the (priority 1) FrameTasks. This uses only the redundant DOFs
+        # the FrameTasks leave free and never sacrifices end-effector tracking.
         joint_weights = np.full(num_variables, 1e-4)
-        config_options = ConfigurationTaskOptions(task_gain=1e-4, lm_damping=0.0)
+        config_options = ConfigurationTaskOptions(
+            task_gain=1.0, lm_damping=0.0, priority=2
+        )
         config_task = ConfigurationTask(
             oink,
             q_start[oink.q_indices],
@@ -458,6 +466,22 @@ def main(
             scene, dense_targets, ee_frame_names
         )
 
+        # Track the dense joint targets through OInK instead of playing them back
+        # directly. A ConfigurationTask follows the interpolated joint target each
+        # control step, while the shared PositionLimit + VelocityLimit constraints
+        # keep the executed motion within limits.
+        joint_weights = np.ones(num_variables)
+        config_options = ConfigurationTaskOptions(
+            task_gain=task_gain, lm_damping=lm_damping
+        )
+        config_task = ConfigurationTask(
+            oink,
+            q_start[oink.q_indices],
+            joint_weights,
+            config_options,
+        )
+        tasks = [config_task]
+
     print(f"Sparse targets: {len(sparse_target_positions_by_frame[ee_frame_names[0]])}")
     print(f"Dense targets:  {len(dense_target_positions_by_frame[ee_frame_names[0]])}")
 
@@ -502,11 +526,33 @@ def main(
                 time.sleep(max(0.0, dt - elapsed))
 
     else:
-        trajectory = dense_targets
-        if sleep:
-            for q in trajectory:
-                viz.display(q)
-                time.sleep(dt)
+        q_current = q_start.copy()
+        trajectory = [q_current.copy()]
+        delta_q = np.zeros(num_variables, dtype=float)
+        # Non-group indices are always zero; only group indices are written each step.
+        delta_q_full = np.zeros(model_pin.nv, dtype=float)
+
+        for idx in range(len(dense_targets)):
+            loop_start = time.time()
+
+            # Retarget the ConfigurationTask to the current dense joint waypoint.
+            config_task.setTargetConfiguration(dense_targets[idx][oink.q_indices])
+
+            try:
+                oink.solveIk(scene, tasks, constraints, delta_q, regularization)
+            except RuntimeError as exc:
+                print(f"Warning: OInK failed at dense step {idx}: {exc}")
+                delta_q[:] = 0.0
+
+            delta_q_full[oink.v_indices] = delta_q
+            q_current = scene.integrate(q_current, delta_q_full)
+            scene.setJointPositions(q_current)
+            trajectory.append(q_current.copy())
+
+            if sleep:
+                viz.display(q_current)
+                elapsed = time.time() - loop_start
+                time.sleep(max(0.0, dt - elapsed))
 
     print("Finished tracking action chunk.")
     print(f"Generated trajectory with {len(trajectory)} configurations.")
@@ -554,7 +600,7 @@ def main(
     if action_space == "cartesian":
         print("  colored traces: executed OInK-constrained end-effector trajectories")
     else:
-        print("  colored traces: executed joint-space end-effector trajectories")
+        print("  colored traces: executed OInK-constrained joint-space trajectories")
     print("  red spheres: current end-effector positions")
     print("Use the Viser GUI controls to animate, scrub, or reset the trajectory.")
 

--- a/roboplan_examples/python/example_action_chunk_tracking.py
+++ b/roboplan_examples/python/example_action_chunk_tracking.py
@@ -2,7 +2,8 @@
 Track mock learned policy action chunks.
 This example demonstrates how a learned policy action chunk can be treated as a
 short-horizon command sequence, interpolated at a smaller control timestep, and
-tracked through the OInK solver to respect position and velocity limits.
+tracked through the OInK solver to respect position and velocity limits (and an optional
+acceleration limit).
 
 Supported chunk types:
   1. Cartesian/end-effector targets: sparse absolute SE(3) target poses
@@ -13,8 +14,9 @@ The main idea is:
       -> sparse target poses/configurations
       -> dense interpolated targets at control_dt
       -> Cartesian actions: OInK FrameTasks tracking with PositionLimit + VelocityLimit
+         (+ optional AccelerationLimit)
       -> joint-space actions: OInK ConfigurationTask tracking with PositionLimit +
-         VelocityLimit
+         VelocityLimit (+ optional AccelerationLimit)
       -> visualization
 
 For multi-arm models such as "dual", Cartesian chunks create one frame task per
@@ -45,6 +47,7 @@ from roboplan.interpolation import (
     interpolateJointTrajectory,
 )
 from roboplan.optimal_ik import (
+    AccelerationLimit,
     ConfigurationTask,
     ConfigurationTaskOptions,
     FrameTask,
@@ -272,11 +275,12 @@ def main(
     action_space: ActionSpace = "cartesian",
     chunk_horizon: int = 6,
     action_scale: float = 1.0,
-    segment_time: float = 0.2,
+    segment_time: float = 0.5,
     control_freq: float = 100.0,
     task_gain: float = 1.0,
     lm_damping: float = 0.01,
     regularization: float = 1e-6,
+    limit_acceleration: bool = False,
     sleep: bool = False,
     playback_speed: float = 1.0,
     host: str = "localhost",
@@ -294,6 +298,12 @@ def main(
         task_gain: OInK task gain (FrameTask in Cartesian mode, ConfigurationTask in joint mode).
         lm_damping: OInK task Levenberg-Marquardt damping.
         regularization: Tikhonov regularization passed to OInK.
+        limit_acceleration: If true (and the model defines acceleration limits), add an OInK
+            AccelerationLimit so the executed motion respects joint acceleration limits. Off by
+            default: it bounds how fast velocity can change but does not brake toward the task
+            target, so aggressive chunks will overshoot (the arm saturates velocity and cannot
+            decelerate in time). Use a gentler chunk (smaller action_scale / larger segment_time)
+            when enabling it.
         sleep: If true, sleep between dense tracking steps while initially generating the trajectory.
         playback_speed: Playback speed multiplier for GUI animation.
         host: Viser host.
@@ -385,6 +395,19 @@ def main(
         PositionLimit(oink, gain=1.0),
         VelocityLimit(oink, dt, v_max),
     ]
+
+    # Acceleration limit (opt-in): bounds the change in velocity between control steps so the
+    # motion does not snap/jerk. It needs the previous step's velocity, so the rollout loops call
+    # accel_limit.setLastVelocity(...) each iteration. Off by default because it does not brake
+    # toward the task target, so aggressive chunks will overshoot.
+    accel_limit = None
+    if limit_acceleration:
+        a_max = np.hstack(
+            [scene.getJointInfo(name).limits.max_acceleration for name in joint_names]
+        )
+        accel_limit = AccelerationLimit(oink, dt, a_max)
+        constraints.append(accel_limit)
+        print(f"Acceleration limit enabled (a_max={a_max}).")
 
     if action_space == "cartesian":
         # Regularize toward the start configuration at priority 2 so it is projected into
@@ -509,6 +532,10 @@ def main(
             ):
                 frame_task.setTargetFrameTransform(base_T_world @ frame_tforms[idx])
 
+            # Center the acceleration bound on the previous step's velocity (delta_q / dt).
+            if accel_limit is not None:
+                accel_limit.setLastVelocity(delta_q / dt)
+
             try:
                 oink.solveIk(scene, tasks, constraints, delta_q, regularization)
             except RuntimeError as exc:
@@ -537,6 +564,10 @@ def main(
 
             # Retarget the ConfigurationTask to the current dense joint waypoint.
             config_task.setTargetConfiguration(dense_targets[idx][oink.q_indices])
+
+            # Center the acceleration bound on the previous step's velocity (delta_q / dt).
+            if accel_limit is not None:
+                accel_limit.setLastVelocity(delta_q / dt)
 
             try:
                 oink.solveIk(scene, tasks, constraints, delta_q, regularization)

--- a/roboplan_examples/python/example_oink.py
+++ b/roboplan_examples/python/example_oink.py
@@ -15,6 +15,7 @@ from roboplan.filters import SE3LowPassFilter
 from roboplan.core import Scene, CartesianConfiguration
 from roboplan.example_models import get_package_share_dir
 from roboplan.optimal_ik import (
+    AccelerationLimit,
     ConfigurationTask,
     ConfigurationTaskOptions,
     FrameTask,
@@ -36,6 +37,7 @@ def main(
     self_collision_num_pairs: int = 0,
     self_collision_d_min: float = 0.02,
     self_collision_gain: float = 1.0,
+    limit_acceleration: bool = False,
     host: str = "localhost",
     port: str = "8000",
 ):
@@ -59,6 +61,8 @@ def main(
             between every pair of self-collision bodies declared by the SRDF.
         self_collision_gain: Barrier gain (gamma) for the self-collision barrier. Higher
             values produce stronger pushback as bodies approach `self_collision_d_min`.
+        limit_acceleration: If true, adds an acceleration limit.
+            Note that this can cause overshoot with sudden marker motions, though.
         host: The host for the ViserVisualizer.
         port: The port for the ViserVisualizer.
     """
@@ -130,6 +134,13 @@ def main(
     velocity_limit = VelocityLimit(oink, dt, v_max)
 
     constraints = [position_limit, velocity_limit]
+
+    if limit_acceleration:
+        a_max = np.hstack(
+            [scene.getJointInfo(name).limits.max_acceleration for name in joint_names]
+        )
+        accel_limit = AccelerationLimit(oink, dt, a_max)
+        constraints.append(accel_limit)
 
     # Self-collision barrier: keep every collision pair in the model at least
     # `self_collision_d_min` meters apart. Skip when the model has no collision pairs.
@@ -270,6 +281,11 @@ def main(
                             frame_tasks[idx].setTargetFrameTransform(
                                 base_T_world @ raw_targets[idx]
                             )
+
+                    # Center the acceleration bound on the previous step's velocity
+                    # (delta_q / dt) so the limit couples consecutive control steps.
+                    if limit_acceleration:
+                        accel_limit.setLastVelocity(delta_q / dt)
 
                     # Solve IK for one step with constraints (and the self-collision
                     # barrier when the model has collision pairs).

--- a/roboplan_oink/CMakeLists.txt
+++ b/roboplan_oink/CMakeLists.txt
@@ -93,6 +93,7 @@ add_library(roboplan_oink SHARED
     src/tasks/configuration.cpp
     src/constraints/position_limit.cpp
     src/constraints/velocity_limit.cpp
+    src/constraints/acceleration_limit.cpp
     src/barriers/position_barrier.cpp
     src/barriers/self_collision_barrier.cpp
 )

--- a/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
+++ b/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
@@ -206,6 +206,49 @@ class VelocityLimit(Constraints):
     @v_max.setter
     def v_max(self, arg: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], /) -> None: ...
 
+class AccelerationLimit(Constraints):
+    """
+    Constraint to enforce joint acceleration limits by bounding the change in velocity
+    between successive IK steps (plus a braking-distance term toward position limits).
+    Inspired by pink.limits.AccelerationLimit.
+    """
+
+    def __init__(self, oink: Oink, dt: float, a_max: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> None:
+        """Create an acceleration limit with per-joint maximum accelerations."""
+
+    def setLastVelocity(self, v_prev: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> None:
+        """
+        Record the velocity integrated on the previous step (Delta_q_prev = v_prev * dt,
+        reusing the constraint's dt). Call once per control step before solving so the
+        acceleration bound is centered on the previous velocity.
+        """
+
+    def reset(self) -> None:
+        """
+        Reset the previous-step displacement to zero (e.g. when the robot is at rest).
+        """
+
+    @property
+    def dt(self) -> float:
+        """Time step for acceleration calculation."""
+
+    @dt.setter
+    def dt(self, arg: float, /) -> None: ...
+
+    @property
+    def a_max(self) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
+        """Maximum joint accelerations."""
+
+    @a_max.setter
+    def a_max(self, arg: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], /) -> None: ...
+
+    @property
+    def Delta_q_prev(self) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
+        """Displacement applied on the previous step."""
+
+    @Delta_q_prev.setter
+    def Delta_q_prev(self, arg: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], /) -> None: ...
+
 class Barrier:
     """Abstract base class for Control Barrier Functions."""
 

--- a/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
+++ b/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
@@ -167,6 +167,11 @@ class ConfigurationTask(Task):
     @joint_weights.setter
     def joint_weights(self, arg: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], /) -> None: ...
 
+    def setTargetConfiguration(self, target: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> None:
+        """
+        Sets the target joint configuration for this task, for runtime retargeting.
+        """
+
 class Constraints:
     """Abstract base class for IK constraints."""
 

--- a/roboplan_oink/bindings/src/optimal_ik.cpp
+++ b/roboplan_oink/bindings/src/optimal_ik.cpp
@@ -89,7 +89,9 @@ void init_optimal_ik(nanobind::module_& m) {
            "oink"_a, "target_q"_a, "joint_weights"_a, "options"_a = ConfigurationTaskOptions{})
       .def_rw("target_q", &ConfigurationTask::target_q, "Target joint configuration.")
       .def_rw("joint_weights", &ConfigurationTask::joint_weights,
-              "Weights for each joint in the configuration task.");
+              "Weights for each joint in the configuration task.")
+      .def("setTargetConfiguration", &ConfigurationTask::setTargetConfiguration, "target"_a,
+           "Sets the target joint configuration for this task, for runtime retargeting.");
 
   // Bind the abstract Constraints base class
   nanobind::class_<Constraints>(m, "Constraints", "Abstract base class for IK constraints.");

--- a/roboplan_oink/bindings/src/optimal_ik.cpp
+++ b/roboplan_oink/bindings/src/optimal_ik.cpp
@@ -9,6 +9,7 @@
 #include <roboplan/core/scene.hpp>
 #include <roboplan_oink/barriers/position_barrier.hpp>
 #include <roboplan_oink/barriers/self_collision_barrier.hpp>
+#include <roboplan_oink/constraints/acceleration_limit.hpp>
 #include <roboplan_oink/constraints/position_limit.hpp>
 #include <roboplan_oink/constraints/velocity_limit.hpp>
 #include <roboplan_oink/optimal_ik.hpp>
@@ -110,6 +111,25 @@ void init_optimal_ik(nanobind::module_& m) {
            "v_max"_a)
       .def_rw("dt", &VelocityLimit::dt, "Time step for velocity calculation.")
       .def_rw("v_max", &VelocityLimit::v_max, "Maximum joint velocities.");
+
+  // Bind AccelerationLimit constraint
+  nanobind::class_<AccelerationLimit, Constraints>(
+      m, "AccelerationLimit",
+      "Constraint to enforce joint acceleration limits by bounding the change in velocity\n"
+      "between successive IK steps (plus a braking-distance term toward position limits).\n"
+      "Inspired by pink.limits.AccelerationLimit.")
+      .def(nanobind::init<const Oink&, double, const Eigen::VectorXd&>(), "oink"_a, "dt"_a,
+           "a_max"_a, "Create an acceleration limit with per-joint maximum accelerations.")
+      .def("setLastVelocity", &AccelerationLimit::setLastVelocity, "v_prev"_a,
+           "Record the velocity integrated on the previous step (Delta_q_prev = v_prev * dt,\n"
+           "reusing the constraint's dt). Call once per control step before solving so the\n"
+           "acceleration bound is centered on the previous velocity.")
+      .def("reset", &AccelerationLimit::reset,
+           "Reset the previous-step displacement to zero (e.g. when the robot is at rest).")
+      .def_rw("dt", &AccelerationLimit::dt, "Time step for acceleration calculation.")
+      .def_rw("a_max", &AccelerationLimit::a_max, "Maximum joint accelerations.")
+      .def_rw("Delta_q_prev", &AccelerationLimit::Delta_q_prev,
+              "Displacement applied on the previous step.");
 
   // Bind the abstract Barrier base class
   nanobind::class_<Barrier>(m, "Barrier", "Abstract base class for Control Barrier Functions.")

--- a/roboplan_oink/include/roboplan_oink/constraints/acceleration_limit.hpp
+++ b/roboplan_oink/include/roboplan_oink/constraints/acceleration_limit.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <roboplan_oink/optimal_ik.hpp>
+
+namespace roboplan {
+
+/// @brief Acceleration limit constraint for inverse kinematics.
+///
+/// Bounds the change in joint velocity between successive differential-IK steps so the
+/// executed motion does not "jump" in velocity (i.e. unbounded acceleration). Inspired by
+/// pink.limits.AccelerationLimit.
+///
+/// The limit combines two inequalities, both expressed as box bounds on the configuration
+/// displacement Δq (the QP variable). With dt the control timestep, a_max the per-joint
+/// acceleration limit, and Δq_prev the displacement applied on the previous step:
+///
+///  1. Finite-difference acceleration bound:
+///         -a_max <= ((Δq/dt) - (Δq_prev/dt)) / dt <= a_max
+///     i.e.  Δq_prev - a_max*dt² <= Δq <= Δq_prev + a_max*dt²
+///
+///  2. "Braking distance" to the joint position limits, so the velocity can always be
+///     brought to zero before hitting a limit (see [Flacco2015], [DelPrete2018]):
+///         -dt*sqrt(2*a_max*(q - q_min)) <= Δq <= dt*sqrt(2*a_max*(q_max - q))
+///
+/// The tighter of the two is taken per joint, yielding box bounds l <= G*Δq <= u with
+/// G = identity (one constraint row per group velocity DOF).
+struct AccelerationLimit : public Constraints {
+  /// @brief Constructor with dimension validation.
+  /// @param oink The Oink solver this constraint will be used with (provides num_variables and
+  ///        v_indices for selecting the correct joints from the full model).
+  /// @param dt Control timestep used to convert acceleration to displacement (seconds).
+  /// @param a_max Maximum acceleration vector for each group joint (rad/s² or m/s²).
+  ///        Size must equal oink.num_variables. Entries must be non-negative; use infinity to
+  ///        leave a joint unconstrained.
+  /// @throws std::invalid_argument if dt <= 0, a_max size mismatches, or any entry is negative.
+  AccelerationLimit(const Oink& oink, double dt, const Eigen::VectorXd& a_max);
+
+  /// @brief Record the velocity applied on the previous IK step.
+  ///
+  /// The acceleration bound is centered on the previous velocity, so this must be called once
+  /// per control step (before solving) with the velocity that was just integrated. The constraint
+  /// timestep `dt` is reused to form the previous displacement: Δq_prev = v_prev * dt.
+  ///
+  /// @param v_prev Latest integrated group velocity (size oink.num_variables).
+  /// @throws std::invalid_argument if v_prev size mismatches.
+  void setLastVelocity(const Eigen::VectorXd& v_prev);
+
+  /// @brief Reset the previous-step displacement to zero (e.g. when the robot is at rest).
+  void reset();
+
+  /// @brief Get the number of constraint rows (num_variables).
+  int getNumConstraints(const Scene& scene) const override;
+
+  /// @brief Compute QP constraint matrices for acceleration limits.
+  /// @param scene The scene containing robot state and model.
+  /// @param constraint_matrix Output constraint matrix G (num_variables × num_variables).
+  /// @param lower_bounds Output lower bounds vector (num_variables).
+  /// @param upper_bounds Output upper bounds vector (num_variables).
+  /// @return void on success, error message on failure.
+  tl::expected<void, std::string>
+  computeQpConstraints(const Scene& scene, Eigen::Ref<Eigen::MatrixXd> constraint_matrix,
+                       Eigen::Ref<Eigen::VectorXd> lower_bounds,
+                       Eigen::Ref<Eigen::VectorXd> upper_bounds) const override;
+
+  double dt;                            /// Control timestep (seconds).
+  Eigen::VectorXd a_max;                /// Maximum acceleration per group joint.
+  Eigen::VectorXd Delta_q_prev;         /// Displacement applied on the previous step.
+  int num_variables;                    /// Number of group velocity DOFs.
+  Eigen::VectorXi v_indices;            /// Velocity indices of the joint group.
+  mutable Eigen::VectorXd q_max;        /// Pre-allocated maximum joint position limits.
+  mutable Eigen::VectorXd q_min;        /// Pre-allocated minimum joint position limits.
+  mutable Eigen::VectorXd delta_q_max;  /// Pre-allocated workspace for distance to upper limit.
+  mutable Eigen::VectorXd delta_q_min;  /// Pre-allocated workspace for distance to lower limit.
+};
+
+}  // namespace roboplan

--- a/roboplan_oink/include/roboplan_oink/tasks/configuration.hpp
+++ b/roboplan_oink/include/roboplan_oink/tasks/configuration.hpp
@@ -59,6 +59,16 @@ struct ConfigurationTask : public Task {
                     const Eigen::VectorXd& joint_weights,
                     const ConfigurationTaskOptions& options = {});
 
+  /// @brief Sets the target joint configuration for this task.
+  ///
+  /// Allows updating the tracked configuration at runtime (e.g., to follow a
+  /// sequence of joint targets) without reconstructing the task. Mirrors
+  /// FrameTask::setTargetFrameTransform for joint-space tracking.
+  ///
+  /// @param target The new target joint configuration (size must equal q_indices.size()).
+  /// @throws std::invalid_argument if target size doesn't match the group's q_indices size.
+  void setTargetConfiguration(const Eigen::VectorXd& target);
+
   /// @brief Computes the configuration space error.
   ///
   ///     error = pin.difference(model, q_current, q_target)

--- a/roboplan_oink/src/constraints/acceleration_limit.cpp
+++ b/roboplan_oink/src/constraints/acceleration_limit.cpp
@@ -1,0 +1,129 @@
+#include <roboplan_oink/constraints/acceleration_limit.hpp>
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+#include <OsqpEigen/OsqpEigen.h>
+#include <roboplan/core/scene_utils.hpp>
+#include <roboplan_oink/optimal_ik.hpp>
+
+namespace roboplan {
+
+AccelerationLimit::AccelerationLimit(const Oink& oink, double dt, const Eigen::VectorXd& a_max)
+    : dt(dt), a_max(a_max), Delta_q_prev(Eigen::VectorXd::Zero(oink.num_variables)),
+      num_variables(oink.num_variables), v_indices(oink.v_indices), delta_q_max(oink.num_variables),
+      delta_q_min(oink.num_variables) {
+  if (dt <= 0.0) {
+    throw std::invalid_argument("AccelerationLimit: dt must be positive, got " +
+                                std::to_string(dt));
+  }
+  if (a_max.size() != static_cast<Eigen::Index>(num_variables)) {
+    throw std::invalid_argument("AccelerationLimit: a_max size (" + std::to_string(a_max.size()) +
+                                ") does not match oink.num_variables (" +
+                                std::to_string(num_variables) + ")");
+  }
+  for (int i = 0; i < a_max.size(); ++i) {
+    if (a_max(i) < 0.0) {
+      throw std::invalid_argument("AccelerationLimit: a_max[" + std::to_string(i) +
+                                  "] must be non-negative, got " + std::to_string(a_max(i)));
+    }
+  }
+}
+
+void AccelerationLimit::setLastVelocity(const Eigen::VectorXd& v_prev) {
+  if (v_prev.size() != static_cast<Eigen::Index>(num_variables)) {
+    throw std::invalid_argument("AccelerationLimit: v_prev size (" + std::to_string(v_prev.size()) +
+                                ") does not match num_variables (" + std::to_string(num_variables) +
+                                ")");
+  }
+  Delta_q_prev = v_prev * dt;
+}
+
+void AccelerationLimit::reset() { Delta_q_prev.setZero(); }
+
+int AccelerationLimit::getNumConstraints(const Scene& /*scene*/) const { return num_variables; }
+
+tl::expected<void, std::string> AccelerationLimit::computeQpConstraints(
+    const Scene& scene, Eigen::Ref<Eigen::MatrixXd> constraint_matrix,
+    Eigen::Ref<Eigen::VectorXd> lower_bounds, Eigen::Ref<Eigen::VectorXd> upper_bounds) const {
+  // Validate pre-allocated workspace dimensions.
+  if (constraint_matrix.rows() != num_variables || constraint_matrix.cols() != num_variables) {
+    return tl::make_unexpected("AccelerationLimit: constraint_matrix size mismatch. Expected (" +
+                               std::to_string(num_variables) + " x " +
+                               std::to_string(num_variables) + "), got (" +
+                               std::to_string(constraint_matrix.rows()) + " x " +
+                               std::to_string(constraint_matrix.cols()) + ")");
+  }
+  if (lower_bounds.size() != num_variables) {
+    return tl::make_unexpected("AccelerationLimit: lower_bounds size mismatch. Expected " +
+                               std::to_string(num_variables) + ", got " +
+                               std::to_string(lower_bounds.size()));
+  }
+  if (upper_bounds.size() != num_variables) {
+    return tl::make_unexpected("AccelerationLimit: upper_bounds size mismatch. Expected " +
+                               std::to_string(num_variables) + ", got " +
+                               std::to_string(upper_bounds.size()));
+  }
+
+  const auto& q = scene.getCurrentJointPositions();
+  auto maybe_q_collapsed = collapseContinuousJointPositions(scene, "", q);
+  if (!maybe_q_collapsed) {
+    return tl::make_unexpected("AccelerationLimit: " + maybe_q_collapsed.error());
+  }
+  const auto& q_collapsed = maybe_q_collapsed.value();
+
+  // Fetch joint position limits once (used for the braking-distance term).
+  if (q_min.size() == 0u) {
+    const auto maybe_position_limits = scene.getPositionLimitVectors("", /*collapsed*/ true);
+    if (!maybe_position_limits) {
+      return tl::make_unexpected("AccelerationLimit: " + maybe_position_limits.error());
+    }
+    q_min = maybe_position_limits->first;
+    q_max = maybe_position_limits->second;
+  }
+
+  // Distances to the position limits (clamped at zero to keep the sqrt real if the current
+  // configuration sits slightly beyond a limit due to numerical error).
+  for (int i = 0; i < num_variables; ++i) {
+    const int vi = v_indices(i);
+    delta_q_max(i) = std::isfinite(q_max(vi)) ? std::max(0.0, q_max(vi) - q_collapsed(vi))
+                                              : std::numeric_limits<double>::infinity();
+    delta_q_min(i) = std::isfinite(q_min(vi)) ? std::max(0.0, q_collapsed(vi) - q_min(vi))
+                                              : std::numeric_limits<double>::infinity();
+  }
+
+  // Box constraints l <= G*dq <= u with G = identity.
+  constraint_matrix.setIdentity();
+
+  const double dt_sq = dt * dt;
+  for (int i = 0; i < num_variables; ++i) {
+    // Acceleration finite-difference bound, centered on the previous displacement.
+    const double accel_upper = a_max(i) * dt_sq + Delta_q_prev(i);
+    const double accel_lower = a_max(i) * dt_sq - Delta_q_prev(i);
+
+    // Braking-distance bound toward each position limit.
+    const double brake_upper = dt * std::sqrt(2.0 * a_max(i) * delta_q_max(i));
+    const double brake_lower = dt * std::sqrt(2.0 * a_max(i) * delta_q_min(i));
+
+    // Take the tighter of the two per side. The lower side mirrors Pink's stacked
+    // -P*dq <= h form: dq >= -min(accel_lower, brake_lower).
+    double upper = std::min(accel_upper, brake_upper);
+    double lower = -std::min(accel_lower, brake_lower);
+
+    // Clamp to OSQP's valid range.
+    if (!std::isfinite(upper) || upper > OsqpEigen::INFTY) {
+      upper = OsqpEigen::INFTY;
+    }
+    if (!std::isfinite(lower) || lower < -OsqpEigen::INFTY) {
+      lower = -OsqpEigen::INFTY;
+    }
+
+    upper_bounds(i) = upper;
+    lower_bounds(i) = lower;
+  }
+
+  return {};
+}
+
+}  // namespace roboplan

--- a/roboplan_oink/src/tasks/configuration.cpp
+++ b/roboplan_oink/src/tasks/configuration.cpp
@@ -31,6 +31,15 @@ ConfigurationTask::ConfigurationTask(const Oink& oink, const Eigen::VectorXd& ta
   initializeStorage(nv, nv);
 }
 
+void ConfigurationTask::setTargetConfiguration(const Eigen::VectorXd& target) {
+  if (target.size() != q_indices.size()) {
+    throw std::invalid_argument(
+        "ConfigurationTask::setTargetConfiguration: target size (" + std::to_string(target.size()) +
+        ") does not match group q_indices size (" + std::to_string(q_indices.size()) + ")");
+  }
+  target_q = target;
+}
+
 tl::expected<void, std::string> ConfigurationTask::computeError(const Scene& scene) {
   const auto& model = scene.getModel();
   const Eigen::VectorXd& q = scene.getCurrentJointPositions();

--- a/roboplan_oink/test/CMakeLists.txt
+++ b/roboplan_oink/test/CMakeLists.txt
@@ -61,6 +61,18 @@ target_link_libraries(
   roboplan_example_models::roboplan_example_models
 )
 
+# Build AccelerationLimit unit tests
+add_executable(test_acceleration_limit constraints/test_acceleration_limit.cpp)
+set_property(TARGET test_acceleration_limit PROPERTY CXX_STANDARD 20)
+target_link_libraries(
+  test_acceleration_limit
+  roboplan::roboplan
+  roboplan_oink
+  GTest::gmock_main
+  GTest::gtest_main
+  roboplan_example_models::roboplan_example_models
+)
+
 # Build PositionBarrier unit tests
 add_executable(test_position_barrier barriers/test_position_barrier.cpp)
 set_property(TARGET test_position_barrier PROPERTY CXX_STANDARD 20)
@@ -93,6 +105,7 @@ if ( ament_cmake_gtest_FOUND )
     ament_add_gtest_test(test_configuration_task)
     ament_add_gtest_test(test_velocity_limit)
     ament_add_gtest_test(test_position_limit)
+    ament_add_gtest_test(test_acceleration_limit)
     ament_add_gtest_test(test_position_barrier)
     ament_add_gtest_test(test_self_collision_barrier)
 else()
@@ -102,6 +115,7 @@ else()
     gtest_discover_tests(test_configuration_task)
     gtest_discover_tests(test_velocity_limit)
     gtest_discover_tests(test_position_limit)
+    gtest_discover_tests(test_acceleration_limit)
     gtest_discover_tests(test_position_barrier)
     gtest_discover_tests(test_self_collision_barrier)
 endif()

--- a/roboplan_oink/test/constraints/test_acceleration_limit.cpp
+++ b/roboplan_oink/test/constraints/test_acceleration_limit.cpp
@@ -1,0 +1,210 @@
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include <cmath>
+#include <memory>
+
+#include <OsqpEigen/OsqpEigen.h>
+#include <roboplan/core/scene.hpp>
+#include <roboplan_example_models/resources.hpp>
+#include <roboplan_oink/constraints/acceleration_limit.hpp>
+#include <roboplan_oink/optimal_ik.hpp>
+
+namespace roboplan {
+
+class AccelerationLimitTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    const auto model_prefix = example_models::get_package_models_dir();
+    urdf_path_ = model_prefix / "ur_robot_model" / "ur5_gripper.urdf";
+    srdf_path_ = model_prefix / "ur_robot_model" / "ur5_gripper.srdf";
+    package_paths_ = {example_models::get_package_share_dir()};
+    yaml_config_path_ = model_prefix / "ur_robot_model" / "ur5_config.yaml";
+
+    scene_ = std::make_shared<Scene>("test_scene", urdf_path_, srdf_path_, package_paths_,
+                                     yaml_config_path_);
+    oink_ = std::make_shared<Oink>(*scene_);
+
+    const auto& model = scene_->getModel();
+    num_variables_ = model.nv;
+
+    // Use a mid-range configuration so the braking-distance term does not bind.
+    Eigen::VectorXd q = Eigen::VectorXd::Zero(num_variables_);
+    scene_->setJointPositions(q);
+  }
+
+  std::filesystem::path urdf_path_;
+  std::filesystem::path srdf_path_;
+  std::vector<std::filesystem::path> package_paths_;
+  std::filesystem::path yaml_config_path_;
+  std::shared_ptr<Scene> scene_;
+  std::shared_ptr<Oink> oink_;
+  int num_variables_;
+};
+
+TEST_F(AccelerationLimitTest, Construction) {
+  double dt = 0.01;
+  Eigen::VectorXd a_max = Eigen::VectorXd::Ones(num_variables_) * 5.0;
+
+  AccelerationLimit constraint(*oink_, dt, a_max);
+
+  EXPECT_EQ(constraint.dt, dt);
+  EXPECT_EQ(constraint.a_max.size(), num_variables_);
+  EXPECT_TRUE(constraint.a_max.isApprox(a_max));
+  EXPECT_EQ(constraint.Delta_q_prev.size(), num_variables_);
+  EXPECT_TRUE(constraint.Delta_q_prev.isApprox(Eigen::VectorXd::Zero(num_variables_)));
+}
+
+TEST_F(AccelerationLimitTest, GetNumConstraints) {
+  AccelerationLimit constraint(*oink_, 0.01, Eigen::VectorXd::Ones(num_variables_) * 5.0);
+  EXPECT_EQ(constraint.getNumConstraints(*scene_), num_variables_);
+}
+
+TEST_F(AccelerationLimitTest, ConstraintMatrixIsIdentity) {
+  AccelerationLimit constraint(*oink_, 0.01, Eigen::VectorXd::Ones(num_variables_) * 5.0);
+
+  Eigen::MatrixXd G(num_variables_, num_variables_);
+  Eigen::VectorXd lower(num_variables_), upper(num_variables_);
+  ASSERT_TRUE(constraint.computeQpConstraints(*scene_, G, lower, upper).has_value());
+
+  EXPECT_TRUE(G.isApprox(Eigen::MatrixXd::Identity(num_variables_, num_variables_)));
+}
+
+// From rest (Delta_q_prev = 0), the bound should be the symmetric acceleration box a_max*dt²
+// (assuming the braking-distance term is looser, which holds at this mid-range configuration).
+TEST_F(AccelerationLimitTest, BoundsFromRest) {
+  double dt = 0.01;
+  Eigen::VectorXd a_max = Eigen::VectorXd::Ones(num_variables_) * 5.0;
+  AccelerationLimit constraint(*oink_, dt, a_max);
+
+  Eigen::MatrixXd G(num_variables_, num_variables_);
+  Eigen::VectorXd lower(num_variables_), upper(num_variables_);
+  ASSERT_TRUE(constraint.computeQpConstraints(*scene_, G, lower, upper).has_value());
+
+  for (int i = 0; i < num_variables_; ++i) {
+    EXPECT_NEAR(upper(i), a_max(i) * dt * dt, 1e-12);
+    EXPECT_NEAR(lower(i), -a_max(i) * dt * dt, 1e-12);
+  }
+}
+
+// The acceleration box is centered on the previous displacement: with Delta_q_prev = d,
+// the admissible displacement is [d - a_max*dt², d + a_max*dt²].
+TEST_F(AccelerationLimitTest, BoundsCenteredOnPreviousDisplacement) {
+  double dt = 0.01;
+  Eigen::VectorXd a_max = Eigen::VectorXd::Ones(num_variables_) * 5.0;
+  AccelerationLimit constraint(*oink_, dt, a_max);
+
+  // Previous velocity of 0.5 rad/s on every joint -> Delta_q_prev = 0.5 * dt.
+  Eigen::VectorXd v_prev = Eigen::VectorXd::Constant(num_variables_, 0.5);
+  constraint.setLastVelocity(v_prev);
+  EXPECT_TRUE(constraint.Delta_q_prev.isApprox(v_prev * dt));
+
+  Eigen::MatrixXd G(num_variables_, num_variables_);
+  Eigen::VectorXd lower(num_variables_), upper(num_variables_);
+  ASSERT_TRUE(constraint.computeQpConstraints(*scene_, G, lower, upper).has_value());
+
+  const double box = a_max(0) * dt * dt;
+  const double d = 0.5 * dt;
+  for (int i = 0; i < num_variables_; ++i) {
+    EXPECT_NEAR(upper(i), d + box, 1e-12);
+    EXPECT_NEAR(lower(i), -(box - d), 1e-12);  // = d - box
+  }
+}
+
+// reset() clears the previous displacement back to the rest case.
+TEST_F(AccelerationLimitTest, ResetClearsPreviousDisplacement) {
+  AccelerationLimit constraint(*oink_, 0.01, Eigen::VectorXd::Ones(num_variables_) * 5.0);
+  constraint.setLastVelocity(Eigen::VectorXd::Constant(num_variables_, 1.0));
+  ASSERT_FALSE(constraint.Delta_q_prev.isApprox(Eigen::VectorXd::Zero(num_variables_)));
+
+  constraint.reset();
+  EXPECT_TRUE(constraint.Delta_q_prev.isApprox(Eigen::VectorXd::Zero(num_variables_)));
+}
+
+// An infinite acceleration limit leaves the joint unconstrained (bounds clamped to OSQP INFTY).
+TEST_F(AccelerationLimitTest, InfiniteLimitIsUnconstrained) {
+  Eigen::VectorXd a_max =
+      Eigen::VectorXd::Constant(num_variables_, std::numeric_limits<double>::infinity());
+  AccelerationLimit constraint(*oink_, 0.01, a_max);
+
+  Eigen::MatrixXd G(num_variables_, num_variables_);
+  Eigen::VectorXd lower(num_variables_), upper(num_variables_);
+  ASSERT_TRUE(constraint.computeQpConstraints(*scene_, G, lower, upper).has_value());
+
+  for (int i = 0; i < num_variables_; ++i) {
+    EXPECT_GE(upper(i), OsqpEigen::INFTY);
+    EXPECT_LE(lower(i), -OsqpEigen::INFTY);
+  }
+}
+
+// Near the upper position limit, the braking-distance term should clamp the upper bound below
+// the pure acceleration box.
+TEST_F(AccelerationLimitTest, BrakingDistanceLimitsApproachToBound) {
+  const auto limits = scene_->getPositionLimitVectors("", /*collapsed*/ true);
+  ASSERT_TRUE(limits.has_value());
+  const Eigen::VectorXd& q_max = limits->second;
+
+  // Place the first joint just inside its upper limit (if it has a finite one).
+  int test_joint = -1;
+  Eigen::VectorXd q = Eigen::VectorXd::Zero(num_variables_);
+  for (int i = 0; i < num_variables_; ++i) {
+    if (std::isfinite(q_max(i))) {
+      q(i) = q_max(i) - 1e-4;  // 0.1 mrad from the limit
+      test_joint = i;
+      break;
+    }
+  }
+  ASSERT_GE(test_joint, 0) << "Model has no finite upper position limit to test braking.";
+  scene_->setJointPositions(q);
+
+  double dt = 0.01;
+  Eigen::VectorXd a_max = Eigen::VectorXd::Ones(num_variables_) * 5.0;
+  AccelerationLimit constraint(*oink_, dt, a_max);
+
+  Eigen::MatrixXd G(num_variables_, num_variables_);
+  Eigen::VectorXd lower(num_variables_), upper(num_variables_);
+  ASSERT_TRUE(constraint.computeQpConstraints(*scene_, G, lower, upper).has_value());
+
+  const double accel_box = a_max(test_joint) * dt * dt;
+  const double brake = dt * std::sqrt(2.0 * a_max(test_joint) * 1e-4);
+  EXPECT_LT(upper(test_joint), accel_box);
+  EXPECT_NEAR(upper(test_joint), brake, 1e-12);
+}
+
+TEST_F(AccelerationLimitTest, InvalidDtThrows) {
+  EXPECT_THROW(
+      { AccelerationLimit(*oink_, 0.0, Eigen::VectorXd::Ones(num_variables_)); },
+      std::invalid_argument);
+}
+
+TEST_F(AccelerationLimitTest, MismatchedAMaxSizeThrows) {
+  EXPECT_THROW(
+      { AccelerationLimit(*oink_, 0.01, Eigen::VectorXd::Ones(num_variables_ - 1)); },
+      std::invalid_argument);
+}
+
+TEST_F(AccelerationLimitTest, NegativeAMaxThrows) {
+  Eigen::VectorXd a_max = Eigen::VectorXd::Ones(num_variables_);
+  a_max(2) = -1.0;
+  EXPECT_THROW({ AccelerationLimit(*oink_, 0.01, a_max); }, std::invalid_argument);
+}
+
+TEST_F(AccelerationLimitTest, MismatchedVPrevSizeThrows) {
+  AccelerationLimit constraint(*oink_, 0.01, Eigen::VectorXd::Ones(num_variables_));
+  EXPECT_THROW(
+      { constraint.setLastVelocity(Eigen::VectorXd::Ones(num_variables_ - 1)); },
+      std::invalid_argument);
+}
+
+TEST_F(AccelerationLimitTest, MismatchedWorkspaceSize) {
+  AccelerationLimit constraint(*oink_, 0.01, Eigen::VectorXd::Ones(num_variables_));
+
+  Eigen::MatrixXd G(num_variables_ - 1, num_variables_);
+  Eigen::VectorXd lower(num_variables_ - 1), upper(num_variables_ - 1);
+  auto result = constraint.computeQpConstraints(*scene_, G, lower, upper);
+
+  ASSERT_FALSE(result.has_value());
+  EXPECT_TRUE(result.error().find("size mismatch") != std::string::npos);
+}
+
+}  // namespace roboplan

--- a/roboplan_oink/test/tasks/test_configuration_task.cpp
+++ b/roboplan_oink/test/tasks/test_configuration_task.cpp
@@ -123,6 +123,44 @@ TEST_F(ConfigurationTaskTest, ErrorWithOffset) {
   }
 }
 
+// Test runtime retargeting via setTargetConfiguration
+TEST_F(ConfigurationTaskTest, SetTargetConfiguration) {
+  const Eigen::VectorXd& q = scene_->getCurrentJointPositions();
+  Eigen::VectorXd target_q = q;
+  Eigen::VectorXd joint_weights = Eigen::VectorXd::Ones(nv_);
+
+  ConfigurationTask task(*oink_, target_q, joint_weights);
+
+  // At the original (current) target, the error should be zero.
+  ASSERT_TRUE(task.computeError(*scene_).has_value());
+  EXPECT_NEAR(task.error_container.norm(), 0.0, 1e-10);
+
+  // Retarget at runtime to a new configuration with an offset on the first joint.
+  Eigen::VectorXd new_target = q;
+  new_target(0) += 0.25;
+  task.setTargetConfiguration(new_target);
+
+  EXPECT_TRUE(task.target_q.isApprox(new_target));
+
+  // The error should now reflect the new target.
+  ASSERT_TRUE(task.computeError(*scene_).has_value());
+  EXPECT_NEAR(task.error_container(0), 0.25, 1e-10);
+  for (int i = 1; i < nv_; ++i) {
+    EXPECT_NEAR(task.error_container(i), 0.0, 1e-10);
+  }
+}
+
+// Test that setTargetConfiguration rejects a wrongly-sized target
+TEST_F(ConfigurationTaskTest, SetTargetConfigurationInvalidSize) {
+  Eigen::VectorXd target_q = Eigen::VectorXd::Zero(nq_);
+  Eigen::VectorXd joint_weights = Eigen::VectorXd::Ones(nv_);
+
+  ConfigurationTask task(*oink_, target_q, joint_weights);
+
+  Eigen::VectorXd bad_target = Eigen::VectorXd::Zero(nq_ + 1);
+  EXPECT_THROW({ task.setTargetConfiguration(bad_target); }, std::invalid_argument);
+}
+
 // Test Jacobian computation dimensions and identity
 TEST_F(ConfigurationTaskTest, JacobianIsIdentity) {
   Eigen::VectorXd target_q = Eigen::VectorXd::Zero(nq_);


### PR DESCRIPTION
This PR started by ensuring we could use OInK as just a joint tracker with constraints, as described in #249 (which works).

Also added a reimplementation of the acceleration limit from Pink. The `AccelerationLimit` causes some gnarly oscillations, even when I turned up the maximum values. So I've left them disabled by default.

Closes #249