### PR TITLE
Store list of link names in group info

### DIFF
--- a/roboplan/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan/bindings/python/roboplan/core/_core_ext.pyi
@@ -200,6 +200,13 @@ class JointGroupInfo:
     def joint_indices(self, arg: Sequence[int], /) -> None: ...
 
     @property
+    def link_names(self) -> list[str]:
+        """The link (body) names that make up the group."""
+
+    @link_names.setter
+    def link_names(self, arg: Sequence[str], /) -> None: ...
+
+    @property
     def q_indices(self) -> Annotated[NDArray[numpy.int32], dict(shape=(None,), order='C')]:
         """The position vector indices in the group."""
 

--- a/roboplan/bindings/src/core.cpp
+++ b/roboplan/bindings/src/core.cpp
@@ -90,6 +90,8 @@ void init_core_types(nanobind::module_& m) {
       .def_rw("joint_names", &JointGroupInfo::joint_names,
               "The joint names that make up the group.")
       .def_rw("joint_indices", &JointGroupInfo::joint_indices, "The joint indices in the group.")
+      .def_rw("link_names", &JointGroupInfo::link_names,
+              "The link (body) names that make up the group.")
       .def_rw("q_indices", &JointGroupInfo::q_indices, "The position vector indices in the group.")
       .def_rw("v_indices", &JointGroupInfo::v_indices, "The velocity vector indices in the group.")
       .def_rw("has_continuous_dofs", &JointGroupInfo::has_continuous_dofs,

--- a/roboplan/include/roboplan/core/types.hpp
+++ b/roboplan/include/roboplan/core/types.hpp
@@ -118,6 +118,13 @@ struct JointGroupInfo {
   /// @brief The joint indices in the group.
   std::vector<size_t> joint_indices;
 
+  /// @brief The link (body) names that make up the group.
+  /// @details This includes the links driven by the group's joints (e.g., the links along a
+  /// chain, or the child links of the listed joints) as well as any links manually specified
+  /// via `<link>` elements inside the group in the SRDF. Useful for selecting the subset of
+  /// visual or collision geometry that belongs to a group.
+  std::vector<std::string> link_names;
+
   /// @brief The position vector indices in the group.
   Eigen::VectorXi q_indices;
 

--- a/roboplan/src/core/scene_utils.cpp
+++ b/roboplan/src/core/scene_utils.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 #include <optional>
 #include <stdexcept>
+#include <unordered_set>
 
 #include <tinyxml2.h>
 
@@ -82,11 +83,22 @@ std::unordered_map<std::string, JointGroupInfo> createJointGroupInfo(const pinoc
 
     JointGroupInfo group_info;
 
-    // There are a few valid elements in groups: "joint", "chain", and "group".
+    // Accumulate the group's links in a set so duplicates collapse automatically.
+    std::unordered_set<std::string> link_name_set;
+
+    // There are a few valid elements in groups: "link", "joint", "chain", and "group".
     for (tinyxml2::XMLElement* child = group->FirstChildElement(); child != nullptr;
          child = child->NextSiblingElement()) {
       const std::string elem_name = child->Name();
-      if (elem_name == "joint") {
+      if (elem_name == "link") {
+        // Links can be manually specified to be part of a group in the SRDF.
+        const char* link_name;
+        if (child->QueryStringAttribute("name", &link_name) != tinyxml2::XML_SUCCESS) {
+          throw std::runtime_error("Group '" + std::string(name) +
+                                   "' specifies a link with no name in the SRDF!");
+        }
+        link_name_set.insert(link_name);
+      } else if (elem_name == "joint") {
         // The joint case is straightforward; just add the joint name.
         const char* joint_name;
         if (child->QueryStringAttribute("name", &joint_name) != tinyxml2::XML_SUCCESS) {
@@ -164,8 +176,22 @@ std::unordered_map<std::string, JointGroupInfo> createJointGroupInfo(const pinoc
         group_info.joint_indices.insert(group_info.joint_indices.end(),
                                         subgroup_info.joint_indices.begin(),
                                         subgroup_info.joint_indices.end());
+        link_name_set.insert(subgroup_info.link_names.begin(), subgroup_info.link_names.end());
       }
     }
+
+    // Now that all the group's joints are known, collect the links that they drive.
+    // A single moving joint can support multiple links: the link it actuates plus any links rigidly
+    // attached to it through fixed joints, which Pinocchio collapses into the same parent joint.
+    for (const auto jid : group_info.joint_indices) {
+      for (const auto& frame : model.frames) {
+        if (frame.type == pinocchio::BODY && frame.parentJoint == jid) {
+          link_name_set.insert(frame.name);
+        }
+      }
+    }
+
+    group_info.link_names.assign(link_name_set.begin(), link_name_set.end());
 
     // Once we've defined all joint names in the group, compute the position and velocity indices.
     std::vector<int> q_indices;
@@ -232,9 +258,19 @@ std::unordered_map<std::string, JointGroupInfo> createJointGroupInfo(const pinoc
     }
   }
 
+  // The default group contains every link (body frame) in the model.
+  std::vector<std::string> all_link_names;
+  all_link_names.reserve(model.nframes);
+  for (const auto& frame : model.frames) {
+    if (frame.type == pinocchio::BODY) {
+      all_link_names.push_back(frame.name);
+    }
+  }
+
   joint_group_map[""] = JointGroupInfo{
       .joint_names = std::vector<std::string>(model.names.begin() + 1, model.names.end()),
-      .joint_indices = all_joint_indices,
+      .joint_indices = std::move(all_joint_indices),
+      .link_names = std::move(all_link_names),
       .q_indices = Eigen::VectorXi::LinSpaced(model.nq, 0, model.nq - 1),
       .v_indices = Eigen::VectorXi::LinSpaced(model.nv, 0, model.nv - 1),
       .has_continuous_dofs = default_group_has_continuous_dofs,

--- a/roboplan/src/core/types.cpp
+++ b/roboplan/src/core/types.cpp
@@ -50,6 +50,11 @@ std::ostream& operator<<(std::ostream& os, const JointGroupInfo& info) {
     os << " " << name;
   }
   os << "\n";
+  os << "  Links:";
+  for (const auto& name : info.link_names) {
+    os << " " << name;
+  }
+  os << "\n";
   os << "  q indices: " << info.q_indices.transpose() << "\n";
   os << "  v indices: " << info.v_indices.transpose() << "\n";
   return os;

--- a/roboplan/test/test_joints.cpp
+++ b/roboplan/test/test_joints.cpp
@@ -83,6 +83,9 @@ TEST_F(RoboPlanJointTest, SceneProperties) {
   ASSERT_EQ(full_group_info.v_indices.size(), 2);
   ASSERT_EQ(full_group_info.nq_collapsed, 2);
   ASSERT_TRUE(full_group_info.has_continuous_dofs);
+  // The default group should contain every link in the model.
+  EXPECT_THAT(full_group_info.link_names,
+              ::testing::UnorderedElementsAre("base_link", "link1", "link2", "link3"));
 
   const auto arm_group_info = scene_->getJointGroupInfo("arm").value();
   const std::vector<std::string> expected_arm_joint_names = {"revolute_joint", "mimic_joint"};
@@ -91,6 +94,33 @@ TEST_F(RoboPlanJointTest, SceneProperties) {
   ASSERT_EQ(arm_group_info.v_indices.size(), 1);
   ASSERT_EQ(arm_group_info.nq_collapsed, 1);
   ASSERT_FALSE(arm_group_info.has_continuous_dofs);
+  // The arm group lists revolute_joint and mimic_joint, whose child links are link2 and link3.
+  EXPECT_THAT(arm_group_info.link_names, ::testing::UnorderedElementsAre("link2", "link3"));
+}
+
+TEST_F(RoboPlanJointTest, JointGroupLinksFromChainAndExplicitLinks) {
+  // A chain group should pull in every link along the chain, and an explicit <link> element
+  // should be added on top of the links derived from the group's joints.
+  const std::string srdf = R"(
+<robot name="robot">
+  <group name="chain_group">
+    <chain base_link="base_link" tip_link="link3"/>
+  </group>
+  <group name="explicit_group">
+    <joint name="revolute_joint"/>
+    <link name="base_link"/>
+  </group>
+</robot>
+)";
+  Scene scene("chain_scene", URDF, srdf);
+
+  // The chain from base_link to link3 covers link1, link2, and link3 (base_link is excluded).
+  const auto chain_info = scene.getJointGroupInfo("chain_group").value();
+  EXPECT_THAT(chain_info.link_names, ::testing::UnorderedElementsAre("link1", "link2", "link3"));
+
+  // The explicit group derives link2 from revolute_joint and additionally includes base_link.
+  const auto explicit_info = scene.getJointGroupInfo("explicit_group").value();
+  EXPECT_THAT(explicit_info.link_names, ::testing::UnorderedElementsAre("base_link", "link2"));
 }
 
 TEST_F(RoboPlanJointTest, CurrentJointPositionsWithMimics) {

--- a/roboplan_example_models/models/franka_robot_model/fr3.srdf
+++ b/roboplan_example_models/models/franka_robot_model/fr3.srdf
@@ -2,6 +2,9 @@
 <robot name="fr3">
   <group name="fr3_arm">
     <chain base_link="fr3_link0" tip_link="fr3_link8"/>
+    <!-- Include these links to render in ROS visualizers. -->
+    <link name="fr3_leftfinger"/>
+    <link name="fr3_rightfinger"/>
   </group>
   <group_state group="fr3_arm" name="ready">
     <joint name="fr3_joint1" value="0"/>

--- a/roboplan_rrt/bindings/test/test_rrt.py
+++ b/roboplan_rrt/bindings/test/test_rrt.py
@@ -22,6 +22,9 @@ def test_scene() -> Scene:
 
 
 def test_plan(test_scene: Scene) -> None:
+    # Ensure determinism in the test.
+    test_scene.setRngSeed(286)
+
     options = RRTOptions()
     options.group_name = "arm"
     options.max_connection_distance = 1.0
@@ -46,6 +49,10 @@ def test_plan(test_scene: Scene) -> None:
 def test_plan_rrt_star(test_scene: Scene) -> None:
     # Plan the same problem with and without RRT*. RRT* keeps rewiring and optimizing,
     # so its path must be equal or shorter than plain RRT.
+
+    # Ensure determinism in the test.
+    test_scene.setRngSeed(286)
+
     start = JointConfiguration()
     start.positions = test_scene.randomCollisionFreePositions()
     assert start.positions is not None

--- a/roboplan_rrt/test/test_rrt.cpp
+++ b/roboplan_rrt/test/test_rrt.cpp
@@ -44,7 +44,7 @@ TEST_F(RoboPlanRRTTest, Plan) {
   const auto maybe_path = rrt->plan(start, goal);
   ASSERT_TRUE(maybe_path.has_value());
 
-  // Ensure the path starts and ends at the correct poses.
+  // Ensure the path starts and ends at the correct configurations.
   const auto path = maybe_path.value();
   std::cout << path << "\n";
   ASSERT_EQ(path.positions[0], start.positions);
@@ -71,7 +71,7 @@ TEST_F(RoboPlanRRTTest, PlanRRTConnect) {
   const auto maybe_path = rrt->plan(start, goal);
   ASSERT_TRUE(maybe_path.has_value());
 
-  // Ensure the path starts and ends at the correct poses.
+  // Ensure the path starts and ends at the correct configurations.
   const auto path = maybe_path.value();
   std::cout << path << "\n";
   ASSERT_EQ(path.positions[0], start.positions);
@@ -104,7 +104,7 @@ TEST_F(RoboPlanRRTTest, PlanRRTStar) {
   ASSERT_TRUE(maybe_star_path.has_value());
   ASSERT_TRUE(maybe_rrt_path.has_value());
 
-  // Ensure the path starts and ends at the correct poses.
+  // Ensure the path starts and ends at the correct configurations.
   const auto path = maybe_star_path.value();
   std::cout << path << "\n";
   ASSERT_EQ(path.positions[0], start.positions);
@@ -147,7 +147,7 @@ TEST_F(RoboPlanRRTTest, PlanRRTStarConnect) {
   ASSERT_TRUE(maybe_star_path.has_value());
   ASSERT_TRUE(maybe_connect_path.has_value());
 
-  // Ensure the path starts and ends at the correct poses.
+  // Ensure the path starts and ends at the correct configurations.
   const auto path = maybe_star_path.value();
   std::cout << path << "\n";
   ASSERT_EQ(path.positions[0], start.positions);
@@ -186,21 +186,21 @@ TEST_F(RoboPlanRRTTest, FastReturnUsesFullBudget) {
   EXPECT_LT(plan_and_count(/*fast_return*/ true), plan_and_count(/*fast_return*/ false));
 }
 
-TEST_F(RoboPlanRRTTest, InvalidPoses) {
+TEST_F(RoboPlanRRTTest, InvalidConfigurations) {
   RRTOptions options;
   options.group_name = "arm";
   auto rrt = std::make_unique<RRT>(scene_, options);
   rrt->setRngSeed(1234);
 
-  const auto valid_pose = scene_->randomCollisionFreePositions().value();
-  const Eigen::VectorXd invalid_pose{{-6, -6, -6, -6, -6, -6}};
+  const auto q_valid = scene_->randomCollisionFreePositions().value();
+  const Eigen::VectorXd q_invalid{{-6, -6, -6, -6, -6, -6}};
 
   JointConfiguration start;
-  start.positions = valid_pose;
+  start.positions = q_valid;
   JointConfiguration goal;
-  goal.positions = invalid_pose;
+  goal.positions = q_invalid;
 
-  // Planning will fail as the goal pose is unreachable due to joint limits.
+  // Planning will fail as the goal configuration is unreachable due to joint limits.
   const auto path = rrt->plan(start, goal);
   ASSERT_FALSE(path.has_value());
 }
@@ -240,12 +240,12 @@ TEST_F(RoboPlanRRTTest, TestGrowTree) {
 
   const CollisionContext collision_context(*scene_);
 
-  // Initialize the search to the start pose.
+  // Initialize the search to the start configuration.
   KdTree tree;
   std::vector<Node> nodes;
   rrt->initializeTree(tree, nodes, q_start);
 
-  // A single EXTEND step adds exactly one node at the expected pose,
+  // A single EXTEND step adds exactly one node at the expected configuration,
   // which is exactly options.max_connection_distance away.
   ASSERT_TRUE(rrt->growTree(tree, nodes, q_end, collision_context, /*greedy*/ false));
   ASSERT_EQ(nodes.size(), 2);
@@ -282,7 +282,7 @@ TEST_F(RoboPlanRRTTest, TestJoinTrees) {
 
   const CollisionContext collision_context(*scene_);
 
-  // Initialize the search to the start pose.
+  // Initialize the search to the start configuration.
   KdTree start_tree, goal_tree;
   std::vector<Node> start_nodes, goal_nodes;
   rrt->initializeTree(start_tree, start_nodes, q_start);


### PR DESCRIPTION
This PR allows storing link information in the scene's per-group `JointGroupInfo`.

This is useful for visualization applications where we only want to render markers for a specific subset of a full robot model. See https://github.com/open-planning/roboplan-ros/issues/48 for more info, and https://github.com/open-planning/roboplan-ros/pull/50 for the `roboplan-ros` PR.

(EDIT: some more flakes in RRT testing squashed in the process, some of which were already there but RRT* made them far more likely due to incorporating 500-node limits)