### PR TITLE
Improve OInK build times

### DIFF
--- a/roboplan_oink/CMakeLists.txt
+++ b/roboplan_oink/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 # Add libraries
 add_library(roboplan_oink SHARED
     src/optimal_ik.cpp
+    src/qp_backend.cpp
     src/tasks/frame.cpp
     src/tasks/configuration.cpp
     src/constraints/position_limit.cpp

--- a/roboplan_oink/include/roboplan_oink/detail/qp_solver_fwd.hpp
+++ b/roboplan_oink/include/roboplan_oink/detail/qp_solver_fwd.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+
+// Forward declaration of the ProxQP dense solver. The solver is a private implementation
+// detail of roboplan_oink; consumers of this header never need the proxsuite headers.
+namespace proxsuite::proxqp::dense {
+template <typename T> struct QP;
+}  // namespace proxsuite::proxqp::dense
+
+namespace roboplan::detail {
+
+/// @brief Deleter for the forward-declared ProxQP solver.
+///
+/// Defined out-of-line in qp_backend.cpp, where the complete solver type is available.
+/// This lets Oink hold the solver through a unique_ptr without instantiating the
+/// (compile-time expensive) proxsuite templates in every translation unit that
+/// constructs or destroys an Oink.
+struct QpDeleter {
+  void operator()(proxsuite::proxqp::dense::QP<double>* solver) const;
+};
+
+/// @brief Owning handle to the ProxQP dense solver, usable with an incomplete solver type.
+using QpSolverPtr = std::unique_ptr<proxsuite::proxqp::dense::QP<double>, QpDeleter>;
+
+}  // namespace roboplan::detail

--- a/roboplan_oink/include/roboplan_oink/oink_settings.hpp
+++ b/roboplan_oink/include/roboplan_oink/oink_settings.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace roboplan {
+
+/// @brief Solver settings for the Oink QP solver (ProxQP).
+///
+/// This is a solver-agnostic subset of the underlying ProxQP settings. See
+/// https://simple-robotics.github.io/proxsuite/ for the semantics of the tolerances.
+struct OinkSettings {
+  /// Absolute stopping tolerance on the primal/dual residuals.
+  double eps_abs = 1e-6;
+  /// Relative stopping tolerance on the primal/dual residuals (0 disables it).
+  double eps_rel = 0.0;
+  /// Maximum number of solver iterations.
+  int max_iter = 10000;
+  /// Print solver internals to stdout.
+  bool verbose = false;
+  /// Warm start each solve with the previous solution (recommended for control loops).
+  bool warm_start = true;
+  /// When the QP is primal-infeasible (e.g., a violated barrier conflicting with velocity
+  /// limits), solve the closest feasible problem in the least-squares sense instead of
+  /// failing. This guarantees that solveIk() always returns a usable displacement.
+  bool primal_infeasibility_solving = true;
+};
+
+}  // namespace roboplan

--- a/roboplan_oink/include/roboplan_oink/optimal_ik.hpp
+++ b/roboplan_oink/include/roboplan_oink/optimal_ik.hpp
@@ -10,37 +10,13 @@
 #include <roboplan/core/scene.hpp>
 #include <roboplan/core/types.hpp>
 
-// Forward declaration of the ProxQP dense solver. The solver is a private implementation
-// detail of roboplan_oink; consumers of this header never need the proxsuite headers.
-namespace proxsuite::proxqp::dense {
-template <typename T> struct QP;
-}  // namespace proxsuite::proxqp::dense
+#include <roboplan_oink/detail/qp_solver_fwd.hpp>
+#include <roboplan_oink/oink_settings.hpp>
 
 namespace roboplan {
 
 /// @brief Infinity value used for unbounded QP constraint bounds.
 constexpr double kInfinity = std::numeric_limits<double>::infinity();
-
-/// @brief Solver settings for the Oink QP solver (ProxQP).
-///
-/// This is a solver-agnostic subset of the underlying ProxQP settings. See
-/// https://simple-robotics.github.io/proxsuite/ for the semantics of the tolerances.
-struct OinkSettings {
-  /// Absolute stopping tolerance on the primal/dual residuals.
-  double eps_abs = 1e-6;
-  /// Relative stopping tolerance on the primal/dual residuals (0 disables it).
-  double eps_rel = 0.0;
-  /// Maximum number of solver iterations.
-  int max_iter = 10000;
-  /// Print solver internals to stdout.
-  bool verbose = false;
-  /// Warm start each solve with the previous solution (recommended for control loops).
-  bool warm_start = true;
-  /// When the QP is primal-infeasible (e.g., a violated barrier conflicting with velocity
-  /// limits), solve the closest feasible problem in the least-squares sense instead of
-  /// failing. This guarantees that solveIk() always returns a usable displacement.
-  bool primal_infeasibility_solving = true;
-};
 
 /// @brief Abstract base class for IK tasks.
 ///
@@ -309,7 +285,6 @@ struct Oink {
   Oink(const Scene& scene, const OinkSettings& custom_settings)
       : Oink(scene, "", custom_settings) {}
 
-  /// Out-of-line destructor required because the ProxQP solver is only forward-declared here.
   ~Oink();
 
   /// @brief Solve inverse kinematics for tasks only
@@ -446,7 +421,7 @@ private:
 public:
   // QP solver (ProxQP dense backend). Reconstructed whenever the constraint row count
   // changes, since ProxQP fixes the problem dimensions at construction.
-  std::unique_ptr<proxsuite::proxqp::dense::QP<double>> solver;
+  detail::QpSolverPtr solver;
   OinkSettings settings;
 
   // Problem dimensions

--- a/roboplan_oink/include/roboplan_oink/qp_backend.hpp
+++ b/roboplan_oink/include/roboplan_oink/qp_backend.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+#include <Eigen/Core>
+#include <tl/expected.hpp>
+
+#include <roboplan_oink/detail/qp_solver_fwd.hpp>
+#include <roboplan_oink/oink_settings.hpp>
+
+// Private interface to the ProxQP dense backend. This header deliberately avoids the
+// roboplan scene/pinocchio headers so that qp_backend.cpp -- the only translation unit
+// that instantiates the (compile-time expensive) proxsuite solver templates -- stays
+// cheap to parse, and optimal_ik.cpp never sees the proxsuite headers at all.
+namespace roboplan::detail {
+
+/// @brief Initialize/update the ProxQP solver with the assembled QP and solve it.
+///
+/// @param solver The solver handle. (Re)constructed in place when init_required is true.
+/// @param settings Oink solver settings applied when the solver is (re)constructed.
+/// @param init_required Rebuild the solver (ProxQP fixes problem dimensions at construction).
+/// @param num_variables Number of decision variables.
+/// @param total_rows Number of inequality rows in A/lower/upper (0 for unconstrained).
+/// @param H Quadratic objective matrix (num_variables x num_variables).
+/// @param c Linear objective vector (num_variables).
+/// @param A Inequality constraint matrix (total_rows x num_variables).
+/// @param lower Inequality lower bounds (total_rows).
+/// @param upper Inequality upper bounds (total_rows).
+/// @param delta_q Pre-allocated output buffer for the solution.
+/// @return void on success, error message on failure.
+tl::expected<void, std::string>
+solveQp(QpSolverPtr& solver, const OinkSettings& settings, bool init_required, int num_variables,
+        int total_rows, const Eigen::MatrixXd& H, const Eigen::VectorXd& c,
+        const Eigen::MatrixXd& A, const Eigen::VectorXd& lower, const Eigen::VectorXd& upper,
+        Eigen::Ref<Eigen::VectorXd, 0, Eigen::InnerStride<Eigen::Dynamic>> delta_q);
+
+}  // namespace roboplan::detail

--- a/roboplan_oink/src/optimal_ik.cpp
+++ b/roboplan_oink/src/optimal_ik.cpp
@@ -2,8 +2,8 @@
 #include <limits>
 
 #include <pinocchio/algorithm/joint-configuration.hpp>
-#include <proxsuite/proxqp/dense/dense.hpp>
 #include <roboplan_oink/optimal_ik.hpp>
+#include <roboplan_oink/qp_backend.hpp>
 
 namespace {
 // Minimum squared norm threshold to avoid division by zero in barrier regularization
@@ -169,8 +169,6 @@ Oink::Oink(const Scene& scene, const std::string& group_name)
   collision_context_ = std::make_unique<CollisionContext>(scene);
 }
 
-// Defined here (not in the header) because proxsuite::proxqp::dense::QP is only
-// forward-declared in the header.
 Oink::~Oink() = default;
 
 tl::expected<void, std::string>
@@ -336,75 +334,9 @@ Oink::solveIk(const Scene& scene, const std::vector<std::shared_ptr<Task>>& task
   constraint_sizes.clear();
   barrier_sizes.clear();
 
-  using proxsuite::nullopt;
-  using proxsuite::proxqp::InitialGuessStatus;
-  using proxsuite::proxqp::QPSolverOutput;
-
-  if (init_required) {
-    // ProxQP fixes the problem dimensions at construction, so the solver is rebuilt
-    // whenever the number of constraint rows changes.
-    solver = std::make_unique<proxsuite::proxqp::dense::QP<double>>(num_variables, /*n_eq=*/0,
-                                                                    /*n_in=*/total_rows);
-    solver->settings.eps_abs = settings.eps_abs;
-    solver->settings.eps_rel = settings.eps_rel;
-    solver->settings.max_iter = settings.max_iter;
-    solver->settings.verbose = settings.verbose;
-    solver->settings.primal_infeasibility_solving = settings.primal_infeasibility_solving;
-    solver->settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
-
-    if (total_rows > 0) {
-      solver->init(H, c, nullopt, nullopt, constraint_workspace_A, constraint_workspace_lower,
-                   constraint_workspace_upper);
-    } else {
-      solver->init(H, c, nullopt, nullopt, nullopt, nullopt, nullopt);
-    }
-  } else {
-    if (total_rows > 0) {
-      solver->update(H, c, nullopt, nullopt, constraint_workspace_A, constraint_workspace_lower,
-                     constraint_workspace_upper);
-    } else {
-      solver->update(H, c, nullopt, nullopt, nullopt, nullopt, nullopt);
-    }
-  }
-
-  solver->solve();
-
-  // PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE is returned when the QP was primal-infeasible and
-  // settings.primal_infeasibility_solving is enabled: the solution minimizes the constraint
-  // violation in the least-squares sense and is the safest displacement available.
-  const QPSolverOutput status = solver->results.info.status;
-  if (status != QPSolverOutput::PROXQP_SOLVED &&
-      status != QPSolverOutput::PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE) {
-    // The solve did not converge, so results.x is not a trustworthy displacement. Reset the
-    // initial guess so a subsequent solveIk() does not warm start from this bad solution (the
-    // equivalent of OsqpEigen::Solver::clearSolverVariables()).
-    solver->settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
-    switch (status) {
-    case QPSolverOutput::PROXQP_MAX_ITER_REACHED:
-      return tl::make_unexpected("QP solver reached the maximum number of iterations");
-    case QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE:
-      return tl::make_unexpected(
-          "QP is primal infeasible (constraints and barriers cannot be satisfied "
-          "simultaneously). Enable OinkSettings::primal_infeasibility_solving to compute the "
-          "closest feasible solution instead.");
-    case QPSolverOutput::PROXQP_DUAL_INFEASIBLE:
-      return tl::make_unexpected("QP is dual infeasible (objective unbounded below)");
-    default:
-      return tl::make_unexpected("QP solver failed to find a solution");
-    }
-  }
-
-  // Warm start subsequent solves with the previous solution. This must only be enabled
-  // after a successful solve has populated the results and factorization; enabling it before
-  // the first solve (or after a failed one) makes ProxQP reuse a factorization/solution that
-  // was never validly computed.
-  if (settings.warm_start) {
-    solver->settings.initial_guess = InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
-  }
-
-  // Extract the solution and copy into delta_q
-  delta_q.noalias() = solver->results.x;
-  return {};
+  return detail::solveQp(solver, settings, init_required, num_variables, total_rows, H, c,
+                         constraint_workspace_A, constraint_workspace_lower,
+                         constraint_workspace_upper, delta_q);
 }
 
 // Overload: tasks only
@@ -444,8 +376,11 @@ Oink::enforceBarriers(const Scene& scene, const std::vector<std::shared_ptr<Barr
   const auto& model = scene.getModel();
   const Eigen::VectorXd& q = scene.getCurrentJointPositions();
 
-  // Compute candidate configuration by integrating delta_q
-  const Eigen::VectorXd q_candidate = pinocchio::integrate(model, q, delta_q);
+  // Compute candidate configuration by integrating delta_q. The copy into a plain VectorXd
+  // makes the call match pinocchio's pre-instantiated integrate() signature, so this TU does
+  // not instantiate the joint-visitor templates itself.
+  const Eigen::VectorXd dq(delta_q);
+  const Eigen::VectorXd q_candidate = pinocchio::integrate(model, q, dq);
 
   // Evaluate all barriers at the candidate configuration. enforce_barriers_data is a
   // pre-allocated pinocchio::Data scoped to this method, so we don't mutate scene state.

--- a/roboplan_oink/src/qp_backend.cpp
+++ b/roboplan_oink/src/qp_backend.cpp
@@ -1,0 +1,83 @@
+#include <roboplan_oink/qp_backend.hpp>
+
+#include <proxsuite/proxqp/dense/dense.hpp>
+
+namespace roboplan::detail {
+
+void QpDeleter::operator()(proxsuite::proxqp::dense::QP<double>* solver) const { delete solver; }
+
+tl::expected<void, std::string>
+solveQp(QpSolverPtr& solver, const OinkSettings& settings, bool init_required, int num_variables,
+        int total_rows, const Eigen::MatrixXd& H, const Eigen::VectorXd& c,
+        const Eigen::MatrixXd& A, const Eigen::VectorXd& lower, const Eigen::VectorXd& upper,
+        Eigen::Ref<Eigen::VectorXd, 0, Eigen::InnerStride<Eigen::Dynamic>> delta_q) {
+  using proxsuite::nullopt;
+  using proxsuite::proxqp::InitialGuessStatus;
+  using proxsuite::proxqp::QPSolverOutput;
+
+  if (init_required) {
+    // ProxQP fixes the problem dimensions at construction, so the solver is rebuilt
+    // whenever the number of constraint rows changes.
+    solver.reset(new proxsuite::proxqp::dense::QP<double>(num_variables, /*n_eq=*/0,
+                                                          /*n_in=*/total_rows));
+    solver->settings.eps_abs = settings.eps_abs;
+    solver->settings.eps_rel = settings.eps_rel;
+    solver->settings.max_iter = settings.max_iter;
+    solver->settings.verbose = settings.verbose;
+    solver->settings.primal_infeasibility_solving = settings.primal_infeasibility_solving;
+    solver->settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+
+    if (total_rows > 0) {
+      solver->init(H, c, nullopt, nullopt, A, lower, upper);
+    } else {
+      solver->init(H, c, nullopt, nullopt, nullopt, nullopt, nullopt);
+    }
+  } else {
+    if (total_rows > 0) {
+      solver->update(H, c, nullopt, nullopt, A, lower, upper);
+    } else {
+      solver->update(H, c, nullopt, nullopt, nullopt, nullopt, nullopt);
+    }
+  }
+
+  solver->solve();
+
+  // PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE is returned when the QP was primal-infeasible and
+  // settings.primal_infeasibility_solving is enabled: the solution minimizes the constraint
+  // violation in the least-squares sense and is the safest displacement available.
+  const QPSolverOutput status = solver->results.info.status;
+  if (status != QPSolverOutput::PROXQP_SOLVED &&
+      status != QPSolverOutput::PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE) {
+    // The solve did not converge, so results.x is not a trustworthy displacement. Reset the
+    // initial guess so a subsequent solveIk() does not warm start from this bad solution (the
+    // equivalent of OsqpEigen::Solver::clearSolverVariables()).
+    solver->settings.initial_guess = InitialGuessStatus::NO_INITIAL_GUESS;
+    switch (status) {
+    case QPSolverOutput::PROXQP_MAX_ITER_REACHED:
+      return tl::make_unexpected("QP solver reached the maximum number of iterations");
+    case QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE:
+      return tl::make_unexpected(
+          "QP is primal infeasible (constraints and barriers cannot be satisfied "
+          "simultaneously). Enable OinkSettings::primal_infeasibility_solving to compute the "
+          "closest feasible solution instead.");
+    case QPSolverOutput::PROXQP_DUAL_INFEASIBLE:
+      return tl::make_unexpected("QP is dual infeasible (objective unbounded below)");
+    default:
+      return tl::make_unexpected("QP solver failed to find a solution");
+    }
+  }
+
+  // Warm start subsequent solves with the previous solution. This must only be enabled
+  // after a successful solve has populated the results and factorization; enabling it before
+  // the first solve (or after a failed one) makes ProxQP reuse a factorization/solution that
+  // was never validly computed.
+  if (settings.warm_start) {
+    solver->settings.initial_guess = InitialGuessStatus::WARM_START_WITH_PREVIOUS_RESULT;
+  }
+
+  // Extract the solution and copy into delta_q
+  delta_q.noalias() = solver->results.x;
+  return {};
+}
+
+}  // namespace roboplan::detail


### PR DESCRIPTION
Not clear whether this is worth it or we should just... stay with what we have and leave the code less complicated.

Anyway, moved the ProxQP backend to its own translation unit to speed up builds -- and more critically, rebuilds.

Look at the "edit src/optimal_ik.cpp" and "edit include/optimal_ik.hpp" rows at the end.

```
  ┌─────────────────────────────┬──────────────┬──────────────┬─────────┐
  │          Scenario           │     main     │   PR #273    │ Speedup │
  ├─────────────────────────────┼──────────────┼──────────────┼─────────┤
  │ cmake configure             │ 1.06s ±0.08  │ 1.10s ±0.11  │ —       │
  ├─────────────────────────────┼──────────────┼──────────────┼─────────┤
  │ Clean build (-j16)          │ 22.28s ±0.26 │ 15.13s ±1.57 │ 1.47×   │
  ├─────────────────────────────┼──────────────┼──────────────┼─────────┤
  │ Clean build (-j4)           │ 34.97s       │ 35.03s       │ 1.00×   │
  ├─────────────────────────────┼──────────────┼──────────────┼─────────┤
  │ Clean build (-j1)           │ 116.6s       │ 116.6s       │ 1.00×   │
  ├─────────────────────────────┼──────────────┼──────────────┼─────────┤
  │ No-op rebuild               │ 0.01s        │ 0.01s        │ —       │
  ├─────────────────────────────┼──────────────┼──────────────┼─────────┤
  │ Edit src/optimal_ik.cpp     │ 20.10s ±0.10 │ 8.53s ±0.97  │ 2.36×   │
  ├─────────────────────────────┼──────────────┼──────────────┼─────────┤
  │ Edit include/optimal_ik.hpp │ 22.87s ±1.74 │ 12.88s ±0.37 │ 1.78×   │
  └─────────────────────────────┴──────────────┴──────────────┴─────────┘
```