### PR TITLE
Fix OInK instability with failures to converge

### DIFF
--- a/roboplan_examples/python/example_oink.py
+++ b/roboplan_examples/python/example_oink.py
@@ -32,7 +32,7 @@ def main(
     model: str = "ur5",
     task_gain: float = 1.0,
     lm_damping: float = 0.01,
-    regularization: float = 1e-6,
+    regularization: float = 1e-3,
     control_freq: float = 100.0,
     reference_filter_tau: float = 0.1,
     self_collision_num_pairs: int = 0,
@@ -259,8 +259,14 @@ def main(
     def control_loop():
         delta_q = np.zeros(num_variables)
         delta_q_full = np.zeros(model_pin.nv)
+        # Visualization is throttled and runs outside the scene lock so the Viser push to
+        # the browser cannot stretch the control period. The solver assumes a fixed dt, so
+        # keeping the control loop at a steady rate prevents jitter.
+        display_period = max(dt, 1.0 / 30.0)
+        last_display = 0.0
         while running:
             loop_start = time.time()
+            q_to_display = None
 
             # Thread-safe scene access for IK solving
             if not paused:
@@ -323,7 +329,22 @@ def main(
                         if isinstance(task, FrameTask):
                             scene.forwardKinematics(q_current, task.frame_name)
 
-                    viz.display(q_current)
+                    q_to_display = q_current
+            else:
+                # While paused (including just after a reset), hold the filter and
+                # last-velocity state at rest so resuming starts from zero velocity
+                # rather than replaying a stale displacement.
+                delta_q[:] = 0.0
+                delta_q_full[:] = 0.0
+
+            # Throttled visualization, outside the scene lock, so a slow browser push does
+            # not perturb the control-loop timing.
+            if (
+                q_to_display is not None
+                and (loop_start - last_display) >= display_period
+            ):
+                viz.display(q_to_display)
+                last_display = loop_start
 
             # Maintain control loop rate
             elapsed = time.time() - loop_start

--- a/roboplan_examples/python/example_oink_position_barriers.py
+++ b/roboplan_examples/python/example_oink_position_barriers.py
@@ -30,7 +30,7 @@ def main(
     model: str = "ur5",
     task_gain: float = 1.0,
     lm_damping: float = 0.01,
-    regularization: float = 1e-6,
+    regularization: float = 1e-3,
     control_freq: float = 400.0,
     barrier_gain: float = 10.0,
     barrier_size: float = 0.5,
@@ -245,8 +245,14 @@ def main(
     def control_loop():
         delta_q = np.zeros(num_variables)
         delta_q_full = np.zeros(model_pin.nv)
+        # Visualization is throttled and runs outside the scene lock so the Viser push to
+        # the browser cannot stretch the control period. The solver assumes a fixed dt, so
+        # keeping the control loop at a steady rate prevents jitter.
+        display_period = max(dt, 1.0 / 30.0)
+        last_display = 0.0
         while running:
             loop_start = time.time()
+            q_to_display = None
 
             # Thread-safe scene access for IK solving
             if not paused:
@@ -295,7 +301,24 @@ def main(
                         if isinstance(task, FrameTask):
                             scene.forwardKinematics(q_current, task.frame_name)
 
-                    viz.display(q_current)
+                    # q_current is a fresh array from integrate(); snapshot it for a
+                    # throttled display outside the lock (below).
+                    q_to_display = q_current
+            else:
+                # While paused (including just after a reset), hold the velocity state at
+                # rest so resuming starts from zero velocity rather than replaying a stale
+                # displacement.
+                delta_q[:] = 0.0
+                delta_q_full[:] = 0.0
+
+            # Throttled visualization, outside the scene lock, so a slow browser push does
+            # not perturb the control-loop timing.
+            if (
+                q_to_display is not None
+                and (loop_start - last_display) >= display_period
+            ):
+                viz.display(q_to_display)
+                last_display = loop_start
 
             # Maintain control loop rate
             elapsed = time.time() - loop_start

--- a/roboplan_oink/include/roboplan_oink/optimal_ik.hpp
+++ b/roboplan_oink/include/roboplan_oink/optimal_ik.hpp
@@ -361,18 +361,23 @@ struct Oink {
   /// @brief Validate delta_q against barriers using forward kinematics.
   ///
   /// This method provides a post-solve safety check by evaluating the actual barrier
-  /// values at the candidate configuration (q + delta_q). If any barrier would be
-  /// violated, delta_q is set to zero to prevent unsafe motion.
+  /// values at the candidate configuration (q + delta_q). It is a backup safety mechanism
+  /// for cases where the linearized CBF constraint in the QP has significant error (e.g.,
+  /// large jumps, near-boundary configurations). The QP constraint uses a first-order
+  /// approximation h(q + δq) ≈ h(q) + J_h · δq, which can have error O(||δq||²) for large
+  /// displacements.
   ///
-  /// This is a backup safety mechanism for cases where the linearized CBF constraint
-  /// in the QP has significant error (e.g., large jumps, near-boundary configurations).
-  /// The QP constraint uses a first-order approximation h(q + δq) ≈ h(q) + J_h · δq,
-  /// which can have significant error O(||δq||²) for large displacements.
+  /// Enforcement is per-barrier rather than global. For each barrier that would be violated
+  /// at the candidate configuration, only the joints that affect that barrier (its nonzero
+  /// Jacobian columns) are zeroed, so an unrelated kinematic chain, e.g, the other arm in a
+  /// dual-arm setup, is not frozen just because one frame left its bound.
+  /// A step that is still violated but strictly reduces the violation is allowed/
+  /// For example, a frame that started outside its bound can recover instead of deadlocking.
   ///
   /// @param scene The scene containing robot model and state
   /// @param barriers Vector of barrier functions to check
-  /// @param delta_q Configuration displacement to validate. Modified in place: set to
-  ///                zero if barrier violation is detected.
+  /// @param delta_q Configuration displacement to validate. Modified in place: the joints of
+  ///                each violated, non-recovering barrier are set to zero.
   /// @param tolerance Tolerance for barrier violation detection. A barrier is considered
   ///                  violated if h(q + delta_q) < -tolerance. Default is 0.0.
   /// @return void on success, error message if barrier evaluation fails

--- a/roboplan_oink/src/constraints/position_limit.cpp
+++ b/roboplan_oink/src/constraints/position_limit.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <roboplan_oink/constraints/position_limit.hpp>
 
 #include <OsqpEigen/OsqpEigen.h>
@@ -59,14 +60,14 @@ tl::expected<void, std::string> PositionLimit::computeQpConstraints(
     const int vi = v_indices(i);
     // Compute distance to upper limit
     if (std::isfinite(q_max(vi))) {
-      delta_q_max(i) = q_max(vi) - q_collapsed(vi);
+      delta_q_max(i) = std::max(0.0, q_max(vi) - q_collapsed(vi));
     } else {
       delta_q_max(i) = std::numeric_limits<double>::infinity();
     }
 
     // Compute distance to lower limit
     if (std::isfinite(q_min(vi))) {
-      delta_q_min(i) = q_collapsed(vi) - q_min(vi);
+      delta_q_min(i) = std::max(0.0, q_collapsed(vi) - q_min(vi));
     } else {
       delta_q_min(i) = std::numeric_limits<double>::infinity();
     }

--- a/roboplan_oink/src/optimal_ik.cpp
+++ b/roboplan_oink/src/optimal_ik.cpp
@@ -420,6 +420,16 @@ Oink::solveIk(const Scene& scene, const std::vector<std::shared_ptr<Task>>& task
     return tl::make_unexpected("QP solver failed to find a solution");
   }
 
+  // If the solver did not converge, even with NoError status, this can return large garbage values.
+  // In this case, return a zero step and reset the warm-start state so the numerical instability
+  // is not carried into the next solve.
+  const OsqpEigen::Status status = solver.getStatus();
+  if (status != OsqpEigen::Status::Solved && status != OsqpEigen::Status::SolvedInaccurate) {
+    delta_q.setZero();
+    solver.clearSolverVariables();
+    return {};
+  }
+
   // Extract the solution and copy into delta_q
   delta_q.noalias() = solver.getSolution();
   return {};

--- a/roboplan_oink/src/optimal_ik.cpp
+++ b/roboplan_oink/src/optimal_ik.cpp
@@ -477,22 +477,41 @@ Oink::enforceBarriers(const Scene& scene, const std::vector<std::shared_ptr<Barr
 
   // Evaluate all barriers at the candidate configuration. enforce_barriers_data is a
   // pre-allocated pinocchio::Data scoped to this method, so we don't mutate scene state.
-  double min_h = OSQP_INFTY;
   for (const auto& barrier : barriers) {
-    auto h_result = barrier->evaluateAtConfiguration(model, enforce_barriers_data, q_candidate);
-    if (!h_result.has_value()) {
-      // Propagate evaluation error
-      return tl::make_unexpected(h_result.error());
+    auto h_candidate_result =
+        barrier->evaluateAtConfiguration(model, enforce_barriers_data, q_candidate);
+    if (!h_candidate_result.has_value()) {
+      return tl::make_unexpected(h_candidate_result.error());
     }
-    // Only consider finite barrier values (infinity means not supported)
-    if (std::isfinite(h_result.value())) {
-      min_h = std::min(min_h, h_result.value());
-    }
-  }
 
-  // If any barrier is violated, stop completely
-  if (min_h < -tolerance) {
-    delta_q.setZero();
+    // Safe (or unsupported, i.e., infinite) barriers do not restrict the step.
+    const double h_candidate = h_candidate_result.value();
+    if (!std::isfinite(h_candidate) || h_candidate >= -tolerance) {
+      continue;
+    }
+
+    // Violated at the candidate: allow the step only if it improves this barrier's value
+    // relative to the current configuration (recovery), otherwise veto its joints.
+    auto h_current_result = barrier->evaluateAtConfiguration(model, enforce_barriers_data, q);
+    if (!h_current_result.has_value()) {
+      return tl::make_unexpected(h_current_result.error());
+    }
+    if (h_candidate > h_current_result.value()) {
+      continue;
+    }
+
+    // Recompute the barrier Jacobian at the current configuration. Zero only the joints with a
+    // nonzero column, mapping the group velocity indices to the full-model indices of delta_q.
+    auto jacobian_result = barrier->computeJacobian(scene);
+    if (!jacobian_result.has_value()) {
+      return tl::make_unexpected(jacobian_result.error());
+    }
+    const Eigen::MatrixXd& barrier_jacobian = barrier->jacobian_container;
+    for (int j = 0; j < num_variables; ++j) {
+      if (barrier_jacobian.col(j).cwiseAbs().maxCoeff() > 0.0) {
+        delta_q(v_indices(j)) = 0.0;
+      }
+    }
   }
 
   return {};


### PR DESCRIPTION
I started seeing the OInK instability behavior again, and pinned it down due to an OSQP state that is somehow not a failure to solve, but a failure to converge?

So now we handle that case and properly zero out the resulting delta_q.

In doing so, the solver was getting "stuck" in these states because of a clamping issue in the `PositionLimit` task.

Other stability/jerk fixes have to do with tweaking the examples and decoupling the animation loop with the IK solving.