### PR TITLE
Fixes for new Ubuntu 26.04 ROS Rolling docker

### DIFF
--- a/.docker/ros/ros_python_requirements_rolling.txt
+++ b/.docker/ros/ros_python_requirements_rolling.txt
@@ -1,7 +1,6 @@
 matplotlib
-numpy<2.0.0
+numpy
 opencv-contrib-python-headless
 plyfile
-typing_extensions==4.10.0
 tyro
 viser>=1.0.29

--- a/roboplan_oink/package.xml
+++ b/roboplan_oink/package.xml
@@ -16,7 +16,7 @@
 
   <depend>roboplan</depend>
   <!-- See https://github.com/tier4/osqp_vendor/issues/26 -->
-  <depend condition="$ROS_DISTRO != lyrical">osqp_vendor</depend>
+  <depend condition="$ROS_DISTRO != lyrical and $ROS_DISTRO != rolling">osqp_vendor</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>libgmock-dev</test_depend>


### PR DESCRIPTION
ROS Rolling docker image seems to have finally made it into Ubuntu 26.04! 