### PR TITLE
Add broadphase culling to collision checking and self-collision barrier

### DIFF
--- a/roboplan/include/roboplan/core/collision_context.hpp
+++ b/roboplan/include/roboplan/core/collision_context.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <pinocchio/collision/broadphase-manager.hpp>
@@ -46,6 +47,39 @@ public:
   /// scratch, so it is safe to call concurrently with queries on other contexts or the Scene.
   bool hasCollisions(const Eigen::VectorXd& q) const;
 
+  /// @brief Refreshes geometry placements at `q` and computes the distance for every active
+  /// collision pair into this context's own GeometryData.
+  /// @details Runs on this context's private scratch, so it is safe to call concurrently with
+  /// queries on other contexts or the Scene. Results are available via getCollisionData().
+  ///
+  /// @param broadphase_margin Broadphase cull distance. Pairs whose world axis-aligned bounding
+  /// boxes are farther apart than this are skipped: their (cheap) AABB-gap lower bound is stored as
+  /// the distance and their witness points are collapsed to the origin, so any Jacobian built from
+  /// them is a zero row. Such pairs are, by construction, farther than the margin and cannot be the
+  /// binding constraint of a barrier whose minimum distance is well inside it. The exact
+  /// narrow-phase distance and witness points are still computed for every pair within the margin.
+  /// Pass std::nullopt (the default) to disable culling and compute the exact distance for every
+  /// pair (equivalent to pinocchio::computeDistances).
+  void computeDistances(const Eigen::VectorXd& q,
+                        std::optional<double> broadphase_margin = std::nullopt) const;
+
+  /// @brief Computes the joint Jacobians at `q` into this context's own Data, so consumers that
+  /// build task/barrier Jacobians (e.g. self-collision) do not have to touch the Scene's scratch.
+  /// Results are available via getData().
+  void computeJointJacobians(const Eigen::VectorXd& q) const;
+
+  /// @brief The immutable model shared with the originating Scene.
+  const pinocchio::Model& getModel() const { return model_; }
+
+  /// @brief This context's private Data scratch (forward kinematics, joint Jacobians).
+  pinocchio::Data& getData() const { return data_; }
+
+  /// @brief The immutable collision geometry model shared with the originating Scene.
+  const pinocchio::GeometryModel& getCollisionModel() const { return collision_model_; }
+
+  /// @brief This context's private GeometryData scratch (geometry placements, distance results).
+  pinocchio::GeometryData& getCollisionData() const { return geom_data_; }
+
 private:
   using BroadPhaseManager = pinocchio::BroadPhaseManagerTpl<coal::DynamicAABBTreeCollisionManager>;
 
@@ -55,6 +89,10 @@ private:
   mutable pinocchio::GeometryData geom_data_;        ///< Owned scratch for geometry placements.
   mutable std::optional<BroadPhaseManager>
       manager_;  ///< Owned; bound to this context's geom_data_.
+
+  /// @brief One coal collision object per geometry object (parallel to collision_model_'s
+  /// geometryObjects), reused by computeDistances() to refresh world AABBs for broadphase culling.
+  mutable std::vector<coal::CollisionObject> aabb_objects_;
 };
 
 }  // namespace roboplan

--- a/roboplan/src/core/collision_context.cpp
+++ b/roboplan/src/core/collision_context.cpp
@@ -1,8 +1,12 @@
 #include <roboplan/core/collision_context.hpp>
 
+#include <limits>
+
 #include <pinocchio/algorithm/geometry.hpp>
+#include <pinocchio/algorithm/jacobian.hpp>
 #include <pinocchio/algorithm/joint-configuration.hpp>
 #include <pinocchio/collision/broadphase.hpp>
+#include <pinocchio/collision/distance.hpp>
 
 #include <roboplan/core/scene.hpp>
 
@@ -18,10 +22,64 @@ CollisionContext::CollisionContext(const Scene& scene)
   pinocchio::updateGeometryPlacements(model_, data_, collision_model_, geom_data_,
                                       pinocchio::neutral(model_));
   manager_->update(/*compute_local_aabb=*/true);
+
+  // One coal collision object per geometry, used by computeDistances() to refresh world AABBs for
+  // broadphase culling. The constructor computes each geometry's local AABB once. reserve() keeps
+  // the objects address-stable during the fill (only relevant for re-entrancy, not correctness).
+  aabb_objects_.reserve(collision_model_.geometryObjects.size());
+  for (const auto& geom_obj : collision_model_.geometryObjects) {
+    aabb_objects_.emplace_back(geom_obj.geometry, /*compute_local_aabb=*/true);
+  }
 }
 
 bool CollisionContext::hasCollisions(const Eigen::VectorXd& q) const {
   return pinocchio::computeCollisions(model_, data_, *manager_, q, /*stopAtFirstCollision=*/true);
+}
+
+void CollisionContext::computeDistances(const Eigen::VectorXd& q,
+                                        std::optional<double> broadphase_margin) const {
+  // Without a margin there is nothing to cull: fall back to the exact all-pairs sweep.
+  if (!broadphase_margin.has_value()) {
+    pinocchio::computeDistances(model_, data_, collision_model_, geom_data_, q);
+    return;
+  }
+  const double margin = *broadphase_margin;
+
+  // Refresh joint + geometry placements on our own scratch, then update each geometry's world AABB.
+  pinocchio::updateGeometryPlacements(model_, data_, collision_model_, geom_data_, q);
+  for (std::size_t i = 0; i < aabb_objects_.size(); ++i) {
+    const auto& oMg = geom_data_.oMg[i];
+    aabb_objects_[i].setTransform(oMg.rotation(), oMg.translation());
+    aabb_objects_[i].computeAABB();
+  }
+
+  // For each active pair, use the AABB gap (a lower bound on the true distance) to decide whether
+  // the exact narrow-phase distance is worth computing.
+  const auto& pairs = collision_model_.collisionPairs;
+  for (std::size_t k = 0; k < pairs.size(); ++k) {
+    auto& result = geom_data_.distanceResults[k];
+    if (!geom_data_.activeCollisionPairs[k]) {
+      result.min_distance = std::numeric_limits<double>::infinity();
+      continue;
+    }
+
+    const auto& pair = pairs[k];
+    const double aabb_gap =
+        aabb_objects_[pair.first].getAABB().distance(aabb_objects_[pair.second].getAABB());
+    if (aabb_gap > margin) {
+      // Provably farther than the margin: skip GJK/EPA. Record the (looser) lower bound as the
+      // distance and collapse the witness points so any Jacobian built from them is a zero row.
+      result.min_distance = aabb_gap;
+      result.nearest_points[0].setZero();
+      result.nearest_points[1].setZero();
+    } else {
+      pinocchio::computeDistance(collision_model_, geom_data_, k);
+    }
+  }
+}
+
+void CollisionContext::computeJointJacobians(const Eigen::VectorXd& q) const {
+  pinocchio::computeJointJacobians(model_, data_, q);
 }
 
 }  // namespace roboplan

--- a/roboplan_examples/python/example_oink.py
+++ b/roboplan_examples/python/example_oink.py
@@ -22,6 +22,7 @@ from roboplan.optimal_ik import (
     Oink,
     PositionLimit,
     SelfCollisionBarrier,
+    SelfCollisionBarrierOptions,
     VelocityLimit,
 )
 
@@ -35,6 +36,7 @@ def main(
     reference_filter_tau: float = 0.1,
     self_collision_num_pairs: int = 0,
     self_collision_d_min: float = 0.02,
+    self_collision_d_max: float = 0.25,
     self_collision_gain: float = 1.0,
     host: str = "localhost",
     port: str = "8000",
@@ -57,6 +59,9 @@ def main(
             that use high-resolution meshes for collision geometries.
         self_collision_d_min: Minimum distance (meters) the IK solver will try to keep
             between every pair of self-collision bodies declared by the SRDF.
+        self_collision_d_max: Maximum distance (meters) the IK solver will use for a
+            broadphase culling step. This can significantly speed up collision checking
+            by pruning out far-away meshes, especially if they have complex geometries.
         self_collision_gain: Barrier gain (gamma) for the self-collision barrier. Higher
             values produce stronger pushback as bodies approach `self_collision_d_min`.
         host: The host for the ViserVisualizer.
@@ -142,9 +147,12 @@ def main(
             scene,
             n_collision_pairs=self_collision_num_pairs,
             dt=dt,
-            gain=self_collision_gain,
-            safe_displacement_gain=0.01,
-            d_min=self_collision_d_min,
+            options=SelfCollisionBarrierOptions(
+                gain=self_collision_gain,
+                safe_displacement_gain=0.01,
+                d_min=self_collision_d_min,
+                d_max=self_collision_d_max,
+            ),
         )
         barriers = [self_collision_barrier]
     else:

--- a/roboplan_examples/python/example_oink.py
+++ b/roboplan_examples/python/example_oink.py
@@ -145,9 +145,9 @@ def main(
         self_collision_barrier = SelfCollisionBarrier(
             oink,
             scene,
-            n_collision_pairs=self_collision_num_pairs,
             dt=dt,
             options=SelfCollisionBarrierOptions(
+                n_collision_pairs=self_collision_num_pairs,
                 gain=self_collision_gain,
                 safe_displacement_gain=0.01,
                 d_min=self_collision_d_min,

--- a/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
+++ b/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
@@ -280,8 +280,15 @@ class PositionBarrier(Barrier):
 class SelfCollisionBarrierOptions:
     """Parameters for SelfCollisionBarrier."""
 
-    def __init__(self, gain: float = 1.0, safe_displacement_gain: float = 1.0, d_min: float = 0.02, safety_margin: float = 0.0, d_max: float | None = 0.5) -> None:
+    def __init__(self, n_collision_pairs: int = 1, gain: float = 1.0, safe_displacement_gain: float = 1.0, d_min: float = 0.02, safety_margin: float = 0.0, d_max: float | None = 0.5) -> None:
         """Constructor with custom parameters."""
+
+    @property
+    def n_collision_pairs(self) -> int:
+        """Maximum number of closest collision pairs to constrain."""
+
+    @n_collision_pairs.setter
+    def n_collision_pairs(self, arg: int, /) -> None: ...
 
     @property
     def gain(self) -> float:
@@ -328,12 +335,14 @@ class SelfCollisionBarrier(Barrier):
     least `d_min` apart. Inspired by pink.barriers.SelfCollisionBarrier.
     """
 
-    def __init__(self, oink: Oink, scene: roboplan.core._core_ext.Scene, n_collision_pairs: int, dt: float, options: SelfCollisionBarrierOptions = ...) -> None:
+    def __init__(self, oink: Oink, scene: roboplan.core._core_ext.Scene, dt: float, options: SelfCollisionBarrierOptions = ...) -> None:
         """Create a self-collision barrier."""
 
     @property
     def n_collision_pairs(self) -> int:
-        """Number of closest collision pairs to constrain."""
+        """
+        Number of closest collision pairs constrained (clipped to the scene's pair count).
+        """
 
     @property
     def d_min(self) -> float:

--- a/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
+++ b/roboplan_oink/bindings/python/roboplan/optimal_ik/_optimal_ik_ext.pyi
@@ -277,6 +277,49 @@ class PositionBarrier(Barrier):
     def p_max(self) -> Annotated[NDArray[numpy.float64], dict(shape=(3), order='C')]:
         """Maximum position bounds."""
 
+class SelfCollisionBarrierOptions:
+    """Parameters for SelfCollisionBarrier."""
+
+    def __init__(self, gain: float = 1.0, safe_displacement_gain: float = 1.0, d_min: float = 0.02, safety_margin: float = 0.0, d_max: float | None = 0.5) -> None:
+        """Constructor with custom parameters."""
+
+    @property
+    def gain(self) -> float:
+        """Barrier gain (gamma)."""
+
+    @gain.setter
+    def gain(self, arg: float, /) -> None: ...
+
+    @property
+    def safe_displacement_gain(self) -> float:
+        """Gain for safe displacement regularization."""
+
+    @safe_displacement_gain.setter
+    def safe_displacement_gain(self, arg: float, /) -> None: ...
+
+    @property
+    def d_min(self) -> float:
+        """Minimum allowed distance between any pair of bodies."""
+
+    @d_min.setter
+    def d_min(self, arg: float, /) -> None: ...
+
+    @property
+    def safety_margin(self) -> float:
+        """Conservative margin for hard constraint guarantee."""
+
+    @safety_margin.setter
+    def safety_margin(self, arg: float, /) -> None: ...
+
+    @property
+    def d_max(self) -> float | None:
+        """
+        Maximum distance (meters) at which a collision pair is tracked; pairs whose bounding boxes are farther apart than this skip exact narrow-phase distance. Visibility / performance bound, not a separation limit.
+        """
+
+    @d_max.setter
+    def d_max(self, arg: float | None) -> None: ...
+
 class SelfCollisionBarrier(Barrier):
     """
     Self-collision avoidance barrier based on hpp-fcl / coal collision pair distances.
@@ -285,7 +328,7 @@ class SelfCollisionBarrier(Barrier):
     least `d_min` apart. Inspired by pink.barriers.SelfCollisionBarrier.
     """
 
-    def __init__(self, oink: Oink, scene: roboplan.core._core_ext.Scene, n_collision_pairs: int, dt: float, gain: float = 1.0, safe_displacement_gain: float = 1.0, d_min: float = 0.02, safety_margin: float = 0.0) -> None:
+    def __init__(self, oink: Oink, scene: roboplan.core._core_ext.Scene, n_collision_pairs: int, dt: float, options: SelfCollisionBarrierOptions = ...) -> None:
         """Create a self-collision barrier."""
 
     @property
@@ -295,6 +338,12 @@ class SelfCollisionBarrier(Barrier):
     @property
     def d_min(self) -> float:
         """Minimum allowed distance between any pair of bodies."""
+
+    @property
+    def d_max(self) -> float | None:
+        """
+        Maximum distance (meters) at which a collision pair is tracked; pairs whose bounding boxes are farther apart than this skip exact narrow-phase distance.
+        """
 
 class Oink:
     """Optimal Inverse Kinematics solver."""

--- a/roboplan_oink/bindings/src/optimal_ik.cpp
+++ b/roboplan_oink/bindings/src/optimal_ik.cpp
@@ -151,9 +151,12 @@ void init_optimal_ik(nanobind::module_& m) {
   // Bind SelfCollisionBarrierOptions configuration struct
   nanobind::class_<SelfCollisionBarrierOptions>(m, "SelfCollisionBarrierOptions",
                                                 "Parameters for SelfCollisionBarrier.")
-      .def(nanobind::init<double, double, double, double, std::optional<double>>(), "gain"_a = 1.0,
-           "safe_displacement_gain"_a = 1.0, "d_min"_a = 0.02, "safety_margin"_a = 0.0,
-           "d_max"_a = std::optional<double>(0.5), "Constructor with custom parameters.")
+      .def(nanobind::init<int, double, double, double, double, std::optional<double>>(),
+           "n_collision_pairs"_a = 1, "gain"_a = 1.0, "safe_displacement_gain"_a = 1.0,
+           "d_min"_a = 0.02, "safety_margin"_a = 0.0, "d_max"_a = std::optional<double>(0.5),
+           "Constructor with custom parameters.")
+      .def_rw("n_collision_pairs", &SelfCollisionBarrierOptions::n_collision_pairs,
+              "Maximum number of closest collision pairs to constrain.")
       .def_rw("gain", &SelfCollisionBarrierOptions::gain, "Barrier gain (gamma).")
       .def_rw("safe_displacement_gain", &SelfCollisionBarrierOptions::safe_displacement_gain,
               "Gain for safe displacement regularization.")
@@ -173,12 +176,11 @@ void init_optimal_ik(nanobind::module_& m) {
       "Self-collision avoidance barrier based on hpp-fcl / coal collision pair distances.\n\n"
       "Constrains the closest `n_collision_pairs` collision pairs in the scene to remain at\n"
       "least `d_min` apart. Inspired by pink.barriers.SelfCollisionBarrier.")
-      .def(nanobind::init<const Oink&, const Scene&, int, double,
-                          const SelfCollisionBarrierOptions&>(),
-           "oink"_a, "scene"_a, "n_collision_pairs"_a, "dt"_a,
-           "options"_a = SelfCollisionBarrierOptions{}, "Create a self-collision barrier.")
+      .def(nanobind::init<const Oink&, const Scene&, double, const SelfCollisionBarrierOptions&>(),
+           "oink"_a, "scene"_a, "dt"_a, "options"_a = SelfCollisionBarrierOptions{},
+           "Create a self-collision barrier.")
       .def_ro("n_collision_pairs", &SelfCollisionBarrier::n_collision_pairs,
-              "Number of closest collision pairs to constrain.")
+              "Number of closest collision pairs constrained (clipped to the scene's pair count).")
       .def_ro("d_min", &SelfCollisionBarrier::d_min,
               "Minimum allowed distance between any pair of bodies.")
       .def_ro(

--- a/roboplan_oink/bindings/src/optimal_ik.cpp
+++ b/roboplan_oink/bindings/src/optimal_ik.cpp
@@ -2,6 +2,7 @@
 
 #include <nanobind/eigen/dense.h>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
@@ -147,20 +148,43 @@ void init_optimal_ik(nanobind::module_& m) {
       .def_ro("p_min", &PositionBarrier::p_min, "Minimum position bounds.")
       .def_ro("p_max", &PositionBarrier::p_max, "Maximum position bounds.");
 
+  // Bind SelfCollisionBarrierOptions configuration struct
+  nanobind::class_<SelfCollisionBarrierOptions>(m, "SelfCollisionBarrierOptions",
+                                                "Parameters for SelfCollisionBarrier.")
+      .def(nanobind::init<double, double, double, double, std::optional<double>>(), "gain"_a = 1.0,
+           "safe_displacement_gain"_a = 1.0, "d_min"_a = 0.02, "safety_margin"_a = 0.0,
+           "d_max"_a = std::optional<double>(0.5), "Constructor with custom parameters.")
+      .def_rw("gain", &SelfCollisionBarrierOptions::gain, "Barrier gain (gamma).")
+      .def_rw("safe_displacement_gain", &SelfCollisionBarrierOptions::safe_displacement_gain,
+              "Gain for safe displacement regularization.")
+      .def_rw("d_min", &SelfCollisionBarrierOptions::d_min,
+              "Minimum allowed distance between any pair of bodies.")
+      .def_rw("safety_margin", &SelfCollisionBarrierOptions::safety_margin,
+              "Conservative margin for hard constraint guarantee.")
+      .def_rw(
+          "d_max", &SelfCollisionBarrierOptions::d_max,
+          "Maximum distance (meters) at which a collision pair is tracked; pairs whose bounding "
+          "boxes are farther apart than this skip exact narrow-phase distance. Visibility / "
+          "performance bound, not a separation limit.");
+
   // Bind SelfCollisionBarrier
   nanobind::class_<SelfCollisionBarrier, Barrier>(
       m, "SelfCollisionBarrier",
       "Self-collision avoidance barrier based on hpp-fcl / coal collision pair distances.\n\n"
       "Constrains the closest `n_collision_pairs` collision pairs in the scene to remain at\n"
       "least `d_min` apart. Inspired by pink.barriers.SelfCollisionBarrier.")
-      .def(nanobind::init<const Oink&, const Scene&, int, double, double, double, double, double>(),
-           "oink"_a, "scene"_a, "n_collision_pairs"_a, "dt"_a, "gain"_a = 1.0,
-           "safe_displacement_gain"_a = 1.0, "d_min"_a = 0.02, "safety_margin"_a = 0.0,
-           "Create a self-collision barrier.")
+      .def(nanobind::init<const Oink&, const Scene&, int, double,
+                          const SelfCollisionBarrierOptions&>(),
+           "oink"_a, "scene"_a, "n_collision_pairs"_a, "dt"_a,
+           "options"_a = SelfCollisionBarrierOptions{}, "Create a self-collision barrier.")
       .def_ro("n_collision_pairs", &SelfCollisionBarrier::n_collision_pairs,
               "Number of closest collision pairs to constrain.")
       .def_ro("d_min", &SelfCollisionBarrier::d_min,
-              "Minimum allowed distance between any pair of bodies.");
+              "Minimum allowed distance between any pair of bodies.")
+      .def_ro(
+          "d_max", &SelfCollisionBarrier::d_max,
+          "Maximum distance (meters) at which a collision pair is tracked; pairs whose bounding "
+          "boxes are farther apart than this skip exact narrow-phase distance.");
 
   // Bind Oink solver
   nanobind::class_<Oink>(m, "Oink", "Optimal Inverse Kinematics solver.")

--- a/roboplan_oink/include/roboplan_oink/barriers/self_collision_barrier.hpp
+++ b/roboplan_oink/include/roboplan_oink/barriers/self_collision_barrier.hpp
@@ -1,13 +1,43 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <optional>
 #include <vector>
 
 #include <pinocchio/multibody/geometry.hpp>
 
+#include <roboplan/core/collision_context.hpp>
 #include <roboplan_oink/optimal_ik.hpp>
 
 namespace roboplan {
+
+/// @brief Optional parameters for SelfCollisionBarrier configuration.
+struct SelfCollisionBarrierOptions {
+  /// @brief Barrier gain (gamma), controls convergence to safe set (default: 1.0).
+  double gain = 1.0;
+
+  /// @brief Gain for safe displacement regularization (default: 1.0).
+  double safe_displacement_gain = 1.0;
+
+  /// @brief Minimum allowed distance between any pair of bodies. Must be non-negative
+  /// (default: 0.02).
+  double d_min = 0.02;
+
+  /// @brief Conservative margin for hard constraint guarantee (default: 0.0).
+  double safety_margin = 0.0;
+
+  /// @brief Maximum distance (meters) at which a collision pair is tracked.
+  /// @details Pairs whose bounding boxes are farther apart than this skip exact narrow-phase
+  /// distance computation (the dominant per-solve cost on dense / mesh-heavy models) and
+  /// therefore exert no influence on the barrier.
+  ///
+  /// This is a visibility / performance bound, NOT a separation limit: it does not constrain how
+  /// far apart bodies may be. When set comfortably larger than the distances at which the barrier
+  /// actively pushes (a few times d_min), it does not change the solution at all — only a too-small
+  /// value silently drops mid-range pairs. Default 0.5. Set to std::nullopt to disable culling.
+  /// Paired with d_min, it defines the band [d_min, d_max] of separations in the barrier.
+  std::optional<double> d_max = 0.5;
+};
 
 /// @brief Self-collision avoidance barrier based on collision pair distances.
 ///
@@ -36,16 +66,11 @@ struct SelfCollisionBarrier : public Barrier {
   ///        no greater than the number of collision pairs in the scene's collision model.
   ///        If fewer pairs than the total are requested, only the closest ones are constrained.
   /// @param dt Timestep matching the control loop period (must match actual control loop).
-  /// @param gain Barrier gain (gamma), controls convergence to safe set. Default 1.0.
-  /// @param safe_displacement_gain Gain for safe displacement regularization. Default 1.0.
-  /// @param d_min Minimum allowed distance between any pair of bodies. Must be non-negative.
-  ///        Default 0.02.
-  /// @param safety_margin Conservative margin for hard constraint guarantee. Default 0.0.
+  /// @param options Optional tuning parameters (default: all options set to defaults).
   /// @throws std::invalid_argument if d_min is negative, n_collision_pairs is non-positive,
   ///         or n_collision_pairs exceeds the number of collision pairs in the scene.
   SelfCollisionBarrier(const Oink& oink, const Scene& scene, int n_collision_pairs, double dt,
-                       double gain = 1.0, double safe_displacement_gain = 1.0, double d_min = 0.02,
-                       double safety_margin = 0.0);
+                       const SelfCollisionBarrierOptions& options = {});
 
   /// @brief Get the number of active barrier constraints.
   /// @return The number of collision pairs being constrained.
@@ -75,15 +100,16 @@ struct SelfCollisionBarrier : public Barrier {
 
   /// @brief Evaluate the minimum barrier value at a candidate configuration.
   ///
-  /// Refreshes geometry placements on a private GeometryData copy and runs narrow-phase
-  /// distance only on the pairs cached by the most recent computeBarrier() call
+  /// Refreshes geometry placements on this barrier's own CollisionContext scratch and runs
+  /// narrow-phase distance only on the pairs cached by the most recent computeBarrier() call
   /// (`closest_pair_indices`). For small displacements between the configuration used in
   /// computeBarrier() and `q`, those are the active constraints, and skipping narrow phase
   /// on the remaining pairs is the dominant per-solve speedup. computeBarrier() must have
   /// run before this method.
   ///
-  /// @param model Pinocchio model (must be the same as the scene's model).
-  /// @param data Pinocchio data (will be modified by FK / distance computation).
+  /// @param model Unused; kept for the Barrier interface. Distances are evaluated on this
+  ///        barrier's CollisionContext, which owns the model shared with the scene.
+  /// @param data Unused; kept for the Barrier interface.
   /// @param q Candidate joint configuration to evaluate.
   /// @return Expected containing the minimum barrier value (negative if any pair is in
   ///         collision), or an error message on failure.
@@ -97,6 +123,12 @@ struct SelfCollisionBarrier : public Barrier {
   /// @brief Minimum allowed distance between any pair of bodies.
   const double d_min;
 
+  /// @brief Maximum distance (meters) at which a collision pair is tracked; pairs whose bounding
+  ///        boxes are farther apart than this skip exact narrow-phase distance. Visibility /
+  ///        performance bound, not a separation limit. std::nullopt disables culling.
+  ///        See SelfCollisionBarrierOptions::d_max.
+  const std::optional<double> d_max;
+
   /// @brief Velocity indices of the joint group (for Jacobian column selection).
   Eigen::VectorXi v_indices;
 
@@ -105,7 +137,7 @@ struct SelfCollisionBarrier : public Barrier {
   std::vector<std::size_t> closest_pair_indices;
 
   /// @brief Workspace buffer holding `min_distance` for every collision pair in the model,
-  ///        repopulated on each computeBarrier() call from the scene's GeometryData.
+  ///        repopulated on each computeBarrier() call from the CollisionContext's GeometryData.
   Eigen::VectorXd all_distances;
 
   /// @brief Pre-allocated workspace for one parent-joint Jacobian (6 x model.nv).
@@ -118,11 +150,11 @@ struct SelfCollisionBarrier : public Barrier {
   ///        velocity DOFs (before selecting the joint-group columns).
   mutable Eigen::RowVectorXd full_row;
 
-  /// @brief Pointer to the scene's collision model (non-owning). Captured at construction.
-  const pinocchio::GeometryModel* collision_model;
-
-  /// @brief Private GeometryData used by evaluateAtConfiguration to avoid mutating scene state.
-  mutable pinocchio::GeometryData eval_geom_data;
+  /// @brief Non-owning pointer to the Oink solver's shared collision scratch (Data + GeometryData),
+  /// captured from `oink.getCollisionContext()` at construction. All distance / joint-Jacobian
+  /// queries run on this context instead of the scene's shared collision data, so the barrier never
+  /// mutates scene state. The referenced Oink must outlive this barrier.
+  const CollisionContext* collision_context;
 };
 
 }  // namespace roboplan

--- a/roboplan_oink/include/roboplan_oink/barriers/self_collision_barrier.hpp
+++ b/roboplan_oink/include/roboplan_oink/barriers/self_collision_barrier.hpp
@@ -11,8 +11,13 @@
 
 namespace roboplan {
 
-/// @brief Optional parameters for SelfCollisionBarrier configuration.
+/// @brief Parameters for SelfCollisionBarrier configuration.
 struct SelfCollisionBarrierOptions {
+  /// @brief Maximum number of closest collision pairs to constrain. Must be > 0. Only the closest
+  /// `n_collision_pairs` pairs at the current configuration are constrained. Values larger than the
+  /// number of collision pairs in the scene are clipped to that count.
+  int n_collision_pairs = 1;
+
   /// @brief Barrier gain (gamma), controls convergence to safe set (default: 1.0).
   double gain = 1.0;
 
@@ -62,14 +67,10 @@ struct SelfCollisionBarrier : public Barrier {
   /// @brief Constructs a self-collision barrier.
   /// @param oink The Oink solver this barrier will be used with.
   /// @param scene The scene whose collision model defines the collision pairs to monitor.
-  /// @param n_collision_pairs Number of closest collision pairs to consider. Must be > 0 and
-  ///        no greater than the number of collision pairs in the scene's collision model.
-  ///        If fewer pairs than the total are requested, only the closest ones are constrained.
-  /// @param dt Timestep matching the control loop period (must match actual control loop).
+  /// @param dt Timestep matching the control loop period. Must be positive.
   /// @param options Optional tuning parameters (default: all options set to defaults).
-  /// @throws std::invalid_argument if d_min is negative, n_collision_pairs is non-positive,
-  ///         or n_collision_pairs exceeds the number of collision pairs in the scene.
-  SelfCollisionBarrier(const Oink& oink, const Scene& scene, int n_collision_pairs, double dt,
+  /// @throws std::invalid_argument if d_min is negative or n_collision_pairs is non-positive.
+  SelfCollisionBarrier(const Oink& oink, const Scene& scene, double dt,
                        const SelfCollisionBarrierOptions& options = {});
 
   /// @brief Get the number of active barrier constraints.
@@ -117,8 +118,8 @@ struct SelfCollisionBarrier : public Barrier {
   evaluateAtConfiguration(const pinocchio::Model& model, pinocchio::Data& data,
                           const Eigen::VectorXd& q) const override;
 
-  /// @brief Number of closest collision pairs to constrain.
-  const int n_collision_pairs;
+  /// @brief Number of closest collision pairs constrained.
+  int n_collision_pairs;
 
   /// @brief Minimum allowed distance between any pair of bodies.
   const double d_min;

--- a/roboplan_oink/include/roboplan_oink/optimal_ik.hpp
+++ b/roboplan_oink/include/roboplan_oink/optimal_ik.hpp
@@ -6,6 +6,7 @@
 #include "OsqpEigen/OsqpEigen.h"
 #include <tl/expected.hpp>
 
+#include <roboplan/core/collision_context.hpp>
 #include <roboplan/core/scene.hpp>
 #include <roboplan/core/types.hpp>
 
@@ -383,6 +384,13 @@ struct Oink {
                   Eigen::Ref<Eigen::VectorXd, 0, Eigen::InnerStride<Eigen::Dynamic>> delta_q,
                   double tolerance = 0.0);
 
+  /// @brief The solver's shared collision scratch (Data + GeometryData + broadphase).
+  /// @details Tasks, constraints, and/or barriers that require collision queries should use this
+  /// context instead of building their own, so a single snapshot of the scene's collision
+  /// geometry is reused across the whole solve. It is snapshotted from the scene at construction;
+  /// if the scene's collision geometry changes, rebuild the solver (context does not auto-sync).
+  const CollisionContext& getCollisionContext() const { return *collision_context_; }
+
 private:
   /// @brief Compute `task`'s Jacobian and error, and add its contribution to the QP Hessian
   /// and gradient (projecting through the current `nullspace_projector` for hierarchical
@@ -459,5 +467,8 @@ public:
   // Allocated once at construction so the per-solve barrier-feasibility check does not
   // create a fresh Data (which is sized for the entire model) on every call.
   pinocchio::Data enforce_barriers_data;
+
+  // Shared collision context, snapshotted from the construction scene.
+  std::unique_ptr<CollisionContext> collision_context_;
 };
 }  // namespace roboplan

--- a/roboplan_oink/src/barriers/self_collision_barrier.cpp
+++ b/roboplan_oink/src/barriers/self_collision_barrier.cpp
@@ -14,11 +14,10 @@
 
 namespace roboplan {
 
-SelfCollisionBarrier::SelfCollisionBarrier(const Oink& oink, const Scene& scene,
-                                           int n_collision_pairs, double dt,
+SelfCollisionBarrier::SelfCollisionBarrier(const Oink& oink, const Scene& scene, double dt,
                                            const SelfCollisionBarrierOptions& options)
     : Barrier(options.gain, dt, options.safe_displacement_gain, options.safety_margin),
-      n_collision_pairs(n_collision_pairs), d_min(options.d_min), d_max(options.d_max),
+      n_collision_pairs(options.n_collision_pairs), d_min(options.d_min), d_max(options.d_max),
       v_indices(oink.v_indices) {
   if (d_min < 0.0) {
     throw std::invalid_argument("SelfCollisionBarrier: d_min must be non-negative (got " +
@@ -28,13 +27,10 @@ SelfCollisionBarrier::SelfCollisionBarrier(const Oink& oink, const Scene& scene,
     throw std::invalid_argument("SelfCollisionBarrier: n_collision_pairs must be positive (got " +
                                 std::to_string(n_collision_pairs) + ")");
   }
+
+  // Clip the requested pair count to what the scene actually has.
   const auto total_pairs = static_cast<int>(scene.getCollisionModel().collisionPairs.size());
-  if (n_collision_pairs > total_pairs) {
-    throw std::invalid_argument("SelfCollisionBarrier: requested " +
-                                std::to_string(n_collision_pairs) +
-                                " collision pairs but the scene only has " +
-                                std::to_string(total_pairs) + " collision pairs.");
-  }
+  n_collision_pairs = std::min(n_collision_pairs, total_pairs);
 
   initializeStorage(n_collision_pairs, oink.num_variables);
   closest_pair_indices.assign(n_collision_pairs, 0);

--- a/roboplan_oink/src/barriers/self_collision_barrier.cpp
+++ b/roboplan_oink/src/barriers/self_collision_barrier.cpp
@@ -15,12 +15,11 @@
 namespace roboplan {
 
 SelfCollisionBarrier::SelfCollisionBarrier(const Oink& oink, const Scene& scene,
-                                           int n_collision_pairs_, double dt, double gain,
-                                           double safe_displacement_gain, double d_min_,
-                                           double safety_margin)
-    : Barrier(gain, dt, safe_displacement_gain, safety_margin),
-      n_collision_pairs(n_collision_pairs_), d_min(d_min_), v_indices(oink.v_indices),
-      collision_model(&scene.getCollisionModel()) {
+                                           int n_collision_pairs_, double dt,
+                                           const SelfCollisionBarrierOptions& options)
+    : Barrier(options.gain, dt, options.safe_displacement_gain, options.safety_margin),
+      n_collision_pairs(n_collision_pairs_), d_min(options.d_min), d_max(options.d_max),
+      v_indices(oink.v_indices) {
   if (d_min < 0.0) {
     throw std::invalid_argument("SelfCollisionBarrier: d_min must be non-negative (got " +
                                 std::to_string(d_min) + ")");
@@ -29,7 +28,7 @@ SelfCollisionBarrier::SelfCollisionBarrier(const Oink& oink, const Scene& scene,
     throw std::invalid_argument("SelfCollisionBarrier: n_collision_pairs must be positive (got " +
                                 std::to_string(n_collision_pairs) + ")");
   }
-  const auto total_pairs = static_cast<int>(collision_model->collisionPairs.size());
+  const auto total_pairs = static_cast<int>(scene.getCollisionModel().collisionPairs.size());
   if (n_collision_pairs > total_pairs) {
     throw std::invalid_argument("SelfCollisionBarrier: requested " +
                                 std::to_string(n_collision_pairs) +
@@ -46,13 +45,16 @@ SelfCollisionBarrier::SelfCollisionBarrier(const Oink& oink, const Scene& scene,
   joint_jacobian2 = Eigen::MatrixXd::Zero(6, nv);
   full_row = Eigen::RowVectorXd::Zero(nv);
 
-  eval_geom_data = pinocchio::GeometryData(*collision_model);
+  // Share the Oink solver's collision scratch. Every distance and joint-Jacobian query below runs
+  // on this context, so the barrier never touches scene state. The context is a snapshot of the
+  // scene's collision geometry taken when the Oink was constructed.
+  collision_context = &oink.getCollisionContext();
 }
 
 int SelfCollisionBarrier::getNumBarriers(const Scene& /*scene*/) const { return n_collision_pairs; }
 
 tl::expected<void, std::string> SelfCollisionBarrier::computeBarrier(const Scene& scene) {
-  const auto& geom_model = scene.getCollisionModel();
+  const auto& geom_model = collision_context->getCollisionModel();
   const auto total_pairs = static_cast<int>(geom_model.collisionPairs.size());
   if (total_pairs < n_collision_pairs) {
     return tl::make_unexpected("SelfCollisionBarrier: scene has fewer collision pairs (" +
@@ -60,11 +62,12 @@ tl::expected<void, std::string> SelfCollisionBarrier::computeBarrier(const Scene
                                std::to_string(n_collision_pairs) + ")");
   }
 
-  // Update geometry placements and recompute every pair distance.
+  // Update geometry placements and recompute pair distances on the barrier's own scratch. Pairs
+  // whose bounding boxes are farther apart than d_max skip exact narrow-phase distance.
   const Eigen::VectorXd& q = scene.getCurrentJointPositions();
-  scene.computeCollisionDistances(q);
+  collision_context->computeDistances(q, d_max);
 
-  const auto& geom_data = scene.getCollisionData();
+  const auto& geom_data = collision_context->getCollisionData();
   for (int k = 0; k < total_pairs; ++k) {
     all_distances[k] = geom_data.distanceResults[k].min_distance;
   }
@@ -85,14 +88,15 @@ tl::expected<void, std::string> SelfCollisionBarrier::computeBarrier(const Scene
 }
 
 tl::expected<void, std::string> SelfCollisionBarrier::computeJacobian(const Scene& scene) {
-  const auto& model = scene.getModel();
-  const auto& data = scene.getData();
-  const auto& geom_model = scene.getCollisionModel();
-  const auto& geom_data = scene.getCollisionData();
+  const auto& model = collision_context->getModel();
+  const auto& data = collision_context->getData();
+  const auto& geom_model = collision_context->getCollisionModel();
+  const auto& geom_data = collision_context->getCollisionData();
 
-  // Joint Jacobians are needed for parent-joint Jacobian extraction below.
+  // Joint Jacobians are needed for parent-joint Jacobian extraction below. They share the same
+  // scratch Data as computeDistances(), so its forward kinematics and the witness points line up.
   const Eigen::VectorXd& q = scene.getCurrentJointPositions();
-  scene.computeJointJacobians(q);
+  collision_context->computeJointJacobians(q);
 
   // NOTE: collision distances should have already been computed in computeBarrier(),
   // so we can reuse the witness points in geom_data without recomputing distances.
@@ -153,22 +157,20 @@ tl::expected<void, std::string> SelfCollisionBarrier::computeJacobian(const Scen
   return {};
 }
 
-tl::expected<double, std::string>
-SelfCollisionBarrier::evaluateAtConfiguration(const pinocchio::Model& model, pinocchio::Data& data,
-                                              const Eigen::VectorXd& q) const {
-  if (collision_model == nullptr) {
-    return tl::make_unexpected("SelfCollisionBarrier: collision_model pointer is null");
-  }
-
-  // Refresh geometry placements at q, then run narrow-phase distance only on the pairs
-  // that computeBarrier() identified as closest. This skips the full pair sweep that
-  // pinocchio::computeDistances() would otherwise do.
-  pinocchio::updateGeometryPlacements(model, data, *collision_model, eval_geom_data, q);
+tl::expected<double, std::string> SelfCollisionBarrier::evaluateAtConfiguration(
+    const pinocchio::Model& /*model*/, pinocchio::Data& /*data*/, const Eigen::VectorXd& q) const {
+  // Refresh geometry placements at q on the barrier's own scratch, then run narrow-phase distance
+  // only on the pairs that computeBarrier() identified as closest. This skips the full pair sweep
+  // that pinocchio::computeDistances() would otherwise do, and never touches scene state.
+  const auto& model = collision_context->getModel();
+  auto& data = collision_context->getData();
+  const auto& geom_model = collision_context->getCollisionModel();
+  auto& geom_data = collision_context->getCollisionData();
+  pinocchio::updateGeometryPlacements(model, data, geom_model, geom_data, q);
 
   double min_distance = std::numeric_limits<double>::infinity();
   for (int i = 0; i < n_collision_pairs; ++i) {
-    const auto& result =
-        pinocchio::computeDistance(*collision_model, eval_geom_data, closest_pair_indices[i]);
+    const auto& result = pinocchio::computeDistance(geom_model, geom_data, closest_pair_indices[i]);
     min_distance = std::min(min_distance, result.min_distance);
   }
   return min_distance - d_min;

--- a/roboplan_oink/src/optimal_ik.cpp
+++ b/roboplan_oink/src/optimal_ik.cpp
@@ -164,6 +164,8 @@ Oink::Oink(const Scene& scene, const std::string& group_name,
   task_H = Eigen::SparseMatrix<double>(num_variables, num_variables);
   H = Eigen::SparseMatrix<double>(num_variables, num_variables);
   c = Eigen::VectorXd::Zero(num_variables);
+
+  collision_context_ = std::make_unique<CollisionContext>(scene);
 }
 
 Oink::Oink(const Scene& scene, const std::string& group_name)
@@ -181,6 +183,8 @@ Oink::Oink(const Scene& scene, const std::string& group_name)
   task_H = Eigen::SparseMatrix<double>(num_variables, num_variables);
   H = Eigen::SparseMatrix<double>(num_variables, num_variables);
   c = Eigen::VectorXd::Zero(num_variables);
+
+  collision_context_ = std::make_unique<CollisionContext>(scene);
 
   settings.setWarmStart(true);
   settings.setVerbosity(false);

--- a/roboplan_oink/test/barriers/test_self_collision_barrier.cpp
+++ b/roboplan_oink/test/barriers/test_self_collision_barrier.cpp
@@ -60,11 +60,10 @@ protected:
 TEST_F(SelfCollisionBarrierTest, ConstructionStoresParameters) {
   ASSERT_GT(num_pairs_, 0) << "Test scene must have at least one collision pair";
 
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                        /*gain=*/2.5,
-                                                        /*safe_displacement_gain=*/0.5,
-                                                        /*d_min=*/0.03,
-                                                        /*safety_margin=*/0.01);
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, num_pairs_, dt_,
+      SelfCollisionBarrierOptions{
+          .gain = 2.5, .safe_displacement_gain = 0.5, .d_min = 0.03, .safety_margin = 0.01});
 
   EXPECT_EQ(barrier->getNumBarriers(*scene_), num_pairs_);
   EXPECT_EQ(barrier->n_collision_pairs, num_pairs_);
@@ -87,8 +86,8 @@ TEST_F(SelfCollisionBarrierTest, ConstructionDefaultsAreReasonable) {
 TEST_F(SelfCollisionBarrierTest, InvalidDmin) {
   EXPECT_THROW(
       {
-        auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_, 1.0,
-                                                              1.0, /*d_min=*/-0.01);
+        auto barrier = std::make_shared<SelfCollisionBarrier>(
+            *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.d_min = -0.01});
       },
       std::invalid_argument);
 }
@@ -113,8 +112,8 @@ TEST_F(SelfCollisionBarrierTest, InvalidPairCount) {
 TEST_F(SelfCollisionBarrierTest, InvalidGainAndDt) {
   EXPECT_THROW(
       {
-        auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                              /*gain=*/0.0);
+        auto barrier = std::make_shared<SelfCollisionBarrier>(
+            *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.gain = 0.0});
       },
       std::invalid_argument);
   EXPECT_THROW(
@@ -129,9 +128,7 @@ TEST_F(SelfCollisionBarrierTest, BarrierValuesPositiveInSafeConfiguration) {
   ASSERT_FALSE(scene_->hasCollisions(q));
 
   auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                        /*gain=*/1.0,
-                                                        /*safe_displacement_gain=*/1.0,
-                                                        /*d_min=*/0.0);
+                                                        SelfCollisionBarrierOptions{.d_min = 0.0});
   auto result = barrier->computeBarrier(*scene_);
   ASSERT_TRUE(result.has_value()) << result.error();
 
@@ -147,8 +144,8 @@ TEST_F(SelfCollisionBarrierTest, ClosestPairsAreSelectedFirst) {
 
   // Pick a strict subset to force pair selection.
   const int requested = std::min(num_pairs_, std::max(1, num_pairs_ / 2));
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, requested, dt_, 1.0, 1.0,
-                                                        /*d_min=*/0.0);
+  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, requested, dt_,
+                                                        SelfCollisionBarrierOptions{.d_min = 0.0});
   auto result = barrier->computeBarrier(*scene_);
   ASSERT_TRUE(result.has_value()) << result.error();
 
@@ -178,10 +175,10 @@ TEST_F(SelfCollisionBarrierTest, DminShiftsBarrierValues) {
   Eigen::VectorXd q = Eigen::VectorXd::Zero(num_variables_);
   scene_->setJointPositions(q);
 
-  auto barrier_no_margin = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                                  1.0, 1.0, /*d_min=*/0.0);
-  auto barrier_with_margin = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_,
-                                                                    dt_, 1.0, 1.0, /*d_min=*/0.05);
+  auto barrier_no_margin = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.d_min = 0.0});
+  auto barrier_with_margin = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.d_min = 0.05});
 
   ASSERT_TRUE(barrier_no_margin->computeBarrier(*scene_).has_value());
   ASSERT_TRUE(barrier_with_margin->computeBarrier(*scene_).has_value());
@@ -212,7 +209,7 @@ TEST_F(SelfCollisionBarrierTest, QpInequalitiesAreFinite) {
   scene_->setJointPositions(q);
 
   auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                        /*gain=*/5.0);
+                                                        SelfCollisionBarrierOptions{.gain = 5.0});
   const int n = barrier->getNumBarriers(*scene_);
   Eigen::MatrixXd G(n, num_variables_);
   Eigen::VectorXd b(n);
@@ -231,8 +228,8 @@ TEST_F(SelfCollisionBarrierTest, EvaluateAtConfigurationMatchesBarrierMinimum) {
   Eigen::VectorXd q = Eigen::VectorXd::Zero(num_variables_);
   scene_->setJointPositions(q);
 
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_, 1.0, 1.0,
-                                                        /*d_min=*/0.01);
+  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
+                                                        SelfCollisionBarrierOptions{.d_min = 0.01});
   ASSERT_TRUE(barrier->computeBarrier(*scene_).has_value());
 
   pinocchio::Data temp_data(scene_->getModel());
@@ -264,10 +261,8 @@ TEST_F(SelfCollisionBarrierTest, IkSolvesWithBarrier) {
   Eigen::VectorXd v_max = Eigen::VectorXd::Constant(num_variables_, 1.0);
   auto vel_limit = std::make_shared<VelocityLimit>(oink, dt_, v_max);
 
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                        /*gain=*/5.0,
-                                                        /*safe_displacement_gain=*/1.0,
-                                                        /*d_min=*/0.02);
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.gain = 5.0, .d_min = 0.02});
 
   std::vector<std::shared_ptr<Task>> tasks = {frame_task};
   std::vector<std::shared_ptr<Constraints>> constraints = {vel_limit};

--- a/roboplan_oink/test/barriers/test_self_collision_barrier.cpp
+++ b/roboplan_oink/test/barriers/test_self_collision_barrier.cpp
@@ -61,9 +61,12 @@ TEST_F(SelfCollisionBarrierTest, ConstructionStoresParameters) {
   ASSERT_GT(num_pairs_, 0) << "Test scene must have at least one collision pair";
 
   auto barrier = std::make_shared<SelfCollisionBarrier>(
-      *oink_, *scene_, num_pairs_, dt_,
-      SelfCollisionBarrierOptions{
-          .gain = 2.5, .safe_displacement_gain = 0.5, .d_min = 0.03, .safety_margin = 0.01});
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_,
+                                  .gain = 2.5,
+                                  .safe_displacement_gain = 0.5,
+                                  .d_min = 0.03,
+                                  .safety_margin = 0.01});
 
   EXPECT_EQ(barrier->getNumBarriers(*scene_), num_pairs_);
   EXPECT_EQ(barrier->n_collision_pairs, num_pairs_);
@@ -75,7 +78,8 @@ TEST_F(SelfCollisionBarrierTest, ConstructionStoresParameters) {
 }
 
 TEST_F(SelfCollisionBarrierTest, ConstructionDefaultsAreReasonable) {
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_);
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, dt_, SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_});
 
   EXPECT_DOUBLE_EQ(barrier->d_min, 0.02);
   EXPECT_DOUBLE_EQ(barrier->gain, 1.0);
@@ -87,7 +91,8 @@ TEST_F(SelfCollisionBarrierTest, InvalidDmin) {
   EXPECT_THROW(
       {
         auto barrier = std::make_shared<SelfCollisionBarrier>(
-            *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.d_min = -0.01});
+            *oink_, *scene_, dt_,
+            SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .d_min = -0.01});
       },
       std::invalid_argument);
 }
@@ -95,29 +100,41 @@ TEST_F(SelfCollisionBarrierTest, InvalidDmin) {
 TEST_F(SelfCollisionBarrierTest, InvalidPairCount) {
   // Non-positive pair counts are rejected.
   EXPECT_THROW(
-      { auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, 0, dt_); },
-      std::invalid_argument);
-  EXPECT_THROW(
-      { auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, -1, dt_); },
-      std::invalid_argument);
-
-  // Requesting more pairs than exist in the model is rejected.
-  EXPECT_THROW(
       {
-        auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_ + 1, dt_);
+        auto barrier = std::make_shared<SelfCollisionBarrier>(
+            *oink_, *scene_, dt_, SelfCollisionBarrierOptions{.n_collision_pairs = 0});
       },
       std::invalid_argument);
+  EXPECT_THROW(
+      {
+        auto barrier = std::make_shared<SelfCollisionBarrier>(
+            *oink_, *scene_, dt_, SelfCollisionBarrierOptions{.n_collision_pairs = -1});
+      },
+      std::invalid_argument);
+}
+
+TEST_F(SelfCollisionBarrierTest, PairCountClippedToSceneCount) {
+  // Requesting more pairs than exist in the model is clipped, not rejected.
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, dt_, SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_ + 5});
+  EXPECT_EQ(barrier->n_collision_pairs, num_pairs_);
+  EXPECT_EQ(barrier->getNumBarriers(*scene_), num_pairs_);
 }
 
 TEST_F(SelfCollisionBarrierTest, InvalidGainAndDt) {
   EXPECT_THROW(
       {
         auto barrier = std::make_shared<SelfCollisionBarrier>(
-            *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.gain = 0.0});
+            *oink_, *scene_, dt_,
+            SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .gain = 0.0});
       },
       std::invalid_argument);
   EXPECT_THROW(
-      { auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, 0.0); },
+      {
+        auto barrier = std::make_shared<SelfCollisionBarrier>(
+            *oink_, *scene_, /*dt=*/0.0,
+            SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_});
+      },
       std::invalid_argument);
 }
 
@@ -127,8 +144,9 @@ TEST_F(SelfCollisionBarrierTest, BarrierValuesPositiveInSafeConfiguration) {
   scene_->setJointPositions(q);
   ASSERT_FALSE(scene_->hasCollisions(q));
 
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                        SelfCollisionBarrierOptions{.d_min = 0.0});
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .d_min = 0.0});
   auto result = barrier->computeBarrier(*scene_);
   ASSERT_TRUE(result.has_value()) << result.error();
 
@@ -144,8 +162,9 @@ TEST_F(SelfCollisionBarrierTest, ClosestPairsAreSelectedFirst) {
 
   // Pick a strict subset to force pair selection.
   const int requested = std::min(num_pairs_, std::max(1, num_pairs_ / 2));
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, requested, dt_,
-                                                        SelfCollisionBarrierOptions{.d_min = 0.0});
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = requested, .d_min = 0.0});
   auto result = barrier->computeBarrier(*scene_);
   ASSERT_TRUE(result.has_value()) << result.error();
 
@@ -176,9 +195,11 @@ TEST_F(SelfCollisionBarrierTest, DminShiftsBarrierValues) {
   scene_->setJointPositions(q);
 
   auto barrier_no_margin = std::make_shared<SelfCollisionBarrier>(
-      *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.d_min = 0.0});
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .d_min = 0.0});
   auto barrier_with_margin = std::make_shared<SelfCollisionBarrier>(
-      *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.d_min = 0.05});
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .d_min = 0.05});
 
   ASSERT_TRUE(barrier_no_margin->computeBarrier(*scene_).has_value());
   ASSERT_TRUE(barrier_with_margin->computeBarrier(*scene_).has_value());
@@ -195,7 +216,8 @@ TEST_F(SelfCollisionBarrierTest, JacobianHasExpectedDimensions) {
   Eigen::VectorXd q = Eigen::VectorXd::Zero(num_variables_);
   scene_->setJointPositions(q);
 
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_);
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, dt_, SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_});
   ASSERT_TRUE(barrier->computeBarrier(*scene_).has_value());
   ASSERT_TRUE(barrier->computeJacobian(*scene_).has_value());
 
@@ -208,8 +230,9 @@ TEST_F(SelfCollisionBarrierTest, QpInequalitiesAreFinite) {
   Eigen::VectorXd q = Eigen::VectorXd::Zero(num_variables_);
   scene_->setJointPositions(q);
 
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                        SelfCollisionBarrierOptions{.gain = 5.0});
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .gain = 5.0});
   const int n = barrier->getNumBarriers(*scene_);
   Eigen::MatrixXd G(n, num_variables_);
   Eigen::VectorXd b(n);
@@ -228,8 +251,9 @@ TEST_F(SelfCollisionBarrierTest, EvaluateAtConfigurationMatchesBarrierMinimum) {
   Eigen::VectorXd q = Eigen::VectorXd::Zero(num_variables_);
   scene_->setJointPositions(q);
 
-  auto barrier = std::make_shared<SelfCollisionBarrier>(*oink_, *scene_, num_pairs_, dt_,
-                                                        SelfCollisionBarrierOptions{.d_min = 0.01});
+  auto barrier = std::make_shared<SelfCollisionBarrier>(
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .d_min = 0.01});
   ASSERT_TRUE(barrier->computeBarrier(*scene_).has_value());
 
   pinocchio::Data temp_data(scene_->getModel());
@@ -262,7 +286,8 @@ TEST_F(SelfCollisionBarrierTest, IkSolvesWithBarrier) {
   auto vel_limit = std::make_shared<VelocityLimit>(oink, dt_, v_max);
 
   auto barrier = std::make_shared<SelfCollisionBarrier>(
-      *oink_, *scene_, num_pairs_, dt_, SelfCollisionBarrierOptions{.gain = 5.0, .d_min = 0.02});
+      *oink_, *scene_, dt_,
+      SelfCollisionBarrierOptions{.n_collision_pairs = num_pairs_, .gain = 5.0, .d_min = 0.02});
 
   std::vector<std::shared_ptr<Task>> tasks = {frame_task};
   std::vector<std::shared_ptr<Constraints>> constraints = {vel_limit};


### PR DESCRIPTION
Inspired by https://github.com/kevinzakka/mink/pull/151, I realized we could also do broadphase culling using Pinocchio's broadphase manager / our `CollisionContext` we added to similarly speed up RRT. The difference here is this uses axis-aligned bounding boxes (AABB) instead of bounding spheres.

Doing some tests, with a broadphase margin of 0.5 meters, the Franka Dual collision barrier was sped up ~2x and the Kinova one (which has pretty fine collision meshes) was ~39x! So yeah a definite win.

It also inches us closer to having thread-safe OInK, though forward kinematics needs to follow suit.