### PR TITLE
Fix Pixi package tasks and ASan stub generation

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -46,12 +46,11 @@ configure = { cmd = [
   # Disable warnings about unused command line arguments
   "--no-warn-unused-cli",
   "-S",
-  "{{ package_path }}",
+  "{{ package_name }}",
   "-B",
   "build//{{ package_name }}",
 ], args = [
   { arg = "package_name" },
-  { arg = "package_path" },
   { arg = "cxx_flags", default = "" },
   { arg = "extra_flags", default = "" },
 ] }
@@ -62,13 +61,11 @@ build = { cmd = [
 ], depends-on = [
   { task = "configure", args = [
     "{{ package_name }}",
-    "{{ package_path }}",
     "{{ cxx_flags }}",
     "{{ extra_flags }}",
   ] },
 ], args = [
   { arg = "package_name" },
-  { arg = "package_path" },
   { arg = "cxx_flags", default = "" },
   { arg = "extra_flags", default = "" },
 ] }
@@ -79,13 +76,11 @@ install = { cmd = [
 ], depends-on = [
   { task = "build", args = [
     "{{ package_name }}",
-    "{{ package_path }}",
     "{{ cxx_flags }}",
     "{{ extra_flags }}",
   ] },
 ], args = [
   { arg = "package_name" },
-  { arg = "package_path" },
   { arg = "cxx_flags", default = "" },
   { arg = "extra_flags", default = "" },
 ] }
@@ -95,17 +90,17 @@ install = { cmd = [
 # dependents: they resolve it via find_package(roboplan) and import roboplan.core
 # during stub generation.
 build_all = { depends-on = [
-  { task = "install", args = ["roboplan_example_models", "roboplan_example_models"] },
-  { task = "install", args = ["roboplan", "roboplan"] },
-  { task = "install", args = ["roboplan_simple_ik", "roboplan_simple_ik"] },
-  { task = "install", args = ["roboplan_oink", "roboplan_oink"] },
-  { task = "install", args = ["roboplan_rrt", "roboplan_rrt"] },
-  { task = "install", args = ["roboplan_toppra", "roboplan_toppra"] },
-  { task = "build", args = ["roboplan_examples", "roboplan_examples"] },
+  { task = "install", args = ["roboplan_example_models"] },
+  { task = "install", args = ["roboplan"] },
+  { task = "install", args = ["roboplan_simple_ik"] },
+  { task = "install", args = ["roboplan_oink"] },
+  { task = "install", args = ["roboplan_rrt"] },
+  { task = "install", args = ["roboplan_toppra"] },
+  { task = "build", args = ["roboplan_examples"] },
 ] }
 install_all = { depends-on = [
   { task = "build_all" },
-  { task = "install", args = ["roboplan_examples", "roboplan_examples"] },
+  { task = "install", args = ["roboplan_examples"] },
 ] }
 
 build_asan = { cmd = [
@@ -116,6 +111,7 @@ build_asan = { cmd = [
   { task = "configure", args = [
     "{{ package_name }}",
     "-fsanitize=address",
+    "-DGENERATE_PYTHON_STUBS=OFF",
   ] },
 ], args = [
   { arg = "package_name" },
@@ -124,56 +120,46 @@ build_asan = { cmd = [
 build_timetrace = { depends-on = [
   { task = "configure", args = [
     "{{ package_name }}",
-    "{{ package_path }}",
     "-ftime-trace",
   ] },
   { task = "build", args = [
     "{{ package_name }}",
-    "{{ package_path }}",
   ] },
 ], args = [
   { arg = "package_name" },
-  { arg = "package_path" },
 ] }
 build_tests = { depends-on = [
   { task = "install", args = [
     "roboplan_example_models",
-    "roboplan_example_models",
     "{{ cxx_flags }}",
     "ON",
   ] },
   { task = "install", args = [
-    "roboplan",
     "roboplan",
     "{{ cxx_flags }}",
     "ON",
   ] },
   { task = "install", args = [
     "roboplan_simple_ik",
-    "roboplan_simple_ik",
     "{{ cxx_flags }}",
     "ON",
   ] },
   { task = "install", args = [
-    "roboplan_oink",
     "roboplan_oink",
     "{{ cxx_flags }}",
     "ON",
   ] },
   { task = "install", args = [
     "roboplan_rrt",
-    "roboplan_rrt",
     "{{ cxx_flags }}",
     "ON",
   ] },
   { task = "install", args = [
-    "roboplan_toppra",
     "roboplan_toppra",
     "{{ cxx_flags }}",
     "ON",
   ] },
   { task = "build", args = [
-    "roboplan_examples",
     "roboplan_examples",
     "{{ cxx_flags }}",
     "ON",


### PR DESCRIPTION
The "package_path" is added in https://github.com/open-planning/roboplan/pull/42, however, this breaks the following commands:
```
pixi run build PACKAGE_NAME
pixi run build_asan PACKAGE_NAME
pixi run build_timetrace PACKAGE_NAME
```

and probably others(?) Since toppra is no longer built from source, I think it is cleanest to remove the package_path. 

When running build_asan, I am failing to run on both macos and linux:

```
❯ pixi run build_asan roboplan_example_models
✨ Pixi task (configure in default): cmake -GNinja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DBUILD_TESTING=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXE_LINKER_FLAGS=$ROBOPLAN_LINKER_FLAG -DCMAKE_MODULE_LINKER_FLAGS=$ROBOPLAN_LINKER_FLAG -DCMAKE_SHARED_LINKER_FLAGS=$ROBOPLAN_LINKER_FLAG -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_COLOR_DIAGNOSTICS=ON -DCMAKE_CXX_FLAGS=-fsanitize=address -DCMAKE_C_FLAGS=-fsanitize=address "" --no-warn-unused-cli -S roboplan_example_models -B build//roboplan_example_models
CMake Warning:
  Ignoring empty string ("") provided on the command line.


Not searching for unused variables given on the command line.
-- The C compiler identification is Clang 19.1.7
-- The CXX compiler identification is Clang 19.1.7
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Users/maurice/manipulation/roboplan/.pixi/envs/default/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Users/maurice/manipulation/roboplan/.pixi/envs/default/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /Users/maurice/manipulation/roboplan/.pixi/envs/default/bin/python3.11 (found version "3.11.15") found components: Interpreter Development.Module Development.SABIModule
-- Configuring done (1.2s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/maurice/manipulation/roboplan/build/roboplan_example_models

✨ Pixi task (build_asan in default): cmake --build build/roboplan_example_models
[18/18] Generating /Users/maurice/manipulation/roboplan/robopl...bindings/python/roboplan/example_models/_example_models_ext.pyi
FAILED: [code=134] /Users/maurice/manipulation/roboplan/roboplan_example_models/bindings/python/roboplan/example_models/py.typed /Users/maurice/manipulation/roboplan/roboplan_example_models/bindings/python/roboplan/example_models/_example_models_ext.pyi 
cd /Users/maurice/manipulation/roboplan/build/roboplan_example_models/bindings && /Users/maurice/manipulation/roboplan/.pixi/envs/default/bin/python3.11 /Users/maurice/manipulation/roboplan/.pixi/envs/default/lib/python3.11/site-packages/nanobind/stubgen.py -q -i /Users/maurice/manipulation/roboplan/build/roboplan_example_models/bindings -M /Users/maurice/manipulation/roboplan/roboplan_example_models/bindings/python/roboplan/example_models/py.typed -m _example_models_ext -o /Users/maurice/manipulation/roboplan/roboplan_example_models/bindings/python/roboplan/example_models/_example_models_ext.pyi
==62706==ERROR: Interceptors are not working. This may be because AddressSanitizer is loaded too late (e.g. via dlopen). Please launch the executable with:
DYLD_INSERT_LIBRARIES=/Users/maurice/manipulation/roboplan/.pixi/envs/default/lib/clang/19/lib/darwin/libclang_rt.asan_osx_dynamic.dylib
"interceptors not installed" && 0
/bin/sh: line 1: 62706 Abort trap: 6           /Users/maurice/manipulation/roboplan/.pixi/envs/default/bin/python3.11 /Users/maurice/manipulation/roboplan/.pixi/envs/default/lib/python3.11/site-packages/nanobind/stubgen.py -q -i /Users/maurice/manipulation/roboplan/build/roboplan_example_models/bindings -M /Users/maurice/manipulation/roboplan/roboplan_example_models/bindings/python/roboplan/example_models/py.typed -m _example_models_ext -o /Users/maurice/manipulation/roboplan/roboplan_example_models/bindings/python/roboplan/example_models/_example_models_ext.pyi
ninja: build stopped: subcommand failed.
```

I don't think generating stubs is necessary here, so I am adding a flag `-DGENERATE_PYTHON_STUBS=OFF` to fix it


I noticed these issues when testing https://github.com/open-planning/roboplan/pull/248