### PR TITLE
Add mujoco_ros2_control option to Franka xacro

### DIFF
--- a/roboplan_example_models/models/franka_robot_model/fr3.urdf
+++ b/roboplan_example_models/models/franka_robot_model/fr3.urdf
@@ -3,7 +3,10 @@
 
   <xacro:include filename="fr3.xacro"/>
 
+  <xacro:arg name="ros2_control_hardware" default="mock"/>
+
   <link name="world"/>
-  <xacro:fr3_robot prefix="" parent_link="world" xyz="0 0 0" rpy="0 0 0"/>
+  <xacro:fr3_robot prefix="" parent_link="world" xyz="0 0 0" rpy="0 0 0"
+                   ros2_control_hardware="$(arg ros2_control_hardware)"/>
 
 </robot>

--- a/roboplan_example_models/models/franka_robot_model/fr3.xacro
+++ b/roboplan_example_models/models/franka_robot_model/fr3.xacro
@@ -1,8 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="fr3">
 
-  <!-- Macro definition for FR3 robot with prefix and parent_link -->
-  <xacro:macro name="fr3_robot" params="prefix parent_link xyz rpy">
+  <!-- Macro definition for FR3 robot with prefix and parent_link.
+       The ros2_control_hardware parameter selects the hardware plugin: "mock" (default) or "mujoco".
+  -->
+  <xacro:macro name="fr3_robot" params="prefix parent_link xyz rpy ros2_control_hardware:=mock">
 
     <!-- Base joint connecting to parent -->
     <joint name="${prefix}base_joint" type="fixed">
@@ -369,13 +371,19 @@
       <dynamics damping="0.3"/>
     </joint>
 
-  <!-- ros2_control setup for mock hardware -->
+  <!-- ros2_control setup, either for mock hardware or MuJoCo simulation -->
   <ros2_control name="${prefix}name" type="system">
     <hardware>
-      <plugin>mock_components/GenericSystem</plugin>
-      <param name="mock_sensor_commands">false</param>
-      <param name="state_following_offset">0.0</param>
-      <param name="calculate_dynamics">true</param>
+      <xacro:if value="${ros2_control_hardware == 'mujoco'}">
+        <plugin>mujoco_ros2_control/MujocoSystemInterface</plugin>
+        <param name="mujoco_model_topic">/mujoco_robot_description</param>
+      </xacro:if>
+      <xacro:if value="${ros2_control_hardware == 'mock'}">
+        <plugin>mock_components/GenericSystem</plugin>
+        <param name="mock_sensor_commands">false</param>
+        <param name="state_following_offset">0.0</param>
+        <param name="calculate_dynamics">true</param>
+      </xacro:if>
     </hardware>
     <joint name="${prefix}fr3_joint1">
       <command_interface name="position"/>
@@ -471,6 +479,18 @@
     <joint name="${prefix}fr3_finger_joint1">
       <command_interface name="position"/>
       <command_interface name="velocity"/>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+    </joint>
+    <!-- Mimics fr3_finger_joint1, so it only has state interfaces. -->
+    <joint name="${prefix}fr3_finger_joint2" mimic="true">
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>


### PR DESCRIPTION
In preparation for a `mujoco_ros2_control` example on the `roboplan-ros` side.