### PR TITLE
Fix Python bindings installs for ROS + Windows

### DIFF
--- a/.github/workflows/build-pypi-wheels.yml
+++ b/.github/workflows/build-pypi-wheels.yml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: read
 
+# Ensures that only one workflow runs at a time for this branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_version:
     name: Check package version

--- a/pixi.toml
+++ b/pixi.toml
@@ -206,7 +206,7 @@ test = { cmd = "ctest -V --test-dir build/{{ package_name }}", args = [
   { arg = "package_name" },
 ], env = { GTEST_COLOR = "YES" } }
 
-test_py  = { cmd = "python -m pytest --capture=no */bindings/test" }
+test_py  = { cmd = "python -m pytest --capture=no */bindings/test roboplan_examples/test" }
 test_cpp = { depends-on = [
   { task = "test", args = ["roboplan"] },
   { task = "test", args = ["roboplan_rrt"] },

--- a/roboplan/bindings/CMakeLists.txt
+++ b/roboplan/bindings/CMakeLists.txt
@@ -63,16 +63,22 @@ target_link_libraries(_core_ext PRIVATE
 
 # PEP 420 namespace package: no roboplan/__init__.py is shipped. Resolve the
 # Python install destination per build context:
-#   - colcon (ament): the site-packages dir (relative to the package's install
-#     prefix) that colcon's PYTHONPATH hook adds. We set this directly rather
-#     than via ament_get_python_install_dir(), which returns
-#     lib/python3/dist-packages on Debian-based ROS -- a path the hook omits.
+#   - colcon (ament): the dir (relative to the package's install prefix) that
+#     colcon's PYTHONPATH hook adds. Use ament_get_python_install_dir() so the
+#     layout matches on Windows (Lib/site-packages), falling back to
+#     site-packages on Debian-based ROS, where ament returns
+#     lib/python3/dist-packages -- a path the hook omits.
 #   - scikit-build wheel: the wheel root (".").
 #   - plain CMake into a prefix (pixi/conda, the Docker images): the
 #     interpreter's site-packages (absolute), so the package is importable.
 if(AMENT_BUILD)
-  set(PYTHON_DESTINATION
-      "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  ament_get_python_install_dir(_ament_python_dir)
+  if(_ament_python_dir MATCHES "dist-packages")
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  else()
+    set(PYTHON_DESTINATION "${_ament_python_dir}")
+  endif()
 elseif(SKBUILD)
   set(PYTHON_DESTINATION ".")
 else()

--- a/roboplan/bindings/python/roboplan/core/__init__.py
+++ b/roboplan/bindings/python/roboplan/core/__init__.py
@@ -1,3 +1,13 @@
 # The `roboplan.core` bindings, backed by the compiled `_core_ext` module.
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 from ._core_ext import *  # noqa: F401,F403
 from ._core_ext import __version__  # noqa: F401

--- a/roboplan/bindings/python/roboplan/filters/__init__.py
+++ b/roboplan/bindings/python/roboplan/filters/__init__.py
@@ -1,3 +1,13 @@
 # The `roboplan.filters` bindings, backed by the compiled `_filters_ext` module.
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 from ._filters_ext import *  # noqa: F401,F403
 from ._filters_ext import __version__  # noqa: F401

--- a/roboplan_cartesian_planning/bindings/CMakeLists.txt
+++ b/roboplan_cartesian_planning/bindings/CMakeLists.txt
@@ -47,16 +47,22 @@ target_link_libraries(_cartesian_ext PRIVATE
 )
 
 # Resolve the Python install destination per build context:
-#   - colcon (ament): the site-packages dir (relative to the package's install
-#     prefix) that colcon's PYTHONPATH hook adds. We set this directly rather
-#     than via ament_get_python_install_dir(), which returns
-#     lib/python3/dist-packages on Debian-based ROS -- a path the hook omits.
+#   - colcon (ament): the dir (relative to the package's install prefix) that
+#     colcon's PYTHONPATH hook adds. Use ament_get_python_install_dir() so the
+#     layout matches on Windows (Lib/site-packages), falling back to
+#     site-packages on Debian-based ROS, where ament returns
+#     lib/python3/dist-packages -- a path the hook omits.
 #   - scikit-build wheel: the wheel root (".").
 #   - plain CMake into a prefix (pixi/conda, the Docker images): the
 #     interpreter's site-packages (absolute), so the package is importable.
 if(AMENT_BUILD)
-  set(PYTHON_DESTINATION
-      "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  ament_get_python_install_dir(_ament_python_dir)
+  if(_ament_python_dir MATCHES "dist-packages")
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  else()
+    set(PYTHON_DESTINATION "${_ament_python_dir}")
+  endif()
 elseif(SKBUILD)
   set(PYTHON_DESTINATION ".")
 else()

--- a/roboplan_cartesian_planning/bindings/python/roboplan/cartesian_planning/__init__.py
+++ b/roboplan_cartesian_planning/bindings/python/roboplan/cartesian_planning/__init__.py
@@ -1,5 +1,15 @@
 # The `roboplan.cartesian_planning` bindings, backed by `_cartesian_ext`.
 # Import core first to guarantee its types are registered before use.
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 import roboplan.core  # noqa: F401
 
 from ._cartesian_ext import *  # noqa: E402,F401,F403

--- a/roboplan_example_models/bindings/CMakeLists.txt
+++ b/roboplan_example_models/bindings/CMakeLists.txt
@@ -41,16 +41,22 @@ target_link_libraries(_example_models_ext PRIVATE
 )
 
 # Resolve the Python install destination per build context:
-#   - colcon (ament): the site-packages dir (relative to the package's install
-#     prefix) that colcon's PYTHONPATH hook adds. We set this directly rather
-#     than via ament_get_python_install_dir(), which returns
-#     lib/python3/dist-packages on Debian-based ROS -- a path the hook omits.
+#   - colcon (ament): the dir (relative to the package's install prefix) that
+#     colcon's PYTHONPATH hook adds. Use ament_get_python_install_dir() so the
+#     layout matches on Windows (Lib/site-packages), falling back to
+#     site-packages on Debian-based ROS, where ament returns
+#     lib/python3/dist-packages -- a path the hook omits.
 #   - scikit-build wheel: the wheel root (".").
 #   - plain CMake into a prefix (pixi/conda, the Docker images): the
 #     interpreter's site-packages (absolute), so the package is importable.
 if(AMENT_BUILD)
-  set(PYTHON_DESTINATION
-      "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  ament_get_python_install_dir(_ament_python_dir)
+  if(_ament_python_dir MATCHES "dist-packages")
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  else()
+    set(PYTHON_DESTINATION "${_ament_python_dir}")
+  endif()
 elseif(SKBUILD)
   set(PYTHON_DESTINATION ".")
 else()

--- a/roboplan_example_models/bindings/python/roboplan/example_models/__init__.py
+++ b/roboplan_example_models/bindings/python/roboplan/example_models/__init__.py
@@ -1,3 +1,13 @@
 # The `roboplan.example_models` bindings, backed by `_example_models_ext`.
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 from ._example_models_ext import *  # noqa: F401,F403
 from ._example_models_ext import __version__  # noqa: F401

--- a/roboplan_examples/CMakeLists.txt
+++ b/roboplan_examples/CMakeLists.txt
@@ -31,5 +31,8 @@ add_subdirectory(python)
 # If ament_cmake is detected, export the package to be visible in ROS 2.
 if ( ament_cmake_FOUND )
     message(STATUS "ament_cmake found. Exporting for ROS 2.")
+    if(BUILD_TESTING)
+        add_subdirectory(test)
+    endif()
     ament_package()
 endif()

--- a/roboplan_examples/package.xml
+++ b/roboplan_examples/package.xml
@@ -19,6 +19,8 @@
 
   <exec_depend>xacro</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/roboplan_examples/test/CMakeLists.txt
+++ b/roboplan_examples/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+find_package(ament_cmake_pytest REQUIRED)
+ament_add_pytest_test(test_import_bindings test_import_bindings.py TIMEOUT 300)

--- a/roboplan_examples/test/test_import_bindings.py
+++ b/roboplan_examples/test/test_import_bindings.py
@@ -1,0 +1,25 @@
+"""
+Smoke test that the Python bindings of all roboplan packages are importable.
+
+This catches packaging issues for downstream packages that may use the bindings.
+"""
+
+import importlib
+
+import pytest
+
+BINDINGS_MODULES = [
+    "roboplan.cartesian_planning",
+    "roboplan.core",
+    "roboplan.example_models",
+    "roboplan.filters",
+    "roboplan.optimal_ik",
+    "roboplan.rrt",
+    "roboplan.simple_ik",
+    "roboplan.toppra",
+]
+
+
+@pytest.mark.parametrize("module", BINDINGS_MODULES)
+def test_import_bindings(module: str) -> None:
+    importlib.import_module(module)

--- a/roboplan_oink/bindings/CMakeLists.txt
+++ b/roboplan_oink/bindings/CMakeLists.txt
@@ -44,16 +44,22 @@ target_link_libraries(_optimal_ik_ext PRIVATE
 )
 
 # Resolve the Python install destination per build context:
-#   - colcon (ament): the site-packages dir (relative to the package's install
-#     prefix) that colcon's PYTHONPATH hook adds. We set this directly rather
-#     than via ament_get_python_install_dir(), which returns
-#     lib/python3/dist-packages on Debian-based ROS -- a path the hook omits.
+#   - colcon (ament): the dir (relative to the package's install prefix) that
+#     colcon's PYTHONPATH hook adds. Use ament_get_python_install_dir() so the
+#     layout matches on Windows (Lib/site-packages), falling back to
+#     site-packages on Debian-based ROS, where ament returns
+#     lib/python3/dist-packages -- a path the hook omits.
 #   - scikit-build wheel: the wheel root (".").
 #   - plain CMake into a prefix (pixi/conda, the Docker images): the
 #     interpreter's site-packages (absolute), so the package is importable.
 if(AMENT_BUILD)
-  set(PYTHON_DESTINATION
-      "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  ament_get_python_install_dir(_ament_python_dir)
+  if(_ament_python_dir MATCHES "dist-packages")
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  else()
+    set(PYTHON_DESTINATION "${_ament_python_dir}")
+  endif()
 elseif(SKBUILD)
   set(PYTHON_DESTINATION ".")
 else()

--- a/roboplan_oink/bindings/python/roboplan/optimal_ik/__init__.py
+++ b/roboplan_oink/bindings/python/roboplan/optimal_ik/__init__.py
@@ -1,5 +1,15 @@
 # The `roboplan.optimal_ik` bindings, backed by `_optimal_ik_ext`.
 # Import core first to guarantee its types are registered before use.
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 import roboplan.core  # noqa: F401
 
 from ._optimal_ik_ext import *  # noqa: E402,F401,F403

--- a/roboplan_rrt/bindings/CMakeLists.txt
+++ b/roboplan_rrt/bindings/CMakeLists.txt
@@ -43,16 +43,22 @@ target_link_libraries(_rrt_ext PRIVATE
 )
 
 # Resolve the Python install destination per build context:
-#   - colcon (ament): the site-packages dir (relative to the package's install
-#     prefix) that colcon's PYTHONPATH hook adds. We set this directly rather
-#     than via ament_get_python_install_dir(), which returns
-#     lib/python3/dist-packages on Debian-based ROS -- a path the hook omits.
+#   - colcon (ament): the dir (relative to the package's install prefix) that
+#     colcon's PYTHONPATH hook adds. Use ament_get_python_install_dir() so the
+#     layout matches on Windows (Lib/site-packages), falling back to
+#     site-packages on Debian-based ROS, where ament returns
+#     lib/python3/dist-packages -- a path the hook omits.
 #   - scikit-build wheel: the wheel root (".").
 #   - plain CMake into a prefix (pixi/conda, the Docker images): the
 #     interpreter's site-packages (absolute), so the package is importable.
 if(AMENT_BUILD)
-  set(PYTHON_DESTINATION
-      "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  ament_get_python_install_dir(_ament_python_dir)
+  if(_ament_python_dir MATCHES "dist-packages")
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  else()
+    set(PYTHON_DESTINATION "${_ament_python_dir}")
+  endif()
 elseif(SKBUILD)
   set(PYTHON_DESTINATION ".")
 else()

--- a/roboplan_rrt/bindings/python/roboplan/rrt/__init__.py
+++ b/roboplan_rrt/bindings/python/roboplan/rrt/__init__.py
@@ -1,3 +1,13 @@
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 import numpy as np
 from pinocchio.visualize import ViserVisualizer
 

--- a/roboplan_simple_ik/bindings/CMakeLists.txt
+++ b/roboplan_simple_ik/bindings/CMakeLists.txt
@@ -43,16 +43,22 @@ target_link_libraries(_simple_ik_ext PRIVATE
 )
 
 # Resolve the Python install destination per build context:
-#   - colcon (ament): the site-packages dir (relative to the package's install
-#     prefix) that colcon's PYTHONPATH hook adds. We set this directly rather
-#     than via ament_get_python_install_dir(), which returns
-#     lib/python3/dist-packages on Debian-based ROS -- a path the hook omits.
+#   - colcon (ament): the dir (relative to the package's install prefix) that
+#     colcon's PYTHONPATH hook adds. Use ament_get_python_install_dir() so the
+#     layout matches on Windows (Lib/site-packages), falling back to
+#     site-packages on Debian-based ROS, where ament returns
+#     lib/python3/dist-packages -- a path the hook omits.
 #   - scikit-build wheel: the wheel root (".").
 #   - plain CMake into a prefix (pixi/conda, the Docker images): the
 #     interpreter's site-packages (absolute), so the package is importable.
 if(AMENT_BUILD)
-  set(PYTHON_DESTINATION
-      "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  ament_get_python_install_dir(_ament_python_dir)
+  if(_ament_python_dir MATCHES "dist-packages")
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  else()
+    set(PYTHON_DESTINATION "${_ament_python_dir}")
+  endif()
 elseif(SKBUILD)
   set(PYTHON_DESTINATION ".")
 else()

--- a/roboplan_simple_ik/bindings/python/roboplan/simple_ik/__init__.py
+++ b/roboplan_simple_ik/bindings/python/roboplan/simple_ik/__init__.py
@@ -1,5 +1,15 @@
 # The `roboplan.simple_ik` bindings, backed by `_simple_ik_ext`.
 # Import core first to guarantee its types are registered before use.
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 import roboplan.core  # noqa: F401
 
 from ._simple_ik_ext import *  # noqa: E402,F401,F403

--- a/roboplan_toppra/bindings/CMakeLists.txt
+++ b/roboplan_toppra/bindings/CMakeLists.txt
@@ -44,16 +44,22 @@ target_link_libraries(_toppra_ext PRIVATE
 )
 
 # Resolve the Python install destination per build context:
-#   - colcon (ament): the site-packages dir (relative to the package's install
-#     prefix) that colcon's PYTHONPATH hook adds. We set this directly rather
-#     than via ament_get_python_install_dir(), which returns
-#     lib/python3/dist-packages on Debian-based ROS -- a path the hook omits.
+#   - colcon (ament): the dir (relative to the package's install prefix) that
+#     colcon's PYTHONPATH hook adds. Use ament_get_python_install_dir() so the
+#     layout matches on Windows (Lib/site-packages), falling back to
+#     site-packages on Debian-based ROS, where ament returns
+#     lib/python3/dist-packages -- a path the hook omits.
 #   - scikit-build wheel: the wheel root (".").
 #   - plain CMake into a prefix (pixi/conda, the Docker images): the
 #     interpreter's site-packages (absolute), so the package is importable.
 if(AMENT_BUILD)
-  set(PYTHON_DESTINATION
-      "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  ament_get_python_install_dir(_ament_python_dir)
+  if(_ament_python_dir MATCHES "dist-packages")
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  else()
+    set(PYTHON_DESTINATION "${_ament_python_dir}")
+  endif()
 elseif(SKBUILD)
   set(PYTHON_DESTINATION ".")
 else()

--- a/roboplan_toppra/bindings/python/roboplan/toppra/__init__.py
+++ b/roboplan_toppra/bindings/python/roboplan/toppra/__init__.py
@@ -1,5 +1,15 @@
 # The `roboplan.toppra` bindings, backed by `_toppra_ext`.
 # Import core first to guarantee its types are registered before use.
+import os
+
+# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
+# module links against, and in a colcon workspace they live outside this
+# package. Register the PATH entries explicitly before importing.
+if os.name == "nt":
+    for _entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _entry and os.path.isdir(_entry):
+            os.add_dll_directory(_entry)
+
 import roboplan.core  # noqa: F401
 
 from ._toppra_ext import *  # noqa: E402,F401,F403


### PR DESCRIPTION
Fixes a lingering issue with Python bindings installs on ROS + Windows, found with `roboplan-ros`.

Apparently even Pinocchio does stuff like this: https://github.com/stack-of-tasks/pinocchio/blob/f101785266e5367969c22103e2b5a3b59e5ace27/bindings/python/pinocchio/windows_dll_manager.py#L19

Also adds a smoke test to verify this problem pre-emptively.