### PR TITLE
Improve Cartesian path planner

### DIFF
--- a/roboplan/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan/bindings/python/roboplan/core/_core_ext.pyi
@@ -450,6 +450,11 @@ class Scene:
         Integrates a velocity vector from a configuration using Lie group operations.
         """
 
+    def difference(self, q_start: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], q_end: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
+        """
+        Computes the velocity vector taking one configuration to another, using Lie group operations. The inverse of integrate().
+        """
+
     def forwardKinematics(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], frame_name: str, base_frame: str = '') -> Annotated[NDArray[numpy.float64], dict(shape=(4, 4), order='F')]:
         """Calculates forward kinematics for a specific frame."""
 

--- a/roboplan/bindings/src/core.cpp
+++ b/roboplan/bindings/src/core.cpp
@@ -223,6 +223,10 @@ void init_core_scene(nanobind::module_& m) {
       .def("integrate", &Scene::integrate,
            "Integrates a velocity vector from a configuration using Lie group operations.", "q"_a,
            "v"_a)
+      .def("difference", &Scene::difference,
+           "Computes the velocity vector taking one configuration to another, using Lie group "
+           "operations. The inverse of integrate().",
+           "q_start"_a, "q_end"_a)
       .def("forwardKinematics", &Scene::forwardKinematics,
            "Calculates forward kinematics for a specific frame.", "q"_a, "frame_name"_a,
            "base_frame"_a = "")

--- a/roboplan/include/roboplan/core/scene.hpp
+++ b/roboplan/include/roboplan/core/scene.hpp
@@ -170,6 +170,12 @@ public:
   /// @return The resulting joint configuration after integration.
   Eigen::VectorXd integrate(const Eigen::VectorXd& q, const Eigen::VectorXd& v) const;
 
+  /// @brief Computes the difference between two configurations, using Lie group operations.
+  /// @param q_start The starting joint configuration (size model.nq).
+  /// @param q_end The ending joint configuration (size model.nq).
+  /// @return The displacement from `q_start` to `q_end` (size model.nv).
+  Eigen::VectorXd difference(const Eigen::VectorXd& q_start, const Eigen::VectorXd& q_end) const;
+
   /// @brief Calculates forward kinematics for a specific frame.
   /// @param q The joint configuration.
   /// @param frame_name The name of the frame for which to perform forward kinematics.

--- a/roboplan/src/core/scene.cpp
+++ b/roboplan/src/core/scene.cpp
@@ -465,6 +465,11 @@ Eigen::VectorXd Scene::integrate(const Eigen::VectorXd& q, const Eigen::VectorXd
   return pinocchio::integrate(model_, q, v);
 }
 
+Eigen::VectorXd Scene::difference(const Eigen::VectorXd& q_start,
+                                  const Eigen::VectorXd& q_end) const {
+  return pinocchio::difference(model_, q_start, q_end);
+}
+
 Eigen::Matrix4d Scene::forwardKinematics(const Eigen::VectorXd& q, const std::string& frame_name,
                                          const std::string& base_frame) const {
   const auto maybe_frame_id = getFrameId(frame_name);

--- a/roboplan_cartesian_planning/bindings/python/roboplan/cartesian_planning/_cartesian_ext.pyi
+++ b/roboplan_cartesian_planning/bindings/python/roboplan/cartesian_planning/_cartesian_ext.pyi
@@ -20,7 +20,7 @@ class CartesianSpeedMode(enum.Enum):
 class CartesianPlannerOptions:
     """Options for the Cartesian path planner."""
 
-    def __init__(self, group_name: str = '', dt: float = 0.01, speed_mode: CartesianSpeedMode = CartesianSpeedMode.Bounded, max_linear_speed: float = 0.1, max_angular_speed: float = 0.5, max_linear_acceleration: float = 0.5, max_angular_acceleration: float = 2.5, max_position_error: float = 0.005, max_orientation_error: float = 0.01, position_cost: float = 1.0, orientation_cost: float = 1.0, task_gain: float = 1.0, lm_damping: float = 0.01, regularization: float = 1e-06, config_task_weight: float = 0.05, velocity_scale: float = 1.0, acceleration_scale: float = 1.0, limit_ratio_tolerance: float = 1.05, toppra_blend_deviation: float = 0.05, toppra_waypoint_spacing: float = 0.005, position_limit_gain: float = 1.0, max_attempts_per_step: int = 16) -> None: ...
+    def __init__(self, group_name: str = '', dt: float = 0.01, speed_mode: CartesianSpeedMode = CartesianSpeedMode.Bounded, max_linear_speed: float = 0.1, max_angular_speed: float = 0.5, max_linear_acceleration: float = 0.5, max_angular_acceleration: float = 2.5, max_position_error: float = 0.005, max_orientation_error: float = 0.01, position_cost: float = 1.0, orientation_cost: float = 1.0, task_gain: float = 1.0, lm_damping: float = 0.01, regularization: float = 1e-06, config_task_weight: float = 0.05, velocity_scale: float = 1.0, acceleration_scale: float = 1.0, toppra_blend_deviation: float = 0.05, position_limit_gain: float = 1.0) -> None: ...
 
     @property
     def group_name(self) -> str:
@@ -137,38 +137,20 @@ class CartesianPlannerOptions:
     @property
     def acceleration_scale(self) -> float:
         """
-        Scaling factor for joint acceleration limits (TimeOptimal re-timing and Bounded joint-acceleration throttle).
+        Scaling factor for joint acceleration limits, applied by the TOPP-RA re-timing.
         """
 
     @acceleration_scale.setter
     def acceleration_scale(self, arg: float, /) -> None: ...
 
     @property
-    def limit_ratio_tolerance(self) -> float:
-        """
-        Acceptance tolerance (>= 1.0) for the Bounded mode's slow-down retry; the peak velocity/acceleration ratios may exceed the (scaled) limits by up to this factor.
-        """
-
-    @limit_ratio_tolerance.setter
-    def limit_ratio_tolerance(self, arg: float, /) -> None: ...
-
-    @property
     def toppra_blend_deviation(self) -> float:
         """
-        Corner-rounding tolerance (rad) for the TimeOptimal mode's TOPP-RA line+blend geometry.
+        Corner-rounding tolerance (rad) for the TOPP-RA line+blend geometry; also sets how far the resolved path may be decimated before re-timing.
         """
 
     @toppra_blend_deviation.setter
     def toppra_blend_deviation(self, arg: float, /) -> None: ...
-
-    @property
-    def toppra_waypoint_spacing(self) -> float:
-        """
-        Spacing (m of tool travel) between the waypoints handed to TOPP-RA in TimeOptimal mode; the dense diff-IK trace is resampled to this spacing so servo jitter does not dominate the blend corner angles. <= 0 disables the resampling.
-        """
-
-    @toppra_waypoint_spacing.setter
-    def toppra_waypoint_spacing(self, arg: float, /) -> None: ...
 
     @property
     def position_limit_gain(self) -> float:
@@ -176,13 +158,6 @@ class CartesianPlannerOptions:
 
     @position_limit_gain.setter
     def position_limit_gain(self, arg: float, /) -> None: ...
-
-    @property
-    def max_attempts_per_step(self) -> int:
-        """Maximum feedrate-throttling attempts per control step."""
-
-    @max_attempts_per_step.setter
-    def max_attempts_per_step(self, arg: int, /) -> None: ...
 
 class CartesianPlannerComponents:
     """

--- a/roboplan_cartesian_planning/bindings/src/cartesian_path_planner.cpp
+++ b/roboplan_cartesian_planning/bindings/src/cartesian_path_planner.cpp
@@ -30,16 +30,15 @@ void init_cartesian_path_planner(nanobind::module_& m) {
                                             "Options for the Cartesian path planner.")
       .def(nanobind::init<std::string, double, CartesianSpeedMode, double, double, double, double,
                           double, double, double, double, double, double, double, double, double,
-                          double, double, double, double, double, int>(),
+                          double, double, double>(),
            "group_name"_a = "", "dt"_a = 0.01, "speed_mode"_a = CartesianSpeedMode::Bounded,
            "max_linear_speed"_a = 0.1, "max_angular_speed"_a = 0.5,
            "max_linear_acceleration"_a = 0.5, "max_angular_acceleration"_a = 2.5,
            "max_position_error"_a = 0.005, "max_orientation_error"_a = 0.01,
            "position_cost"_a = 1.0, "orientation_cost"_a = 1.0, "task_gain"_a = 1.0,
            "lm_damping"_a = 0.01, "regularization"_a = 1e-6, "config_task_weight"_a = 0.05,
-           "velocity_scale"_a = 1.0, "acceleration_scale"_a = 1.0, "limit_ratio_tolerance"_a = 1.05,
-           "toppra_blend_deviation"_a = 0.05, "toppra_waypoint_spacing"_a = 0.005,
-           "position_limit_gain"_a = 1.0, "max_attempts_per_step"_a = 16)
+           "velocity_scale"_a = 1.0, "acceleration_scale"_a = 1.0,
+           "toppra_blend_deviation"_a = 0.05, "position_limit_gain"_a = 1.0)
       .def_rw("group_name", &CartesianPlannerOptions::group_name, "Joint group name.")
       .def_rw("dt", &CartesianPlannerOptions::dt, "Output trajectory sample period (s).")
       .def_rw("speed_mode", &CartesianPlannerOptions::speed_mode, "Speed/timing strategy.")
@@ -69,22 +68,12 @@ void init_cartesian_path_planner(nanobind::module_& m) {
       .def_rw("velocity_scale", &CartesianPlannerOptions::velocity_scale,
               "Scaling factor for joint velocity limits.")
       .def_rw("acceleration_scale", &CartesianPlannerOptions::acceleration_scale,
-              "Scaling factor for joint acceleration limits (TimeOptimal re-timing and Bounded "
-              "joint-acceleration throttle).")
-      .def_rw("limit_ratio_tolerance", &CartesianPlannerOptions::limit_ratio_tolerance,
-              "Acceptance tolerance (>= 1.0) for the Bounded mode's slow-down retry; the peak "
-              "velocity/acceleration ratios may exceed the (scaled) limits by up to this factor.")
+              "Scaling factor for joint acceleration limits, applied by the TOPP-RA re-timing.")
       .def_rw("toppra_blend_deviation", &CartesianPlannerOptions::toppra_blend_deviation,
-              "Corner-rounding tolerance (rad) for the TimeOptimal mode's TOPP-RA line+blend "
-              "geometry.")
-      .def_rw("toppra_waypoint_spacing", &CartesianPlannerOptions::toppra_waypoint_spacing,
-              "Spacing (m of tool travel) between the waypoints handed to TOPP-RA in TimeOptimal "
-              "mode; the dense diff-IK trace is resampled to this spacing so servo jitter does "
-              "not dominate the blend corner angles. <= 0 disables the resampling.")
+              "Corner-rounding tolerance (rad) for the TOPP-RA line+blend geometry; also sets how "
+              "far the resolved path may be decimated before re-timing.")
       .def_rw("position_limit_gain", &CartesianPlannerOptions::position_limit_gain,
-              "Gain for the joint position-limit constraint.")
-      .def_rw("max_attempts_per_step", &CartesianPlannerOptions::max_attempts_per_step,
-              "Maximum feedrate-throttling attempts per control step.");
+              "Gain for the joint position-limit constraint.");
 
   nanobind::class_<CartesianPlannerComponents>(
       m, "CartesianPlannerComponents",

--- a/roboplan_cartesian_planning/include/roboplan_cartesian_planning/cartesian_path_planner.hpp
+++ b/roboplan_cartesian_planning/include/roboplan_cartesian_planning/cartesian_path_planner.hpp
@@ -161,6 +161,8 @@ struct CartesianPlannerComponents {
 
 /// @brief Offline Cartesian path planner that traces a CartesianPath in joint space.
 /// @details Uses the Oink optimal IK solver as a differential-IK tracker.
+/// Note that this planner uses the scene passed into it in a way that is not thread-safe; when
+/// using it, the robot must not be moving and no other planning steps must be running concurrently.
 class CartesianPathPlanner {
 public:
   /// @brief Constructor that builds the default differential-IK setup internally.
@@ -304,20 +306,6 @@ private:
   /// poses at the trajectory's sample period.
   CartesianPeaks computeCartesianPeaks(const JointTrajectory& trajectory,
                                        const CartesianPath& path) const;
-
-  /// @brief Generates a trajectory whose tool speed and acceleration stay within the commanded
-  /// Cartesian maxima.
-  /// @details Resolves and time-parameterizes exactly as TimeOptimal does, then slows the whole
-  /// motion uniformly until the Cartesian maxima are met. Uniform slowing is applied by scaling the
-  /// joint limits handed to TOPP-RA (velocity by 1/m, acceleration by 1/m^2), which reproduces the
-  /// time-scaled trajectory exactly, so the result still respects every joint limit.
-  tl::expected<JointTrajectory, std::string> planBounded(const CartesianPath& path,
-                                                         const Eigen::VectorXd& q_start_full);
-
-  /// @brief Resolves the path geometrically, then time-parameterizes it with TOPP-RA so
-  /// the result respects joint velocity and acceleration limits (tool speed varies).
-  tl::expected<JointTrajectory, std::string> planTimeOptimal(const CartesianPath& path,
-                                                             const Eigen::VectorXd& q_start_full);
 
   /// @brief A pointer to the scene.
   std::shared_ptr<Scene> scene_;

--- a/roboplan_cartesian_planning/include/roboplan_cartesian_planning/cartesian_path_planner.hpp
+++ b/roboplan_cartesian_planning/include/roboplan_cartesian_planning/cartesian_path_planner.hpp
@@ -92,8 +92,10 @@ struct CartesianPlannerOptions {
   /// joints toward the seed configuration (uses only nullspace freedom).
   double config_task_weight = 0.05;
 
-  /// @brief Scaling factor (0, 1] applied to the joint velocity limits used to bound
-  /// each differential-IK step.
+  /// @brief Scaling factor (0, 1] applied to the joint velocity limits.
+  /// @details In Bounded mode, this is applied to the differential-IK tracker itself.
+  /// In TimeOptimal mode, the tracker only resolves path geometry and TOPP-RA applies the scale
+  /// when re-timing, so the resolution pass deliberately runs against the unscaled limits.
   double velocity_scale = 1.0;
 
   /// @brief Scaling factor (0, 1] applied to the joint acceleration limits.
@@ -134,8 +136,9 @@ struct CartesianPlannerOptions {
   double position_limit_gain = 1.0;
 
   /// @brief Maximum number of feedrate-throttling attempts per control step before stalling.
-  /// @details A stall is declared when the robot cannot stay within tolerance even when nearly
-  /// stationary.
+  /// @details Each attempt halves the commanded feedrate, so the ladder reaches a negligible
+  /// reference advance within a handful of tries and stops there on its own. A stall is
+  /// declared when the robot cannot stay within tolerance even when nearly stationary.
   int max_attempts_per_step = 16;
 
   /// @brief Validates the mode-independent option values (dt, tolerances, scales).

--- a/roboplan_cartesian_planning/include/roboplan_cartesian_planning/cartesian_path_planner.hpp
+++ b/roboplan_cartesian_planning/include/roboplan_cartesian_planning/cartesian_path_planner.hpp
@@ -21,13 +21,10 @@ struct FrameTask;
 /// @brief Selects how the planner assigns speed/timing along the Cartesian path.
 enum class CartesianSpeedMode {
   /// @brief Trace the path under bounded Cartesian velocity and acceleration.
-  /// @details Builds a trapezoidal feedrate profile that ramps the Cartesian tool speed up to the
-  /// commanded linear/angular maxima and back down to a stop at the path end, bounding the
-  /// Cartesian linear/angular acceleration by the commanded maxima. The profile is traced with the
-  /// differential-IK tracker, and the feedrate is throttled further wherever the robot would
-  /// otherwise exceed its joint velocity or acceleration limits, or fall outside the path
-  /// tolerance (e.g., near a singularity). The commanded speeds and accelerations therefore act as
-  /// maxima, not fixed values.
+  /// @details Resolves and times the path exactly as TimeOptimal does, then slows the whole motion
+  /// uniformly until the tool speed and acceleration are within the commanded Cartesian maxima.
+  /// The commanded values therefore act as maxima the motion is held under, not fixed values: a
+  /// motion the joint limits already keep slower than the caps is left alone.
   Bounded,
 
   /// @brief Time-optimal re-timing respecting joint velocity/acceleration limits.
@@ -42,8 +39,9 @@ struct CartesianPlannerOptions {
   /// @brief The joint group name to plan for. Empty means the full robot.
   std::string group_name = "";
 
-  /// @brief The output trajectory sample period (control period), in seconds.
-  /// @details This is also the sample time used by the OInK solver.
+  /// @brief The output trajectory sample period, in seconds.
+  /// @details Also bounds each differential-IK step to dt * velocity limit while resolving the
+  /// path, which only sets how far a single IK iteration may move.
   double dt = 0.01;
 
   /// @brief Which timing/speed strategy to use.
@@ -103,16 +101,6 @@ struct CartesianPlannerOptions {
   /// throttle (which slows the feedrate wherever a step would exceed the scaled limits).
   double acceleration_scale = 1.0;
 
-  /// @brief Acceptance tolerance (>= 1.0) for the Bounded mode's slow-down retry.
-  /// @details A trace is accepted once its peak joint velocity and acceleration ratios land within
-  /// this factor of the (scaled) limits; otherwise the whole motion is re-timed slower and retried.
-  /// Because the Bounded mode has no hard joint-acceleration constraint and estimates acceleration
-  /// by finite difference, a value > 1.0 absorbs single-sample spikes at corners/tolerance events
-  /// and avoids needless extra slow-down passes. Set to 1.0 to require the peaks to land within the
-  /// (scaled) limits; for extra margin below the limits use velocity_scale/acceleration_scale
-  /// instead. Only used in Bounded speed mode.
-  double limit_ratio_tolerance = 1.05;
-
   /// @brief Corner-rounding tolerance (joint-space radians) for the TimeOptimal speed
   /// mode, which times the path with TOPP-RA over a straight-segment + circular-blend geometry.
   /// Each corner is rounded by a circular arc that deviates from the sharp corner by at most
@@ -121,25 +109,9 @@ struct CartesianPlannerOptions {
   /// trajectory stops at every waypoint).
   double toppra_blend_deviation = 0.05;
 
-  /// @brief Spacing, in meters, between the waypoints handed to TOPP-RA in TimeOptimal mode.
-  /// @details The dense diff-IK trace is resampled to this spacing before re-timing.
-  /// A value <= 0 disables the resampling and hands the raw dense trace to TOPP-RA.
-  /// The TimeOptimal mode resolves the Cartesian path with a differential-IK servo at a fine
-  /// fixed resolution. Every waypoint of that trace becomes a potential blend corner in
-  /// the TOPP-RA geometry, and at the raw spacing even sub-milliradian servo jitter dominates
-  /// the direction change between adjacent waypoints; the resulting tight blend arcs cap the
-  /// centripetal acceleration and crawl the whole trajectory far below the joint limits.
-  double toppra_waypoint_spacing = 0.005;
-
   /// @brief Gain (0, 1] for the position-limit constraint that steers each step away
   /// from the joint position limits.
   double position_limit_gain = 1.0;
-
-  /// @brief Maximum number of feedrate-throttling attempts per control step before stalling.
-  /// @details Each attempt halves the commanded feedrate, so the ladder reaches a negligible
-  /// reference advance within a handful of tries and stops there on its own. A stall is
-  /// declared when the robot cannot stay within tolerance even when nearly stationary.
-  int max_attempts_per_step = 16;
 
   /// @brief Validates the mode-independent option values (dt, tolerances, scales).
   /// @details Mode-specific options (e.g. the Bounded mode's commanded speeds/accelerations) are
@@ -247,112 +219,98 @@ public:
                                    const CartesianPath& path) const;
 
 private:
-  /// @brief Per-end-effector tracking state for one frame of the path: the arc-length-timed
-  /// waypoint reference plus the world transform, tip frame, and task used to trace it. Held
-  /// together so the servo loop indexes a single vector instead of several parallel ones.
-  struct FrameTrack {
+  /// @brief Per-end-effector geometric reference for one frame of the path: the base-relative
+  /// waypoints plus the world transform, tip frame, and task used to resolve it.
+  /// @details Parameterized by a normalized path parameter `s` in [0, 1] that carries no timing.
+  /// All frames share the same `s`, so they progress through their own waypoints together.
+  struct FrameReference {
     std::vector<Eigen::Matrix4d> waypoints;  ///< Base-relative SE(3) waypoints.
-    std::vector<double> cumulative_times;    ///< Cumulative reference time at each waypoint (s).
-    double total_time = 0.0;                 ///< Total reference duration (s).
+    std::vector<double> cumulative;          ///< Normalized progress in [0, 1] at each waypoint.
+    double linear_length = 0.0;              ///< Total tool travel along the reference (m).
+    double angular_length = 0.0;             ///< Total tool rotation along the reference (rad).
     Eigen::Matrix4d world_T_base = Eigen::Matrix4d::Identity();  ///< Fixed world<-base transform.
-    std::shared_ptr<FrameTask> task;  ///< Tracking task whose target is retargeted each step.
+    std::shared_ptr<FrameTask> task;  ///< Tracking task whose target is retargeted per sample.
     std::string tip_frame;            ///< Name of the tip frame traced (path.tip_frames[f]).
 
-    /// @brief Base-relative reference pose at reference time `s` in [0, total_time].
+    /// @brief Base-relative reference pose at path parameter `s` in [0, 1].
     Eigen::Matrix4d eval(double s) const;
-    /// @brief World-frame target pose of this frame at reference time `s`.
+    /// @brief World-frame target pose of this frame at path parameter `s`.
     Eigen::Matrix4d target(double s) const { return world_T_base * eval(s); }
   };
 
-  /// @brief Trapezoidal feedrate profile: a ceiling on the feedrate (ds/dt) over a uniform
-  /// reference-time grid that bounds the Cartesian acceleration and forces a stop at the path end.
-  struct FeedrateProfile {
-    bool enabled = false;         ///< When false, sample() returns 1.0 (constant full feedrate).
-    std::vector<double> ceiling;  ///< Feedrate ceiling at each grid knot.
-    double ds = 0.0;              ///< Reference-time spacing between knots (s).
-    double s_ddot_max = 0.0;      ///< Maximum feedrate acceleration (1/s).
-    size_t num_corner_knots = 0;  ///< Number of corner caps applied (used to size the loop cap).
-
-    /// @brief Samples the ceiling at reference time `s` (linear interpolation; 1.0 if disabled).
-    double sample(double s) const;
+  /// @brief Peak Cartesian rates observed over a timed trajectory, across all tracked tips.
+  struct CartesianPeaks {
+    double linear_speed = 0.0;          ///< Peak tool speed (m/s).
+    double angular_speed = 0.0;         ///< Peak tool angular speed (rad/s).
+    double linear_acceleration = 0.0;   ///< Peak tool acceleration (m/s^2).
+    double angular_acceleration = 0.0;  ///< Peak tool angular acceleration (rad/s^2).
   };
 
   /// @brief Builds the parts of the OInK problem that do not depend on the path or seed, once,
   /// at construction time.
-  /// @details Populates the reused solver-input buffers (constraints_, barriers_) and the
-  /// velocity-limit verification vector. When `components` is provided this also assembles the
-  /// full task list (tracking tasks followed by extra tasks) and caches the tracking tasks
-  /// (tracking_tasks_) for per-plan() wiring, since the caller's objectives are fixed; otherwise
-  /// the per-end-effector tasks_ are (re)built per plan() because they depend on the path's frames
-  /// and the seed configuration.
+  /// @details Populates the reused solver-input buffers (constraints_, barriers_) and the group
+  /// velocity limits. When `components` is provided this also assembles the full task list
+  /// (tracking tasks followed by extra tasks) and caches the tracking tasks (tracking_tasks_) for
+  /// per-plan() wiring, since the caller's objectives are fixed; otherwise the per-end-effector
+  /// tasks_ are (re)built per plan() because they depend on the path's frames and the seed.
   /// @param components The caller-supplied objectives, or std::nullopt for the default setup.
   /// @throws std::runtime_error if the joint velocity limits cannot be resolved (default setup).
   void buildStaticSolverComponents(const std::optional<CartesianPlannerComponents>& components);
 
-  /// @brief Builds the per-end-effector tracking state (arc-length-timed waypoints, world<-base
-  /// transform, tip frame, and tracking task) for every frame in the path, and wires the tracking
-  /// tasks into the reused solver task list (tasks_).
+  /// @brief Builds the per-end-effector geometric reference for every frame in the path, and wires
+  /// the tracking tasks into the reused solver task list (tasks_).
   /// @details In the custom-components mode the tasks are the caller's (validated to match the
   /// path's tip-frame order); otherwise one priority-1 FrameTask per end-effector plus a
   /// priority-2 nullspace ConfigurationTask are (re)built from the seed configuration.
-  tl::expected<std::vector<FrameTrack>, std::string>
-  buildFrameTracks(const CartesianPath& path, const Eigen::VectorXd& q_start_full,
-                   double linear_speed, double angular_speed);
+  tl::expected<std::vector<FrameReference>, std::string>
+  buildFrameReferences(const CartesianPath& path, const Eigen::VectorXd& q_start_full);
 
-  /// @brief Precomputes the trapezoidal feedrate profile for the given references.
-  /// @details Bounds the feedrate acceleration so the Cartesian acceleration stays within the
-  /// commanded maxima, caps the feedrate at each corner (see cornerFeedrateCap), and runs a
-  /// backward pass so the feedrate can always decelerate to each corner cap and stop at the end.
-  /// A non-positive acceleration returns a disabled profile (constant full feedrate).
-  FeedrateProfile buildFeedrateProfile(const std::vector<FrameTrack>& tracks, double total_time,
-                                       double linear_speed, double angular_speed,
-                                       double linear_acceleration,
-                                       double angular_acceleration) const;
-
-  /// @brief Runs one differential-IK step that retargets every frame to its pose at reference
-  /// time `s` from the committed configuration `q`. Writes the candidate configuration, the group
-  /// step `delta_q`, and the worst-case (max over frames) FK pose error. Does not commit.
-  tl::expected<void, std::string> solveStep(const std::vector<FrameTrack>& tracks,
+  /// @brief Runs one differential-IK step that retargets every frame to its pose at path parameter
+  /// `s` from the configuration `q`. Writes the candidate configuration, the group step `delta_q`,
+  /// and the worst-case (max over frames) FK pose error. Does not commit.
+  tl::expected<void, std::string> solveStep(const std::vector<FrameReference>& references,
                                             const Eigen::VectorXd& q, double s,
                                             Eigen::VectorXd& q_candidate, Eigen::VectorXd& delta_q,
                                             double& position_error, double& orientation_error);
 
-  /// @brief Drives every frame onto its first waypoint within tolerance, updating `q` in place.
-  tl::expected<void, std::string> convergeToStart(const std::vector<FrameTrack>& tracks,
-                                                  Eigen::VectorXd& q);
+  /// @brief Iterates the differential IK at a fixed `s` until every frame is within the pose
+  /// tolerance, updating `q` in place.
+  /// @details This is what keeps the resolved path on the Cartesian path: each sample is solved to
+  /// convergence rather than tracked by a single step, so the robot never trails the reference and
+  /// no throttling or lag-recovery is needed.
+  /// The tolerance here should be far tighter than the path tolerance: see kIkConvergenceFraction.
+  /// @param position_tolerance Residual position error a sample must reach.
+  /// @param orientation_tolerance Residual orientation error a sample must reach.
+  tl::expected<void, std::string> converge(const std::vector<FrameReference>& references, double s,
+                                           double position_tolerance, double orientation_tolerance,
+                                           Eigen::VectorXd& q);
 
-  /// @brief Runs the timed servo loop from the converged start `q`, advancing the reference under
-  /// the feedrate profile and throttling further to stay within the path tolerance and joint
-  /// limits.
-  /// @return A trajectory with positions, velocities, and times populated. The accelerations are
-  /// left for the plan*() caller to fill.
-  tl::expected<JointTrajectory, std::string> runServoLoop(const std::vector<FrameTrack>& tracks,
-                                                          const FeedrateProfile& profile,
-                                                          double total_time, Eigen::VectorXd& q);
+  /// @brief Stage one: resolves the Cartesian path into a purely geometric joint path.
+  /// @details Samples the path by arc length at a density set by the pose tolerance, solving IK to
+  /// convergence at each sample and seeding from the previous solution. The result carries no
+  /// timing at all; stage two assigns it.
+  /// @return The resolved group joint positions, or a description of where and why IK failed.
+  tl::expected<std::vector<Eigen::VectorXd>, std::string>
+  resolvePath(const CartesianPath& path, const Eigen::VectorXd& q_start_full);
 
-  /// @brief Resolves the Cartesian path into a joint-space trace with the Oink tracker.
-  /// @details Orchestrates buildFrameTracks -> buildFeedrateProfile -> convergeToStart ->
-  /// runServoLoop. The reference advances at the commanded Cartesian speeds, ramped under a
-  /// trapezoidal feedrate profile bounded by the accelerations, and throttled to stay within the
-  /// path tolerance. Joint velocity and position limits are enforced per step.
-  /// @param linear_acceleration,angular_acceleration Cartesian acceleration maxima for the
-  /// trapezoidal feedrate profile. A non-positive value disables the profile (constant feedrate).
-  /// @return The trajectory from runServoLoop (positions, velocities, times; see there).
+  /// @brief Stage two: time-parameterizes a resolved joint path with TOPP-RA under the given
+  /// scales, decimating it to its shape-carrying waypoints first and retrying nearby
+  /// discretizations if the solver rejects one.
   tl::expected<JointTrajectory, std::string>
-  trackReference(const CartesianPath& path, const Eigen::VectorXd& q_start_full,
-                 double linear_speed, double angular_speed, double linear_acceleration,
-                 double angular_acceleration);
+  timeParameterize(const std::vector<Eigen::VectorXd>& resolved, double velocity_scale,
+                   double acceleration_scale);
 
-  /// @brief Fills a trajectory's accelerations by backward finite difference of the velocities,
-  /// zeroing the (at-rest) boundary accelerations.
-  void fillAccelerations(JointTrajectory& trajectory) const;
+  /// @brief Peak Cartesian tool rates over a timed trajectory, by finite difference of the tip
+  /// poses at the trajectory's sample period.
+  CartesianPeaks computeCartesianPeaks(const JointTrajectory& trajectory,
+                                       const CartesianPath& path) const;
 
-  /// @brief Generates a trajectory that traces the path under a trapezoidal Cartesian feedrate
-  /// profile: the tool speed ramps up/down within the commanded Cartesian acceleration maxima and
-  /// is capped at the commanded speeds.
-  /// @details If the resulting motion still exceeds the (scaled) joint velocity or acceleration
-  /// limits, the whole trace is re-timed slower (commanded speeds/accelerations scaled down) and
-  /// retried, so the commanded values act as maxima that are relaxed only as needed.
+  /// @brief Generates a trajectory whose tool speed and acceleration stay within the commanded
+  /// Cartesian maxima.
+  /// @details Resolves and time-parameterizes exactly as TimeOptimal does, then slows the whole
+  /// motion uniformly until the Cartesian maxima are met. Uniform slowing is applied by scaling the
+  /// joint limits handed to TOPP-RA (velocity by 1/m, acceleration by 1/m^2), which reproduces the
+  /// time-scaled trajectory exactly, so the result still respects every joint limit.
   tl::expected<JointTrajectory, std::string> planBounded(const CartesianPath& path,
                                                          const Eigen::VectorXd& q_start_full);
 
@@ -376,8 +334,8 @@ private:
   std::shared_ptr<Oink> oink_;
 
   /// @brief Caller-supplied tracking tasks, non-empty only when the components constructor is used.
-  /// @details Cached at construction so buildFrameTracks() can wire each FrameTrack to its task on
-  /// every plan() call; a non-empty value also marks the custom-components mode (in which the
+  /// @details Cached at construction so buildFrameReferences() can wire each reference to its task
+  /// on every plan() call; a non-empty value also marks the custom-components mode (in which the
   /// default FrameTask/ConfigurationTask/VelocityLimit/PositionLimit setup is bypassed). The other
   /// caller-supplied objectives are consumed into oink_/tasks_/constraints_/barriers_ at
   /// construction, so they do not need to be retained.
@@ -394,15 +352,7 @@ private:
   /// @brief Barriers passed to the solver each step. Built once at construction.
   std::vector<std::shared_ptr<Barrier>> barriers_;
 
-  /// @brief Joint velocity limits used to verify each committed step. Built once at construction.
-  /// @details Default mode uses the scene limits scaled by options_.velocity_scale; custom mode
-  /// uses the unscaled scene limits as a hard-limit sanity net.
-  Eigen::VectorXd verify_v_max_;
-
-  /// @brief Whether the per-step velocity verification runs (false if no limits are available).
-  bool has_velocity_check_ = false;
-
-  /// @brief The TOPP-RA time parameterizer, used by the TimeOptimal speed mode.
+  /// @brief The TOPP-RA time parameterizer, used by both speed modes.
   /// @details Constructed once for the planner's joint group and reused across plan() calls.
   PathParameterizerTOPPRA toppra_;
 };

--- a/roboplan_cartesian_planning/src/cartesian_path_planner.cpp
+++ b/roboplan_cartesian_planning/src/cartesian_path_planner.cpp
@@ -54,6 +54,12 @@ constexpr size_t kMaxToppraWaypoints = 10000;
 /// whose estimate is tiny, against tripping the safety cap on benign sub-dt fragments and retries.
 constexpr int kHardCapStepMargin = 1000;
 
+/// @brief Smallest reference advance, relative to the total reference duration, that a throttling
+/// attempt may command.
+/// @details Set to a small value, so that a throttle attempt is considered stalled if it would
+/// re-solve an almost identical problem.
+constexpr double kMinRelativeAdvance = 1e-12;
+
 /// @brief Maximum feedrate (fraction of full speed) the reference may carry through the corner at
 /// `cur` between `prev` and `next`, keeping the Cartesian acceleration within the commanded maxima.
 /// @details The reference is piecewise-linear (linear position interpolation, SLERP orientation),
@@ -226,7 +232,13 @@ void CartesianPathPlanner::buildStaticSolverComponents(
                              "velocity limits: " +
                              maybe_velocity_limits.error());
   }
-  Eigen::VectorXd v_max = maybe_velocity_limits->second.cwiseAbs() * options_.velocity_scale;
+  // The velocity scale belongs to whichever stage owns the final timing:
+  // - Bounded mode emits the traced motion directly, so its steps must respect the scaled limits.
+  // - TimeOptimal mode only resolves path geometry and hands it to TOPP-RA, which applies the scale
+  //   during re-timing.
+  const double resolution_velocity_scale =
+      options_.speed_mode == CartesianSpeedMode::TimeOptimal ? 1.0 : options_.velocity_scale;
+  Eigen::VectorXd v_max = maybe_velocity_limits->second.cwiseAbs() * resolution_velocity_scale;
   if (v_max.size() != num_variables) {
     throw std::runtime_error(
         "Could not initialize Cartesian path planner: velocity limit vector size (" +
@@ -589,8 +601,16 @@ CartesianPathPlanner::runServoLoop(const std::vector<FrameTrack>& tracks,
     bool committed = false;
     double feedrate_eff = feedrate_cmd;
     double committed_s = s;
+    // Halving the feedrate only helps while it still moves the reference. Once an attempt would
+    // advance `s` by less than this, the retry re-solves an unchanged problem (and committing a
+    // step that does not advance `s` at all would spin the loop without progress), so the ladder
+    // stops there and the stall below is declared instead of burning the remaining attempts.
+    const double min_advance = kMinRelativeAdvance * total_time;
     for (int attempt = 0; attempt < options_.max_attempts_per_step; ++attempt) {
       const double s_try = std::min(s + feedrate_eff * options_.dt, total_time);
+      if (s_try < total_time && s_try - s < min_advance) {
+        break;
+      }
       const auto step =
           solveStep(tracks, q, s_try, q_candidate, delta_q, position_error, orientation_error);
       if (!step) {
@@ -618,7 +638,9 @@ CartesianPathPlanner::runServoLoop(const std::vector<FrameTrack>& tracks,
     // real speed (a throttled step naturally slows the profile).
     s = committed_s;
     feedrate = feedrate_eff;
-    q = q_candidate;
+    // Clamp away solver-epsilon overshoot of the position limits, since the QP only satisfiesExpand
+    // commentComment on line R621Resolved its constraints to within the solver tolerance.
+    q = scene_->clampToValidConfiguration(q_candidate);
 
     // The velocity constraint keeps each step within the joint velocity limits inside the QP;
     // verify the committed step actually does, to guard against solver constraint relaxation or
@@ -820,25 +842,49 @@ CartesianPathPlanner::planBounded(const CartesianPath& path, const Eigen::Vector
 tl::expected<JointTrajectory, std::string>
 CartesianPathPlanner::planTimeOptimal(const CartesianPath& path,
                                       const Eigen::VectorXd& q_start_full) {
-  // Resolve a dense geometric joint path that hugs the Cartesian path. The resolution
-  // speed only sets sampling density and tracking tightness here (TOPP-RA assigns the
-  // final timing), so use a deliberately low speed that essentially any robot can follow
-  // without lagging: a faster resolution speed makes the robot trail the reference by up
-  // to the tolerance band, and TOPP-RA would then faithfully reproduce that lag.
-  constexpr double kResolutionLinearSpeed = 0.05;   // m/s
-  constexpr double kResolutionAngularSpeed = 0.25;  // rad/s
+  // Resolve a dense geometric joint path that hugs the Cartesian path. The resolution speed sets
+  // only the sampling density and tracking tightness, since TOPP-RA assigns the final timing.
+  //
+  // A control step advances the reference by `dt` and the tracker nulls the pose error over roughly
+  // that long, so the robot trails the reference by about one step of travel. Hold each modality's
+  // step to this fraction of its own tolerance to keep that lag small, since a trailing trace would
+  // be faithfully reproduced by TOPP-RA.
+  constexpr double kLagFraction = 0.125;
+
+  // Each speed is then clamped to a band measured across the example models. Above the band the
+  // tracker stops keeping up unaided and leans on the servo loop's throttle retries; below it the
+  // trace grows dense enough that per-step jitter accumulates, and the resample stride, which is
+  // derived from tool travel, over-decimates a rotation-dominated path.
+  constexpr double kMinLinearSpeed = 0.05;   // m/s
+  constexpr double kMaxLinearSpeed = 0.15;   // m/s
+  constexpr double kMinAngularSpeed = 0.25;  // rad/s
+  constexpr double kMaxAngularSpeed = 1.0;   // rad/s
+
+  // Translation is additionally held to the resample spacing so the trace is never resolved coarser
+  // than the waypoints it feeds. The spacing is tool travel in meters, so rotation has no such
+  // target, and a non-positive spacing disables the resample and leaves only the lag bound.
+  double step_travel = kLagFraction * options_.max_position_error;
+  if (options_.toppra_waypoint_spacing > 0.0) {
+    step_travel = std::min(step_travel, options_.toppra_waypoint_spacing);
+  }
+  const double step_rotation = kLagFraction * options_.max_orientation_error;
+  const double resolution_linear_speed =
+      std::clamp(step_travel / options_.dt, kMinLinearSpeed, kMaxLinearSpeed);
+  const double resolution_angular_speed =
+      std::clamp(step_rotation / options_.dt, kMinAngularSpeed, kMaxAngularSpeed);
 
   // Geometric resolution is velocity-level only; TOPP-RA enforces the acceleration limits in the
   // re-timing stage, so trace at a constant resolution feedrate (no Cartesian acceleration
   // profile).
-  auto tracked = trackReference(path, q_start_full, kResolutionLinearSpeed, kResolutionAngularSpeed,
-                                /*linear_acceleration=*/0.0, /*angular_acceleration=*/0.0);
+  auto tracked =
+      trackReference(path, q_start_full, resolution_linear_speed, resolution_angular_speed,
+                     /*linear_acceleration=*/0.0, /*angular_acceleration=*/0.0);
   if (!tracked) {
     return tl::make_unexpected(tracked.error());
   }
 
   // The LinearBlend geometry treats every waypoint as a potential corner. At the raw trace
-  // spacing (kResolutionLinearSpeed * dt of tool travel per waypoint), even sub-milliradian
+  // spacing (resolution_linear_speed * dt of tool travel per waypoint), even sub-milliradian
   // servo jitter dominates the direction change between adjacent waypoints, so each one
   // becomes a tight blend arc whose centripetal acceleration bound throttles the whole
   // trajectory far below the joint limits. Resample the trace to space tool travel between
@@ -848,7 +894,7 @@ CartesianPathPlanner::planTimeOptimal(const CartesianPath& path,
   size_t num_target_waypoints = kMaxToppraWaypoints;
   if (options_.toppra_waypoint_spacing > 0.0) {
     const double waypoint_stride =
-        std::max(1.0, options_.toppra_waypoint_spacing / (kResolutionLinearSpeed * options_.dt));
+        std::max(1.0, options_.toppra_waypoint_spacing / (resolution_linear_speed * options_.dt));
     num_target_waypoints =
         std::clamp<size_t>(static_cast<size_t>(std::ceil(
                                static_cast<double>(trace_positions.size()) / waypoint_stride)),

--- a/roboplan_cartesian_planning/src/cartesian_path_planner.cpp
+++ b/roboplan_cartesian_planning/src/cartesian_path_planner.cpp
@@ -62,9 +62,9 @@ constexpr double kStagnationImprovement = 0.99;
 constexpr int kMaxStagnantIters = 5;
 
 /// @brief Fraction of the pose tolerance the reference advances between IK seeding samples.
-/// @details This walk exists so every IK solve starts from a near neighbour, which keeps the
-/// solution on one branch and reaches convergence in a few iterations. It is not the output
-/// resolution: which of these samples become waypoints is decided afterwards, by tool deviation.
+/// @details This walk exists so every IK solve starts from a near neighbor, which keeps the
+/// solution away from large jumps. It is not the output resolution: which of these samples
+/// become waypoints is decided afterwards, by tool deviation.
 constexpr double kSeedStepFraction = 0.5;
 
 /// @brief Share of the pose tolerance allotted to the gaps between resolved samples.
@@ -248,13 +248,60 @@ CartesianPathPlanner::plan(const CartesianPath& path, const JointConfiguration& 
                                std::to_string(q_start.positions.size()) + ".");
   }
 
-  switch (options_.speed_mode) {
-  case CartesianSpeedMode::Bounded:
-    return planBounded(path, q_start.positions);
-  case CartesianSpeedMode::TimeOptimal:
-    return planTimeOptimal(path, q_start.positions);
+  const bool bounded = options_.speed_mode == CartesianSpeedMode::Bounded;
+  if (bounded) {
+    if (options_.max_linear_speed <= 0.0 || options_.max_angular_speed <= 0.0) {
+      return tl::make_unexpected(
+          "max_linear_speed and max_angular_speed must be strictly positive.");
+    }
+    if (options_.max_linear_acceleration <= 0.0 || options_.max_angular_acceleration <= 0.0) {
+      return tl::make_unexpected(
+          "max_linear_acceleration and max_angular_acceleration must be strictly positive.");
+    }
   }
-  return tl::make_unexpected("Unknown CartesianSpeedMode.");
+
+  const auto resolved = resolvePath(path, q_start.positions);
+  if (!resolved) {
+    return tl::make_unexpected(resolved.error());
+  }
+
+  double velocity_scale = options_.velocity_scale;
+  double acceleration_scale = options_.acceleration_scale;
+  auto trajectory = timeParameterize(*resolved, velocity_scale, acceleration_scale);
+  if (!trajectory) {
+    return tl::make_unexpected(trajectory.error());
+  }
+  if (!bounded) {
+    return trajectory;
+  }
+
+  // Bounded mode: the path is timed against the joint limits above, then the whole motion is
+  // slowed until the tool obeys the commanded Cartesian maxima too. Re-timing in time-scale m
+  // divides speed by m and acceleration by m^2, and handing TOPP-RA joint limits scaled the same
+  // way reproduces exactly that slower trajectory, so the joint limits stay satisfied for free.
+  for (int pass = 0; pass < kMaxBoundedSlowdownPasses; ++pass) {
+    const CartesianPeaks peaks = computeCartesianPeaks(*trajectory, path);
+    double slowdown = 1.0;
+    slowdown = std::max(slowdown, peaks.linear_speed / options_.max_linear_speed);
+    slowdown = std::max(slowdown, peaks.angular_speed / options_.max_angular_speed);
+    slowdown =
+        std::max(slowdown, std::sqrt(peaks.linear_acceleration / options_.max_linear_acceleration));
+    slowdown = std::max(slowdown,
+                        std::sqrt(peaks.angular_acceleration / options_.max_angular_acceleration));
+    if (slowdown <= kBoundedSpeedTolerance) {
+      break;
+    }
+    velocity_scale /= slowdown;
+    acceleration_scale /= slowdown * slowdown;
+    auto slower = timeParameterize(*resolved, velocity_scale, acceleration_scale);
+    if (!slower) {
+      // The faster trajectory is still valid against the joint limits, so keep it rather than
+      // failing outright; it simply exceeds the commanded Cartesian caps.
+      break;
+    }
+    trajectory = std::move(slower);
+  }
+  return trajectory;
 }
 
 tl::expected<std::vector<CartesianPathPlanner::FrameReference>, std::string>
@@ -456,10 +503,8 @@ CartesianPathPlanner::resolvePath(const CartesianPath& path, const Eigen::Vector
     return tl::make_unexpected(references.error());
   }
 
-  // Walk the path in small steps so every IK solve starts from a near neighbour. The step is a
-  // seeding concern, not an output resolution: a solve that had to cross the whole path at once
-  // would need thousands of iterations and could land on a different IK branch. Which of these
-  // samples survive as waypoints is decided below, on tool deviation.
+  // Walk the path in small steps so every IK solve starts from a near neighbor.
+  // This helps seed IK solutions to see if the path can be followed without large jumps.
   const double seed_linear_step = kSeedStepFraction * options_.max_position_error;
   const double seed_angular_step = kSeedStepFraction * options_.max_orientation_error;
   double steps = 1.0;
@@ -497,9 +542,17 @@ CartesianPathPlanner::resolvePath(const CartesianPath& path, const Eigen::Vector
 
   // Choose the fewest waypoints that still describe the motion. Every waypoint handed to the time
   // parameterization becomes a corner it must slow through, and its blend radius is capped by the
-  // adjacent segment, so waypoint count sets the achievable speed directly: an unnecessary sample
-  // costs a near-stop and buys nothing. Keep a sample only when dropping it would let the tool
-  // stray, measured the way the trajectory will actually travel.
+  // adjacent segment, so waypoint count sets the achievable speed directly. An unnecessary sample
+  // costs a near-stop and buys nothing, so keep it only when dropping it would let the tool frame
+  // deviate away from the intended path.
+  //
+  // Starting from just the first and last sample, we recursively check whether a straight
+  // joint-space interpolation between two kept samples stays close though to the reference at all
+  // the intermediate samples. If the worst deviation exceeds the budget, that sample must be kept
+  // and we split the span. Otherwise every intermediate sample is redundant and can be removed.
+  //
+  // The budget is `kSubdivisionToleranceFraction` of the user's specified pose tolerance, reserving
+  // the rest for the corner-rounding that TOPP-RA applies during time parameterization.
   const double position_budget = kSubdivisionToleranceFraction * options_.max_position_error;
   const double orientation_budget = kSubdivisionToleranceFraction * options_.max_orientation_error;
   std::vector<bool> keep(walked.size(), false);
@@ -690,77 +743,6 @@ double CartesianPathPlanner::computeAchievedPathLength(const JointTrajectory& tr
     }
   }
   return length;
-}
-
-tl::expected<JointTrajectory, std::string>
-CartesianPathPlanner::planBounded(const CartesianPath& path, const Eigen::VectorXd& q_start_full) {
-  if (options_.max_linear_speed <= 0.0 || options_.max_angular_speed <= 0.0) {
-    return tl::make_unexpected("max_linear_speed and max_angular_speed must be strictly positive.");
-  }
-  if (options_.max_linear_acceleration <= 0.0 || options_.max_angular_acceleration <= 0.0) {
-    return tl::make_unexpected(
-        "max_linear_acceleration and max_angular_acceleration must be strictly positive.");
-  }
-
-  const auto resolved = resolvePath(path, q_start_full);
-  if (!resolved) {
-    return tl::make_unexpected(resolved.error());
-  }
-
-  // Time the path against the joint limits first, then slow the whole motion until the tool obeys
-  // the commanded Cartesian maxima too. Re-timing in time-scale m divides speed by m and
-  // acceleration by m^2, and handing TOPP-RA joint limits scaled the same way reproduces exactly
-  // that slower trajectory, so the joint limits stay satisfied for free.
-  double velocity_scale = options_.velocity_scale;
-  double acceleration_scale = options_.acceleration_scale;
-  auto trajectory = timeParameterize(*resolved, velocity_scale, acceleration_scale);
-  if (!trajectory) {
-    return tl::make_unexpected(trajectory.error());
-  }
-
-  for (int pass = 0; pass < kMaxBoundedSlowdownPasses; ++pass) {
-    const CartesianPeaks peaks = computeCartesianPeaks(*trajectory, path);
-    double slowdown = 1.0;
-    slowdown = std::max(slowdown, peaks.linear_speed / options_.max_linear_speed);
-    slowdown = std::max(slowdown, peaks.angular_speed / options_.max_angular_speed);
-    slowdown =
-        std::max(slowdown, std::sqrt(peaks.linear_acceleration / options_.max_linear_acceleration));
-    slowdown = std::max(slowdown,
-                        std::sqrt(peaks.angular_acceleration / options_.max_angular_acceleration));
-    if (slowdown <= kBoundedSpeedTolerance) {
-      break;
-    }
-    velocity_scale /= slowdown;
-    acceleration_scale /= slowdown * slowdown;
-    auto slower = timeParameterize(*resolved, velocity_scale, acceleration_scale);
-    if (!slower) {
-      // The faster trajectory is still valid against the joint limits, so keep it rather than
-      // failing outright; it simply exceeds the commanded Cartesian caps.
-      break;
-    }
-    trajectory = std::move(slower);
-  }
-  return trajectory;
-}
-
-tl::expected<JointTrajectory, std::string>
-CartesianPathPlanner::planTimeOptimal(const CartesianPath& path,
-                                      const Eigen::VectorXd& q_start_full) {
-  const auto resolved = resolvePath(path, q_start_full);
-  if (!resolved) {
-    return tl::make_unexpected(resolved.error());
-  }
-  return timeParameterize(*resolved, options_.velocity_scale, options_.acceleration_scale);
-}
-
-/// @brief Resolves a joint group, throwing the planner's construction error if it does not exist.
-JointGroupInfo resolveJointGroup(const Scene& scene, const std::string& group_name) {
-  auto maybe_joint_group_info = scene.getJointGroupInfo(group_name);
-  if (!maybe_joint_group_info) {
-    throw std::runtime_error("Could not initialize Cartesian path planner: " +
-                             maybe_joint_group_info.error());
-  }
-  return maybe_joint_group_info.value();
 }
 
 }  // namespace roboplan

--- a/roboplan_cartesian_planning/src/cartesian_path_planner.cpp
+++ b/roboplan_cartesian_planning/src/cartesian_path_planner.cpp
@@ -25,153 +25,113 @@ namespace {
 /// @brief Small epsilon for distance/angle/limit comparisons and strict-inequality slack.
 constexpr double kEps = 1e-9;
 
-/// @brief Maximum number of differential-IK steps used to drive the robot onto the
-/// first waypoint before the timed trace begins.
+/// @brief Maximum number of differential-IK iterations spent converging onto one path sample.
 constexpr int kMaxIkConvergenceIters = 500;
-
-/// @brief Turns smaller than this (radians) are treated as straight by the corner feedrate cap.
-constexpr double kCornerAngleMin = 1.0 * std::numbers::pi / 180.0;
-
-/// @brief Maximum number of whole-trace slow-down retries in the Bounded speed mode.
-constexpr int kMaxSlowdownIters = 6;
-
-/// @brief Relative tolerance when verifying a committed step against the joint velocity limits,
-/// absorbing the QP's constraint-satisfaction tolerance.
-constexpr double kLimitRelTolerance = 1e-2;
-
-/// @brief Headroom factor applied to each slow-down so the next trace clears the limit rather
-/// than landing exactly on it.
-constexpr double kSlowdownHeadroom = 1.1;
 
 /// @brief Hard cap on the number of waypoints handed to TOPP-RA, bounding the
 /// time-parameterization problem size (and hence planning time) for pathologically long paths.
-/// The trace is normally resampled to a coarser tool-travel spacing before this cap applies
-/// (see CartesianPlannerOptions::toppra_waypoint_spacing).
 constexpr size_t kMaxToppraWaypoints = 10000;
 
-/// @brief Fixed additive slack (in control steps) added to the servo loop's step budget, on top of
-/// the estimate derived from the reference duration and throttling attempts. Guards short motions,
-/// whose estimate is tiny, against tripping the safety cap on benign sub-dt fragments and retries.
-constexpr int kHardCapStepMargin = 1000;
+/// @brief Number of blend deviations tried when TOPP-RA rejects a path, each half the last.
+/// @details TOPP-RA's forward pass occasionally reports an infeasible interval on a path that is
+/// perfectly feasible, and the same path with tighter blending solves fine. The first attempt uses
+/// the caller's own value, so a healthy plan pays nothing, and each retry only tightens the
+/// blending, so a rescued trajectory hugs the resolved path at least as closely as asked.
+constexpr int kMaxBlendAttempts = 3;
 
-/// @brief Smallest reference advance, relative to the total reference duration, that a throttling
-/// attempt may command.
-/// @details Set to a small value, so that a throttle attempt is considered stalled if it would
-/// re-solve an almost identical problem.
-constexpr double kMinRelativeAdvance = 1e-12;
+/// @brief Hard cap on the number of samples the geometric resolution stage may take, bounding the
+/// IK work for a pathologically long path or a very tight pose tolerance.
+constexpr size_t kMaxResolutionSamples = 100000;
 
-/// @brief Maximum feedrate (fraction of full speed) the reference may carry through the corner at
-/// `cur` between `prev` and `next`, keeping the Cartesian acceleration within the commanded maxima.
-/// @details The reference is piecewise-linear (linear position interpolation, SLERP orientation),
-/// so at a waypoint where the path direction turns by an angle theta the commanded velocity
-/// direction flips abruptly. Crossing the corner at Cartesian speed v changes the velocity by
-/// |dv| = 2 v sin(theta/2) over roughly one control period dt, implying an acceleration |dv|/dt.
-/// Capping that at the commanded maximum gives the cornering speed v <= a * dt / (2 sin(theta/2));
-/// converted to a feedrate (v / commanded speed) and taking the binding of position and
-/// orientation yields the cap. A near-reversal drives the cap toward zero (the servo loop's
-/// feedrate floor crawls through it).
-double cornerFeedrateCap(const Eigen::Matrix4d& prev, const Eigen::Matrix4d& cur,
-                         const Eigen::Matrix4d& next, double linear_acceleration,
-                         double linear_speed, double angular_acceleration, double angular_speed,
-                         double dt) {
-  double cap = 1.0;
-  const auto cap_from_turn = [&](double deflection, double accel, double speed) {
-    if (deflection <= kCornerAngleMin || speed <= 0.0) {
-      return;
-    }
-    const double velocity_change = 2.0 * std::sin(0.5 * deflection);
-    cap = std::min(cap, accel * dt / (speed * velocity_change));
-  };
+/// @brief Fraction of one resolution step that a sample's residual IK error must fall below.
+/// @details The resolved path must be shaped by the commanded motion, not by where each IK solve
+/// happened to stop. Converging only to the path tolerance leaves a residual comparable to (or
+/// larger than) the step between samples, so consecutive solutions scatter within the tolerance
+/// ball and the path arrives at the time parameterization full of kinks it must stop at. Requiring
+/// the residual to be far smaller than the step makes successive samples differ by real motion.
+constexpr double kIkConvergenceFraction = 0.01;
 
-  // Position turn.
-  const Eigen::Vector3d in_pos = cur.block<3, 1>(0, 3) - prev.block<3, 1>(0, 3);
-  const Eigen::Vector3d out_pos = next.block<3, 1>(0, 3) - cur.block<3, 1>(0, 3);
-  if (in_pos.norm() > kEps && out_pos.norm() > kEps) {
-    const double cos_angle = std::clamp(in_pos.normalized().dot(out_pos.normalized()), -1.0, 1.0);
-    cap_from_turn(std::acos(cos_angle), linear_acceleration, linear_speed);
-  }
-  // Orientation turn: change of rotation axis between the incoming and outgoing relative rotations
-  // (only meaningful when both actually rotate).
-  const Eigen::AngleAxisd in_rot(prev.block<3, 3>(0, 0).transpose() * cur.block<3, 3>(0, 0));
-  const Eigen::AngleAxisd out_rot(cur.block<3, 3>(0, 0).transpose() * next.block<3, 3>(0, 0));
-  if (in_rot.angle() > kEps && out_rot.angle() > kEps) {
-    const double cos_angle = std::clamp(in_rot.axis().dot(out_rot.axis()), -1.0, 1.0);
-    cap_from_turn(std::acos(cos_angle), angular_acceleration, angular_speed);
-  }
-  return std::clamp(cap, 0.0, 1.0);
-}
+/// @brief Relative error improvement below which an IK solve counts as having stagnated.
+constexpr double kStagnationImprovement = 0.99;
 
-/// @brief Factor (>= 1) by which to slow a trace so its peak joint velocity/acceleration ratios
-/// fall within `tolerance` of the targets; 1.0 means both are already acceptable.
-/// @details Re-timing the path in time-scale m multiplies joint velocity by 1/m and joint
-/// acceleration by 1/m^2, so acceleration overshoot is corrected by sqrt of its ratio and velocity
-/// linearly. Only the offending modality contributes; kSlowdownHeadroom adds margin.
-double computeSlowdownFactor(double peak_velocity_ratio, double velocity_target,
-                             double peak_acceleration_ratio, double acceleration_target,
-                             double tolerance) {
-  double slowdown = 1.0;
-  if (peak_acceleration_ratio > acceleration_target * tolerance) {
-    slowdown = std::max(slowdown, std::sqrt(peak_acceleration_ratio / acceleration_target) *
-                                      kSlowdownHeadroom);
-  }
-  if (peak_velocity_ratio > velocity_target * tolerance) {
-    slowdown = std::max(slowdown, peak_velocity_ratio / velocity_target * kSlowdownHeadroom);
-  }
-  return slowdown;
-}
+/// @brief Consecutive stagnant iterations after which a sample stops iterating.
+/// @details The target above is deliberately tighter than the solver's own achievable precision, so
+/// a well-conditioned sample plateaus rather than reaching it. Stopping on the plateau takes the
+/// best solution available and lets the caller's path tolerance decide whether it is good enough,
+/// instead of failing a path that is resolved far more accurately than asked for.
+constexpr int kMaxStagnantIters = 5;
 
-}  // namespace
+/// @brief Fraction of the pose tolerance the reference advances between IK seeding samples.
+/// @details This walk exists so every IK solve starts from a near neighbour, which keeps the
+/// solution on one branch and reaches convergence in a few iterations. It is not the output
+/// resolution: which of these samples become waypoints is decided afterwards, by tool deviation.
+constexpr double kSeedStepFraction = 0.5;
 
-Eigen::Matrix4d CartesianPathPlanner::FrameTrack::eval(double s) const {
-  if (waypoints.empty()) {
-    return Eigen::Matrix4d::Identity();
-  }
-  if (waypoints.size() == 1 || total_time <= 0.0) {
-    return waypoints.back();
-  }
+/// @brief Share of the pose tolerance allotted to the gaps between resolved samples.
+/// @details The tolerance is spent twice over: once on how far the straight joint-space hop between
+/// consecutive waypoints bows off the commanded path, and again on how far the time
+/// parameterization rounds the corners between them. Splitting it leaves room for both.
+constexpr double kSubdivisionToleranceFraction = 0.5;
 
-  s = std::clamp(s, 0.0, total_time);
+/// @brief Maximum passes the Bounded mode spends slowing a trajectory under the Cartesian maxima.
+/// @details Scaling the joint limits by (1/m, 1/m^2) reproduces the m-times-slower trajectory
+/// exactly, so one pass normally suffices; the rest absorb TOPP-RA's discretization.
+constexpr int kMaxBoundedSlowdownPasses = 4;
 
-  // Find the segment [i, i+1] containing reference time s.
-  size_t i = 0;
-  while (i + 2 < cumulative_times.size() && cumulative_times.at(i + 1) < s) {
-    ++i;
-  }
-  const double t0 = cumulative_times.at(i);
-  const double t1 = cumulative_times.at(i + 1);
-  const double segment_duration = t1 - t0;
-  const double fraction = segment_duration > 0.0 ? (s - t0) / segment_duration : 0.0;
+/// @brief Relative slack on the Cartesian maxima, so the Bounded slow-down stops once it is close
+/// rather than chasing the last fraction of a percent through repeated re-timings.
+constexpr double kBoundedSpeedTolerance = 1.02;
 
-  return interpolatePose(waypoints.at(i), waypoints.at(i + 1), fraction);
-}
-
-double CartesianPathPlanner::FeedrateProfile::sample(double s) const {
-  if (!enabled || ceiling.empty()) {
-    return 1.0;
-  }
-  const double x = std::clamp(s / ds, 0.0, static_cast<double>(ceiling.size() - 1));
-  const size_t k = std::min(ceiling.size() - 2, static_cast<size_t>(x));
-  const double frac = x - static_cast<double>(k);
-  return ceiling.at(k) + frac * (ceiling.at(k + 1) - ceiling.at(k));
-}
-
-CartesianPathPlanner::CartesianPathPlanner(const std::shared_ptr<Scene> scene,
-                                           const CartesianPlannerOptions& options)
-    : scene_{scene}, options_{options}, oink_{std::make_shared<Oink>(*scene, options.group_name)},
-      toppra_{scene, options.group_name} {
-  const auto maybe_joint_group_info = scene_->getJointGroupInfo(options_.group_name);
+/// @brief Resolves a joint group, throwing the planner's construction error if it does not exist.
+JointGroupInfo resolveJointGroup(const Scene& scene, const std::string& group_name) {
+  auto maybe_joint_group_info = scene.getJointGroupInfo(group_name);
   if (!maybe_joint_group_info) {
     throw std::runtime_error("Could not initialize Cartesian path planner: " +
                              maybe_joint_group_info.error());
   }
-  joint_group_info_ = maybe_joint_group_info.value();
+  return maybe_joint_group_info.value();
+}
+
+}  // namespace
+
+Eigen::Matrix4d CartesianPathPlanner::FrameReference::eval(double s) const {
+  if (waypoints.empty()) {
+    return Eigen::Matrix4d::Identity();
+  }
+  if (waypoints.size() == 1) {
+    return waypoints.back();
+  }
+
+  s = std::clamp(s, 0.0, 1.0);
+
+  // Find the segment [i, i+1] containing path parameter s.
+  const auto upper = std::upper_bound(cumulative.begin(), cumulative.end(), s);
+  size_t i = static_cast<size_t>(std::distance(cumulative.begin(), upper));
+  i = std::clamp<size_t>(i, 1, cumulative.size() - 1) - 1;
+
+  const double t0 = cumulative.at(i);
+  const double t1 = cumulative.at(i + 1);
+  const double span = t1 - t0;
+  const double fraction = span > 0.0 ? (s - t0) / span : 0.0;
+
+  return interpolatePose(waypoints.at(i), waypoints.at(i + 1), fraction);
+}
+
+CartesianPathPlanner::CartesianPathPlanner(const std::shared_ptr<Scene> scene,
+                                           const CartesianPlannerOptions& options)
+    : scene_{scene}, options_{options},
+      joint_group_info_{resolveJointGroup(*scene, options.group_name)},
+      oink_{std::make_shared<Oink>(*scene, options.group_name)},
+      toppra_{scene, options.group_name} {
   buildStaticSolverComponents(std::nullopt);
 }
 
 CartesianPathPlanner::CartesianPathPlanner(const std::shared_ptr<Scene> scene,
                                            const CartesianPlannerOptions& options,
                                            const CartesianPlannerComponents& components)
-    : scene_{scene}, options_{options}, oink_{components.oink}, toppra_{scene, options.group_name} {
+    : scene_{scene}, options_{options},
+      joint_group_info_{resolveJointGroup(*scene, options.group_name)}, oink_{components.oink},
+      toppra_{scene, options.group_name} {
   if (!components.oink) {
     throw std::runtime_error(
         "Could not initialize Cartesian path planner: components.oink must not be null.");
@@ -186,12 +146,6 @@ CartesianPathPlanner::CartesianPathPlanner(const std::shared_ptr<Scene> scene,
                                "components.tracking_tasks must not contain a null entry.");
     }
   }
-  const auto maybe_joint_group_info = scene_->getJointGroupInfo(options_.group_name);
-  if (!maybe_joint_group_info) {
-    throw std::runtime_error("Could not initialize Cartesian path planner: " +
-                             maybe_joint_group_info.error());
-  }
-  joint_group_info_ = maybe_joint_group_info.value();
   buildStaticSolverComponents(components);
 }
 
@@ -212,33 +166,18 @@ void CartesianPathPlanner::buildStaticSolverComponents(
     constraints_ = components->constraints;
     barriers_ = components->barriers;
 
-    // The caller owns limit handling through the constraints they supplied, so the planner relies
-    // entirely on their OInK setup here. The scene's physical velocity limits (unscaled) are used
-    // only as an optional hard-limit verification net: if unavailable or mismatched, we simply
-    // skip the per-step check rather than failing (unlike the default setup below, which must build
-    // the VelocityLimit constraint itself and therefore requires the limits).
-    if (maybe_velocity_limits && maybe_velocity_limits->second.size() == num_variables) {
-      verify_v_max_ = maybe_velocity_limits->second.cwiseAbs();
-      has_velocity_check_ = true;
-    }
     return;
   }
 
-  // Default setup: the velocity/position-limit constraints and the verification limits do not
-  // depend on the path or seed, so build them once here. The per-end-effector FrameTasks and the
-  // nullspace ConfigurationTask are (re)built in buildFrameTracks() because they do.
+  // Default setup: the velocity/position-limit constraints do not depend on the path or seed, so
+  // build them once here. The per-end-effector FrameTasks and the nullspace ConfigurationTask are
+  // (re)built in buildFrameReferences() because they do.
   if (!maybe_velocity_limits) {
     throw std::runtime_error("Could not initialize Cartesian path planner: could not get joint "
                              "velocity limits: " +
                              maybe_velocity_limits.error());
   }
-  // The velocity scale belongs to whichever stage owns the final timing:
-  // - Bounded mode emits the traced motion directly, so its steps must respect the scaled limits.
-  // - TimeOptimal mode only resolves path geometry and hands it to TOPP-RA, which applies the scale
-  //   during re-timing.
-  const double resolution_velocity_scale =
-      options_.speed_mode == CartesianSpeedMode::TimeOptimal ? 1.0 : options_.velocity_scale;
-  Eigen::VectorXd v_max = maybe_velocity_limits->second.cwiseAbs() * resolution_velocity_scale;
+  Eigen::VectorXd v_max = maybe_velocity_limits->second.cwiseAbs();
   if (v_max.size() != num_variables) {
     throw std::runtime_error(
         "Could not initialize Cartesian path planner: velocity limit vector size (" +
@@ -246,13 +185,11 @@ void CartesianPathPlanner::buildStaticSolverComponents(
         std::to_string(num_variables) + ").");
   }
 
-  // Enforce both joint velocity and joint position limits inside the QP:
-  //   - VelocityLimit bounds each step to dt * v_max (so |delta_q|/dt <= v_max).
+  // Bound each IK iteration inside the QP:
+  //   - VelocityLimit caps a single step at dt * v_max, keeping iterations well conditioned.
   //   - PositionLimit restricts each step so the integrated configuration stays within limits.
   constraints_ = {std::make_shared<VelocityLimit>(*oink_, options_.dt, v_max),
                   std::make_shared<PositionLimit>(*oink_, options_.position_limit_gain)};
-  verify_v_max_ = std::move(v_max);
-  has_velocity_check_ = true;
 }
 
 tl::expected<void, std::string> CartesianPlannerOptions::validate() const {
@@ -268,9 +205,6 @@ tl::expected<void, std::string> CartesianPlannerOptions::validate() const {
   }
   if (acceleration_scale <= 0.0 || acceleration_scale > 1.0) {
     return tl::make_unexpected("acceleration_scale must be in the interval (0, 1].");
-  }
-  if (limit_ratio_tolerance < 1.0) {
-    return tl::make_unexpected("limit_ratio_tolerance must be >= 1.0.");
   }
   return {};
 }
@@ -323,65 +257,84 @@ CartesianPathPlanner::plan(const CartesianPath& path, const JointConfiguration& 
   return tl::make_unexpected("Unknown CartesianSpeedMode.");
 }
 
-tl::expected<std::vector<CartesianPathPlanner::FrameTrack>, std::string>
-CartesianPathPlanner::buildFrameTracks(const CartesianPath& path,
-                                       const Eigen::VectorXd& q_start_full, double linear_speed,
-                                       double angular_speed) {
+tl::expected<std::vector<CartesianPathPlanner::FrameReference>, std::string>
+CartesianPathPlanner::buildFrameReferences(const CartesianPath& path,
+                                           const Eigen::VectorXd& q_start_full) {
   const size_t num_frames = path.tforms.size();
 
   // The Oink FrameTask expects its target expressed in the world frame, while the CartesianPath
   // waypoints are given relative to each frame's base. The base frame is fixed relative to the
   // world for a fixed-base robot, so compute world_T_base once per frame and use it to map each
   // base-relative reference pose into the world frame.
-  std::vector<FrameTrack> tracks(num_frames);
+  std::vector<FrameReference> references(num_frames);
   for (size_t f = 0; f < num_frames; ++f) {
-    FrameTrack& track = tracks.at(f);
-    track.tip_frame = path.tip_frames.at(f);
+    FrameReference& reference = references.at(f);
+    reference.tip_frame = path.tip_frames.at(f);
+    reference.waypoints = path.tforms.at(f);
 
-    // Arc-length timing: time each segment by whichever of the linear/angular motion takes longer
-    // at the commanded speeds, so advancing the reference at feedrate 1.0 traces the path at the
-    // binding commanded max speed on each segment.
-    track.waypoints = path.tforms.at(f);
-    track.cumulative_times.assign(track.waypoints.size(), 0.0);
-    for (size_t i = 1; i < track.waypoints.size(); ++i) {
+    // Arc-length parameterization: measure each segment as the larger of its share of the total
+    // translation and its share of the total rotation, so a frame progresses evenly through
+    // whichever motion dominates locally. The result is normalized to [0, 1] and carries no
+    // timing, which is the whole point: every frame reaches its end at s = 1 together.
+    const size_t count = reference.waypoints.size();
+    std::vector<double> linear_steps(count, 0.0);
+    std::vector<double> angular_steps(count, 0.0);
+    for (size_t i = 1; i < count; ++i) {
       const auto [linear_distance, angular_distance] =
-          poseError(track.waypoints.at(i - 1), track.waypoints.at(i));
-      const double linear_time = linear_speed > 0.0 ? linear_distance / linear_speed : 0.0;
-      const double angular_time = angular_speed > 0.0 ? angular_distance / angular_speed : 0.0;
-      track.cumulative_times.at(i) =
-          track.cumulative_times.at(i - 1) + std::max(linear_time, angular_time);
+          poseError(reference.waypoints.at(i - 1), reference.waypoints.at(i));
+      linear_steps.at(i) = linear_distance;
+      angular_steps.at(i) = angular_distance;
+      reference.linear_length += linear_distance;
+      reference.angular_length += angular_distance;
     }
-    track.total_time = track.cumulative_times.empty() ? 0.0 : track.cumulative_times.back();
+
+    reference.cumulative.assign(count, 0.0);
+    for (size_t i = 1; i < count; ++i) {
+      const double linear_share =
+          reference.linear_length > kEps ? linear_steps.at(i) / reference.linear_length : 0.0;
+      const double angular_share =
+          reference.angular_length > kEps ? angular_steps.at(i) / reference.angular_length : 0.0;
+      reference.cumulative.at(i) =
+          reference.cumulative.at(i - 1) + std::max(linear_share, angular_share);
+    }
+    const double total = reference.cumulative.back();
+    if (total > kEps) {
+      for (double& value : reference.cumulative) {
+        value /= total;
+      }
+    }
+    reference.cumulative.back() = 1.0;
 
     // Resolve the tip frame up front so the FrameTask construction below cannot throw.
-    if (const auto maybe_tip_id = scene_->getFrameId(track.tip_frame); !maybe_tip_id) {
-      return tl::make_unexpected("Could not resolve tip frame '" + track.tip_frame +
+    if (const auto maybe_tip_id = scene_->getFrameId(reference.tip_frame); !maybe_tip_id) {
+      return tl::make_unexpected("Could not resolve tip frame '" + reference.tip_frame +
                                  "': " + maybe_tip_id.error());
     }
     try {
-      track.world_T_base = scene_->forwardKinematics(q_start_full, path.base_frames.at(f));
+      reference.world_T_base = scene_->forwardKinematics(q_start_full, path.base_frames.at(f));
     } catch (const std::exception& e) {
       return tl::make_unexpected(std::string("Could not resolve base frame '") +
                                  path.base_frames.at(f) + "': " + e.what());
     }
   }
 
-  // Wire up the per-end-effector tracking tasks. The constraints, barriers, and velocity-limit
-  // verification were assembled once at construction (see buildStaticSolverComponents).
+  // Wire up the per-end-effector tracking tasks.
+  // Constraints and barriers were assembled once at construction (see buildStaticSolverComponents).
   if (!tracking_tasks_.empty()) {
     // Caller-supplied setup: map each pre-assembled tracking task to its path frame (matched by
     // order) and validate the ordering. The solver task list (tasks_) is already built.
     for (size_t f = 0; f < num_frames; ++f) {
       const auto& tracking_task = tracking_tasks_.at(f);
-      if (tracking_task->frame_name != tracks.at(f).tip_frame) {
-        return tl::make_unexpected(
-            "Tracking task " + std::to_string(f) + " tracks frame '" + tracking_task->frame_name +
-            "' but path end-effector " + std::to_string(f) + " is '" + tracks.at(f).tip_frame +
-            "'. Tracking tasks must be ordered to match the path's tip frames.");
+      if (tracking_task->frame_name != references.at(f).tip_frame) {
+        return tl::make_unexpected("Tracking task " + std::to_string(f) + " tracks frame '" +
+                                   tracking_task->frame_name + "' but path end-effector " +
+                                   std::to_string(f) + " is '" + references.at(f).tip_frame +
+                                   "'. Tracking tasks must be ordered to match the path's tip "
+                                   "frames.");
       }
-      tracks.at(f).task = tracking_task;
+      references.at(f).task = tracking_task;
     }
-    return tracks;
+    return references;
   }
 
   // Default setup: (re)build one priority-1 frame task per end-effector tracking its reference
@@ -394,16 +347,16 @@ CartesianPathPlanner::buildFrameTracks(const CartesianPath& path,
   for (size_t f = 0; f < num_frames; ++f) {
     CartesianConfiguration target;
     target.base_frame = "";  // FrameTask interprets the target tform in the world frame.
-    target.tip_frame = tracks.at(f).tip_frame;
-    target.tform = tracks.at(f).target(0.0);
+    target.tip_frame = references.at(f).tip_frame;
+    target.tform = references.at(f).target(0.0);
     FrameTaskOptions frame_options;
     frame_options.position_cost = options_.position_cost;
     frame_options.orientation_cost = options_.orientation_cost;
     frame_options.task_gain = options_.task_gain;
     frame_options.lm_damping = options_.lm_damping;
     frame_options.priority = 1;
-    tracks.at(f).task = std::make_shared<FrameTask>(oink, *scene_, target, frame_options);
-    tasks_.push_back(tracks.at(f).task);
+    references.at(f).task = std::make_shared<FrameTask>(oink, *scene_, target, frame_options);
+    tasks_.push_back(references.at(f).task);
   }
 
   const Eigen::VectorXd joint_weights =
@@ -413,95 +366,21 @@ CartesianPathPlanner::buildFrameTracks(const CartesianPath& path,
   const Eigen::VectorXd target_q = q_start_full(oink.q_indices);
   tasks_.push_back(
       std::make_shared<ConfigurationTask>(oink, target_q, joint_weights, config_options));
-  return tracks;
-}
-
-CartesianPathPlanner::FeedrateProfile CartesianPathPlanner::buildFeedrateProfile(
-    const std::vector<FrameTrack>& tracks, double total_time, double linear_speed,
-    double angular_speed, double linear_acceleration, double angular_acceleration) const {
-  FeedrateProfile profile;
-  if (linear_acceleration <= 0.0 || angular_acceleration <= 0.0) {
-    return profile;  // Disabled: constant full feedrate (used by the TimeOptimal resolution pass).
-  }
-
-  // Bound the feedrate acceleration s_ddot (units 1/s) so the Cartesian acceleration stays within
-  // the commanded maxima. On a straight segment the Cartesian linear acceleration is
-  // s_ddot * v_nominal, where v_nominal <= linear_speed; bounding s_ddot <= linear_acceleration /
-  // linear_speed therefore keeps it within linear_acceleration (and likewise for rotation). Take
-  // the binding (smaller) limit, ignoring a modality the path has no motion in.
-  double total_linear_distance = 0.0;
-  double total_angular_distance = 0.0;
-  for (const auto& track : tracks) {
-    const auto& waypoints = track.waypoints;
-    for (size_t i = 1; i < waypoints.size(); ++i) {
-      const auto [linear_distance, angular_distance] =
-          poseError(waypoints.at(i - 1), waypoints.at(i));
-      total_linear_distance += linear_distance;
-      total_angular_distance += angular_distance;
-    }
-  }
-  double s_ddot_max = std::numeric_limits<double>::infinity();
-  if (total_linear_distance > kEps && linear_speed > 0.0) {
-    s_ddot_max = std::min(s_ddot_max, linear_acceleration / linear_speed);
-  }
-  if (total_angular_distance > kEps && angular_speed > 0.0) {
-    s_ddot_max = std::min(s_ddot_max, angular_acceleration / angular_speed);
-  }
-  if (!std::isfinite(s_ddot_max) || s_ddot_max <= 0.0 || total_time <= 0.0) {
-    return profile;  // Degenerate (zero-length path): fall back to constant feedrate.
-  }
-
-  // Feedrate ceiling on a uniform grid in reference time (one knot per control period): start at
-  // full speed everywhere, force a stop at the path end, then clamp each corner knot to its cap.
-  const size_t num_intervals =
-      std::max<size_t>(1, static_cast<size_t>(std::ceil(total_time / options_.dt)));
-  const double ds = total_time / static_cast<double>(num_intervals);
-  std::vector<double> ceiling(num_intervals + 1, 1.0);
-  ceiling.back() = 0.0;
-  size_t num_corner_knots = 0;
-  for (const auto& track : tracks) {
-    const auto& waypoints = track.waypoints;
-    if (waypoints.size() < 3) {
-      continue;
-    }
-    for (size_t i = 1; i + 1 < waypoints.size(); ++i) {
-      const double cap = cornerFeedrateCap(waypoints.at(i - 1), waypoints.at(i),
-                                           waypoints.at(i + 1), linear_acceleration, linear_speed,
-                                           angular_acceleration, angular_speed, options_.dt);
-      const size_t k = std::min(
-          num_intervals, static_cast<size_t>(std::llround(track.cumulative_times.at(i) / ds)));
-      ceiling.at(k) = std::min(ceiling.at(k), cap);
-      ++num_corner_knots;
-    }
-  }
-  // Backward pass: enforce that the feedrate at each knot can still decelerate to the cap at the
-  // next knot within s_ddot_max (v^2 <= v_next^2 + 2 * a * ds). This turns the per-corner caps
-  // into a continuous deceleration envelope the servo loop ramps up against.
-  for (size_t k = ceiling.size() - 1; k-- > 0;) {
-    const double feasible =
-        std::sqrt(ceiling.at(k + 1) * ceiling.at(k + 1) + 2.0 * s_ddot_max * ds);
-    ceiling.at(k) = std::min(ceiling.at(k), feasible);
-  }
-
-  profile.enabled = true;
-  profile.ceiling = std::move(ceiling);
-  profile.ds = ds;
-  profile.s_ddot_max = s_ddot_max;
-  profile.num_corner_knots = num_corner_knots;
-  return profile;
+  return references;
 }
 
 tl::expected<void, std::string>
-CartesianPathPlanner::solveStep(const std::vector<FrameTrack>& tracks, const Eigen::VectorXd& q,
-                                double s, Eigen::VectorXd& q_candidate, Eigen::VectorXd& delta_q,
-                                double& position_error, double& orientation_error) {
+CartesianPathPlanner::solveStep(const std::vector<FrameReference>& references,
+                                const Eigen::VectorXd& q, double s, Eigen::VectorXd& q_candidate,
+                                Eigen::VectorXd& delta_q, double& position_error,
+                                double& orientation_error) {
   Oink& oink = *oink_;
 
   // Refresh the scene state to the committed configuration so the Oink tasks read the correct
   // current pose, and retarget every tracking task.
   scene_->setJointPositions(q);
-  for (const auto& track : tracks) {
-    track.task->setTargetFrameTransform(track.target(s));
+  for (const auto& reference : references) {
+    reference.task->setTargetFrameTransform(reference.target(s));
   }
   delta_q.setZero();
   const auto result =
@@ -516,9 +395,9 @@ CartesianPathPlanner::solveStep(const std::vector<FrameTrack>& tracks, const Eig
   // Worst-case pose error across all tracked frames drives the tolerance/throttling logic.
   position_error = 0.0;
   orientation_error = 0.0;
-  for (const auto& track : tracks) {
-    const Eigen::Matrix4d fk = scene_->forwardKinematics(q_candidate, track.tip_frame);
-    const auto [frame_position_error, frame_orientation_error] = poseError(fk, track.target(s));
+  for (const auto& reference : references) {
+    const Eigen::Matrix4d fk = scene_->forwardKinematics(q_candidate, reference.tip_frame);
+    const auto [frame_position_error, frame_orientation_error] = poseError(fk, reference.target(s));
     position_error = std::max(position_error, frame_position_error);
     orientation_error = std::max(orientation_error, frame_orientation_error);
   }
@@ -526,200 +405,230 @@ CartesianPathPlanner::solveStep(const std::vector<FrameTrack>& tracks, const Eig
 }
 
 tl::expected<void, std::string>
-CartesianPathPlanner::convergeToStart(const std::vector<FrameTrack>& tracks, Eigen::VectorXd& q) {
+CartesianPathPlanner::converge(const std::vector<FrameReference>& references, double s,
+                               double position_tolerance, double orientation_tolerance,
+                               Eigen::VectorXd& q) {
   Eigen::VectorXd delta_q(oink_->num_variables);
   Eigen::VectorXd q_candidate;
   double position_error = 0.0;
   double orientation_error = 0.0;
+  double best_error = std::numeric_limits<double>::infinity();
+  int stagnant = 0;
   for (int i = 0; i < kMaxIkConvergenceIters; ++i) {
     const auto step =
-        solveStep(tracks, q, 0.0, q_candidate, delta_q, position_error, orientation_error);
+        solveStep(references, q, s, q_candidate, delta_q, position_error, orientation_error);
     if (!step) {
-      return tl::make_unexpected("Oink solve failed while converging to the first waypoint: " +
-                                 step.error());
+      return tl::make_unexpected(step.error());
     }
-    q = q_candidate;
-    if (position_error <= options_.max_position_error &&
-        orientation_error <= options_.max_orientation_error) {
+    // Clamp away solver-epsilon overshoot of the position limits, since the QP only satisfies its
+    // constraints to within the solver tolerance.
+    q = scene_->clampToValidConfiguration(q_candidate);
+    if (position_error <= position_tolerance && orientation_error <= orientation_tolerance) {
       return {};
     }
+    // Stop once the solve plateaus: the target is tighter than the solver's own precision, so this
+    // is the normal exit for a healthy sample.
+    const double error = std::max(position_error / std::max(position_tolerance, kEps),
+                                  orientation_error / std::max(orientation_tolerance, kEps));
+    if (error < best_error * kStagnationImprovement) {
+      best_error = error;
+      stagnant = 0;
+    } else if (++stagnant >= kMaxStagnantIters) {
+      break;
+    }
   }
-  return tl::make_unexpected(
-      "Could not converge to the first waypoint within tolerance (position error " +
-      std::to_string(position_error) + " m, orientation error " +
-      std::to_string(orientation_error) +
-      " rad). Ensure q_start places the tool(s) at or near the first waypoint.");
+
+  // The tight target is there to make the path smooth, not to gate success; accept the best
+  // solution found as long as it honors the tolerance the caller actually asked for.
+  if (position_error <= options_.max_position_error &&
+      orientation_error <= options_.max_orientation_error) {
+    return {};
+  }
+  return tl::make_unexpected("position error " + std::to_string(position_error) +
+                             " m, orientation error " + std::to_string(orientation_error) +
+                             " rad exceed the path tolerance");
 }
 
-tl::expected<JointTrajectory, std::string>
-CartesianPathPlanner::runServoLoop(const std::vector<FrameTrack>& tracks,
-                                   const FeedrateProfile& profile, double total_time,
-                                   Eigen::VectorXd& q) {
-  Oink& oink = *oink_;
-  const int num_variables = oink.num_variables;
-
-  // Initialize the trace at the converged start. The accelerations are filled by the plan*()
-  // caller; here we only produce positions, velocities, and times.
-  JointTrajectory trajectory;
-  trajectory.joint_names = joint_group_info_.joint_names;
-  trajectory.positions.push_back(q(oink.q_indices).eval());
-  trajectory.velocities.push_back(Eigen::VectorXd::Zero(num_variables));
-  trajectory.times.push_back(0.0);
-
-  // The acceleration ramps (start, end, and every corner where the feedrate dips to a stop) extend
-  // the motion past the nominal full-speed duration, so size the safety cap on an estimate that
-  // adds a full ramp-up/ramp-down per corner knot plus the endpoints.
-  const double profile_duration =
-      profile.enabled ? total_time + (static_cast<double>(profile.num_corner_knots) + 2.0) * 2.0 /
-                                         profile.s_ddot_max
-                      : total_time;
-  const int hard_cap = static_cast<int>(std::ceil(profile_duration / options_.dt)) *
-                           (options_.max_attempts_per_step + 2) +
-                       kHardCapStepMargin;
-
-  // Per-step scratch reused across iterations.
-  Eigen::VectorXd delta_q(num_variables);
-  Eigen::VectorXd q_candidate;
-  double position_error = 0.0;
-  double orientation_error = 0.0;
-
-  double s = 0.0;
-  double feedrate = 0.0;  // Current feedrate ds/dt in [0, 1]; ramped under the trapezoidal profile.
-  int total_steps = 0;
-  while (s < total_time - kEps) {
-    // Commanded feedrate for this step. Without the profile this is full speed; with it, ramp
-    // toward full speed at s_ddot_max but never above the precomputed deceleration envelope (which
-    // forces the feedrate down before each corner cap and to a stop at the path end), then floor it
-    // at one ramp step so a near-reversal corner is crawled through rather than deadlocking.
-    double feedrate_cmd = 1.0;
-    if (profile.enabled) {
-      const double ramped = feedrate + profile.s_ddot_max * options_.dt;
-      feedrate_cmd = std::min({1.0, profile.sample(s), ramped});
-      feedrate_cmd = std::max(feedrate_cmd, profile.s_ddot_max * options_.dt);
-    }
-
-    bool committed = false;
-    double feedrate_eff = feedrate_cmd;
-    double committed_s = s;
-    // Halving the feedrate only helps while it still moves the reference. Once an attempt would
-    // advance `s` by less than this, the retry re-solves an unchanged problem (and committing a
-    // step that does not advance `s` at all would spin the loop without progress), so the ladder
-    // stops there and the stall below is declared instead of burning the remaining attempts.
-    const double min_advance = kMinRelativeAdvance * total_time;
-    for (int attempt = 0; attempt < options_.max_attempts_per_step; ++attempt) {
-      const double s_try = std::min(s + feedrate_eff * options_.dt, total_time);
-      if (s_try < total_time && s_try - s < min_advance) {
-        break;
-      }
-      const auto step =
-          solveStep(tracks, q, s_try, q_candidate, delta_q, position_error, orientation_error);
-      if (!step) {
-        return tl::make_unexpected("Oink solve failed at reference time " + std::to_string(s) +
-                                   "s: " + step.error());
-      }
-      if (position_error <= options_.max_position_error &&
-          orientation_error <= options_.max_orientation_error) {
-        committed = true;
-        committed_s = s_try;
-        break;
-      }
-      feedrate_eff *= 0.5;
-    }
-
-    if (!committed) {
-      return tl::make_unexpected(
-          "Cartesian planner stalled at reference time " + std::to_string(s) +
-          "s: cannot stay within tolerance (position error " + std::to_string(position_error) +
-          " m, orientation error " + std::to_string(orientation_error) +
-          " rad). The path may be unreachable or pass through a singularity.");
-    }
-
-    // Commit the step. Carry the achieved feedrate forward so the next ramp continues from the
-    // real speed (a throttled step naturally slows the profile).
-    s = committed_s;
-    feedrate = feedrate_eff;
-    // Clamp away solver-epsilon overshoot of the position limits, since the QP only satisfiesExpand
-    // commentComment on line R621Resolved its constraints to within the solver tolerance.
-    q = scene_->clampToValidConfiguration(q_candidate);
-
-    // The velocity constraint keeps each step within the joint velocity limits inside the QP;
-    // verify the committed step actually does, to guard against solver constraint relaxation or
-    // numerical drift. Skipped when no velocity limits are available.
-    if (has_velocity_check_) {
-      const Eigen::ArrayXd velocity_bound =
-          options_.dt * verify_v_max_.array() * (1.0 + kLimitRelTolerance) + kEps;
-      if ((delta_q.array().abs() > velocity_bound).any()) {
-        return tl::make_unexpected(
-            "Joint velocity limit exceeded at reference time " + std::to_string(s) +
-            "s (peak |q_dot| = " +
-            std::to_string((delta_q.array().abs() / options_.dt).maxCoeff()) + " vs. limit " +
-            std::to_string(verify_v_max_.maxCoeff()) + ").");
-      }
-    }
-    if (!scene_->isValidConfiguration(q)) {
-      return tl::make_unexpected("Joint position limit exceeded at reference time " +
-                                 std::to_string(s) + "s.");
-    }
-
-    ++total_steps;
-    trajectory.times.push_back(total_steps * options_.dt);
-    trajectory.positions.push_back(q(oink.q_indices).eval());
-    trajectory.velocities.push_back((delta_q / options_.dt).eval());
-
-    if (total_steps > hard_cap) {
-      return tl::make_unexpected(
-          "Cartesian planner exceeded the maximum number of control steps (" +
-          std::to_string(hard_cap) + "). The path may be infeasible at the requested tolerance.");
-    }
+tl::expected<std::vector<Eigen::VectorXd>, std::string>
+CartesianPathPlanner::resolvePath(const CartesianPath& path, const Eigen::VectorXd& q_start_full) {
+  auto references = buildFrameReferences(path, q_start_full);
+  if (!references) {
+    return tl::make_unexpected(references.error());
   }
 
-  return trajectory;
-}
-
-tl::expected<JointTrajectory, std::string>
-CartesianPathPlanner::trackReference(const CartesianPath& path, const Eigen::VectorXd& q_start_full,
-                                     double linear_speed, double angular_speed,
-                                     double linear_acceleration, double angular_acceleration) {
-  auto tracks = buildFrameTracks(path, q_start_full, linear_speed, angular_speed);
-  if (!tracks) {
-    return tl::make_unexpected(tracks.error());
+  // Walk the path in small steps so every IK solve starts from a near neighbour. The step is a
+  // seeding concern, not an output resolution: a solve that had to cross the whole path at once
+  // would need thousands of iterations and could land on a different IK branch. Which of these
+  // samples survive as waypoints is decided below, on tool deviation.
+  const double seed_linear_step = kSeedStepFraction * options_.max_position_error;
+  const double seed_angular_step = kSeedStepFraction * options_.max_orientation_error;
+  double steps = 1.0;
+  for (const auto& reference : *references) {
+    if (seed_linear_step > 0.0) {
+      steps = std::max(steps, reference.linear_length / seed_linear_step);
+    }
+    if (seed_angular_step > 0.0) {
+      steps = std::max(steps, reference.angular_length / seed_angular_step);
+    }
   }
+  const size_t num_steps =
+      std::clamp<size_t>(static_cast<size_t>(std::ceil(steps)), 1, kMaxResolutionSamples);
 
-  // Common timeline: a single reference time `s` advances all frames together; each reference
-  // clamps `s` to its own duration, so a shorter motion simply holds at its final waypoint.
-  double total_time = 0.0;
-  for (const auto& track : *tracks) {
-    total_time = std::max(total_time, track.total_time);
-  }
+  // Converge each sample far tighter than the deviation it is there to bound, so the resolved path
+  // is shaped by the commanded motion rather than by residual IK error.
+  const double converge_position = kIkConvergenceFraction * options_.max_position_error;
+  const double converge_orientation = kIkConvergenceFraction * options_.max_orientation_error;
 
-  const FeedrateProfile profile = buildFeedrateProfile(
-      *tracks, total_time, linear_speed, angular_speed, linear_acceleration, angular_acceleration);
-
+  std::vector<double> parameters(num_steps + 1);
+  std::vector<Eigen::VectorXd> walked(num_steps + 1);
   Eigen::VectorXd q = q_start_full;
-  if (const auto converged = convergeToStart(*tracks, q); !converged) {
-    return tl::make_unexpected(converged.error());
+  for (size_t k = 0; k <= num_steps; ++k) {
+    const double s = static_cast<double>(k) / static_cast<double>(num_steps);
+    if (const auto converged = converge(*references, s, converge_position, converge_orientation, q);
+        !converged) {
+      return tl::make_unexpected(
+          "Could not resolve path fraction " + std::to_string(s) + ": " + converged.error() +
+          ". The path may leave the reachable workspace or pass through a singularity" +
+          (k == 0 ? ", or q_start may be too far from the first waypoint." : "."));
+    }
+    parameters.at(k) = s;
+    walked.at(k) = q;
   }
-  return runServoLoop(*tracks, profile, total_time, q);
+
+  // Choose the fewest waypoints that still describe the motion. Every waypoint handed to the time
+  // parameterization becomes a corner it must slow through, and its blend radius is capped by the
+  // adjacent segment, so waypoint count sets the achievable speed directly: an unnecessary sample
+  // costs a near-stop and buys nothing. Keep a sample only when dropping it would let the tool
+  // stray, measured the way the trajectory will actually travel.
+  const double position_budget = kSubdivisionToleranceFraction * options_.max_position_error;
+  const double orientation_budget = kSubdivisionToleranceFraction * options_.max_orientation_error;
+  std::vector<bool> keep(walked.size(), false);
+  keep.front() = true;
+  keep.back() = true;
+  std::vector<std::pair<size_t, size_t>> pending{{0, walked.size() - 1}};
+  while (!pending.empty()) {
+    const auto [lo, hi] = pending.back();
+    pending.pop_back();
+    if (hi <= lo + 1) {
+      continue;
+    }
+    double worst = 0.0;
+    size_t worst_index = lo;
+    for (size_t i = lo + 1; i < hi; ++i) {
+      const double fraction = static_cast<double>(i - lo) / static_cast<double>(hi - lo);
+      const Eigen::VectorXd q_interp = scene_->interpolate(walked.at(lo), walked.at(hi), fraction);
+      for (const auto& reference : *references) {
+        const Eigen::Matrix4d fk = scene_->forwardKinematics(q_interp, reference.tip_frame);
+        const auto [position_error, orientation_error] =
+            poseError(fk, reference.target(parameters.at(i)));
+        // Compare both modalities against their own budget so whichever is tighter decides.
+        const double excess = std::max(position_error / std::max(position_budget, kEps),
+                                       orientation_error / std::max(orientation_budget, kEps));
+        if (excess > worst) {
+          worst = excess;
+          worst_index = i;
+        }
+      }
+    }
+    if (worst > 1.0) {
+      keep.at(worst_index) = true;
+      pending.push_back({lo, worst_index});
+      pending.push_back({worst_index, hi});
+    }
+  }
+
+  std::vector<Eigen::VectorXd> resolved;
+  resolved.reserve(walked.size());
+  for (size_t i = 0; i < walked.size(); ++i) {
+    if (keep.at(i)) {
+      resolved.push_back(walked.at(i)(oink_->q_indices).eval());
+    }
+  }
+  return resolved;
 }
 
-void CartesianPathPlanner::fillAccelerations(JointTrajectory& trajectory) const {
-  // Fill accelerations by backward finite difference of the velocities.
-  const int num_variables =
-      trajectory.velocities.empty() ? 0 : static_cast<int>(trajectory.velocities.front().size());
-  trajectory.accelerations.assign(trajectory.velocities.size(),
-                                  Eigen::VectorXd::Zero(num_variables));
-  for (size_t i = 1; i < trajectory.velocities.size(); ++i) {
-    trajectory.accelerations.at(i) =
-        (trajectory.velocities.at(i) - trajectory.velocities.at(i - 1)) / options_.dt;
+tl::expected<JointTrajectory, std::string>
+CartesianPathPlanner::timeParameterize(const std::vector<Eigen::VectorXd>& resolved,
+                                       double velocity_scale, double acceleration_scale) {
+  if (resolved.size() < 2) {
+    return tl::make_unexpected(
+        "Resolved joint path has fewer than 2 waypoints; the Cartesian path may be degenerate "
+        "or too short to time-parameterize.");
   }
-  // The motion starts and ends at rest, so the boundary accelerations are zero. The final servo
-  // step lands exactly on the path end as a sub-dt fragment, which makes its finite-difference
-  // acceleration spuriously large; zero both boundaries so this sampling artifact does not pollute
-  // the reported peak or trigger an unnecessary slow-down.
-  if (!trajectory.accelerations.empty()) {
-    trajectory.accelerations.front().setZero();
-    trajectory.accelerations.back().setZero();
+
+  TOPPRAOptions toppra_options;
+  toppra_options.dt = options_.dt;
+  toppra_options.mode = SplineFittingMode::LinearBlend;
+  toppra_options.velocity_scale = velocity_scale;
+  toppra_options.acceleration_scale = acceleration_scale;
+
+  // A hard cap still bounds the time-parameterization problem size for very long paths.
+  JointPath joint_path;
+  joint_path.joint_names = joint_group_info_.joint_names;
+  joint_path.positions =
+      resolved.size() > kMaxToppraWaypoints
+          ? resampleUniform(resolved, kMaxToppraWaypoints, *scene_, joint_group_info_.q_indices)
+          : resolved;
+
+  std::string last_error;
+  double blend_deviation = options_.toppra_blend_deviation;
+  for (int attempt = 0; attempt < kMaxBlendAttempts; ++attempt) {
+    toppra_options.max_blend_deviation = blend_deviation;
+    auto maybe_trajectory = toppra_.generate(joint_path, toppra_options);
+    if (maybe_trajectory) {
+      return std::move(maybe_trajectory.value());
+    }
+    last_error = maybe_trajectory.error();
+    blend_deviation *= 0.5;
   }
+  return tl::make_unexpected("TOPP-RA time parameterization failed: " + last_error);
+}
+
+CartesianPathPlanner::CartesianPeaks
+CartesianPathPlanner::computeCartesianPeaks(const JointTrajectory& trajectory,
+                                            const CartesianPath& path) const {
+  CartesianPeaks peaks;
+  if (trajectory.positions.size() < 2 || options_.dt <= 0.0) {
+    return peaks;
+  }
+
+  // The trajectory stores only the group coordinates; forwardKinematics needs a full model
+  // configuration. The non-group joints are held at the scene's current state, a constant rigid
+  // offset that cancels in the per-sample differences below.
+  Eigen::VectorXd q_full = scene_->getCurrentJointPositions();
+  for (const auto& tip_frame : path.tip_frames) {
+    std::vector<double> linear_speeds;
+    std::vector<double> angular_speeds;
+    linear_speeds.reserve(trajectory.positions.size());
+    angular_speeds.reserve(trajectory.positions.size());
+
+    q_full(joint_group_info_.q_indices) = trajectory.positions.front();
+    Eigen::Matrix4d previous = scene_->forwardKinematics(q_full, tip_frame);
+    for (size_t i = 1; i < trajectory.positions.size(); ++i) {
+      q_full(joint_group_info_.q_indices) = trajectory.positions.at(i);
+      const Eigen::Matrix4d current = scene_->forwardKinematics(q_full, tip_frame);
+      const auto [linear_distance, angular_distance] = poseError(previous, current);
+      linear_speeds.push_back(linear_distance / options_.dt);
+      angular_speeds.push_back(angular_distance / options_.dt);
+      previous = current;
+    }
+
+    for (const double speed : linear_speeds) {
+      peaks.linear_speed = std::max(peaks.linear_speed, speed);
+    }
+    for (const double speed : angular_speeds) {
+      peaks.angular_speed = std::max(peaks.angular_speed, speed);
+    }
+    for (size_t i = 1; i < linear_speeds.size(); ++i) {
+      peaks.linear_acceleration =
+          std::max(peaks.linear_acceleration,
+                   std::abs(linear_speeds.at(i) - linear_speeds.at(i - 1)) / options_.dt);
+      peaks.angular_acceleration =
+          std::max(peaks.angular_acceleration,
+                   std::abs(angular_speeds.at(i) - angular_speeds.at(i - 1)) / options_.dt);
+    }
+  }
+  return peaks;
 }
 
 std::pair<double, double>
@@ -793,141 +702,65 @@ CartesianPathPlanner::planBounded(const CartesianPath& path, const Eigen::Vector
         "max_linear_acceleration and max_angular_acceleration must be strictly positive.");
   }
 
-  // The Cartesian feedrate profile bounds the *Cartesian* acceleration, but where the Jacobian
-  // varies quickly (corners, near-singular poses) the implied *joint* acceleration can still
-  // exceed the robot's limits. There is no single-step feedrate that fixes this (slowing one step
-  // only trades a high acceleration for a high deceleration), so instead we re-time the whole
-  // motion slower and retry until the (scaled) joint limits are met (see computeSlowdownFactor).
-  // The commanded values therefore act as maxima that are relaxed only as the kinematics require.
-  const double velocity_target = options_.velocity_scale;
-  const double acceleration_target = options_.acceleration_scale;
-  const double ratio_tolerance = options_.limit_ratio_tolerance;
-
-  double speed_scale = 1.0;
-  JointTrajectory trajectory;
-  for (int iter = 0; iter < kMaxSlowdownIters; ++iter) {
-    auto tracked = trackReference(path, q_start_full, options_.max_linear_speed * speed_scale,
-                                  options_.max_angular_speed * speed_scale,
-                                  options_.max_linear_acceleration * speed_scale * speed_scale,
-                                  options_.max_angular_acceleration * speed_scale * speed_scale);
-    if (!tracked) {
-      // A failure (e.g. a stall) may be speed-induced; halve the speed and retry while we can.
-      if (iter + 1 < kMaxSlowdownIters) {
-        speed_scale *= 0.5;
-        continue;
-      }
-      return tl::make_unexpected(tracked.error());
-    }
-
-    // trackReference returns the trace with positions/velocities/times; fill its accelerations so
-    // the peak limit ratios that drive the slow-down decision are available.
-    trajectory = std::move(*tracked);
-    fillAccelerations(trajectory);
-    const auto [peak_velocity_ratio, peak_acceleration_ratio] = computePeakLimitRatios(trajectory);
-
-    // Accept the trace once it lands within the (scaled) joint limits; otherwise slow the whole
-    // motion down and retry.
-    const double slowdown =
-        computeSlowdownFactor(peak_velocity_ratio, velocity_target, peak_acceleration_ratio,
-                              acceleration_target, ratio_tolerance);
-    if (slowdown <= 1.0 || iter + 1 == kMaxSlowdownIters) {
-      break;
-    }
-    speed_scale /= slowdown;
+  const auto resolved = resolvePath(path, q_start_full);
+  if (!resolved) {
+    return tl::make_unexpected(resolved.error());
   }
 
+  // Time the path against the joint limits first, then slow the whole motion until the tool obeys
+  // the commanded Cartesian maxima too. Re-timing in time-scale m divides speed by m and
+  // acceleration by m^2, and handing TOPP-RA joint limits scaled the same way reproduces exactly
+  // that slower trajectory, so the joint limits stay satisfied for free.
+  double velocity_scale = options_.velocity_scale;
+  double acceleration_scale = options_.acceleration_scale;
+  auto trajectory = timeParameterize(*resolved, velocity_scale, acceleration_scale);
+  if (!trajectory) {
+    return tl::make_unexpected(trajectory.error());
+  }
+
+  for (int pass = 0; pass < kMaxBoundedSlowdownPasses; ++pass) {
+    const CartesianPeaks peaks = computeCartesianPeaks(*trajectory, path);
+    double slowdown = 1.0;
+    slowdown = std::max(slowdown, peaks.linear_speed / options_.max_linear_speed);
+    slowdown = std::max(slowdown, peaks.angular_speed / options_.max_angular_speed);
+    slowdown =
+        std::max(slowdown, std::sqrt(peaks.linear_acceleration / options_.max_linear_acceleration));
+    slowdown = std::max(slowdown,
+                        std::sqrt(peaks.angular_acceleration / options_.max_angular_acceleration));
+    if (slowdown <= kBoundedSpeedTolerance) {
+      break;
+    }
+    velocity_scale /= slowdown;
+    acceleration_scale /= slowdown * slowdown;
+    auto slower = timeParameterize(*resolved, velocity_scale, acceleration_scale);
+    if (!slower) {
+      // The faster trajectory is still valid against the joint limits, so keep it rather than
+      // failing outright; it simply exceeds the commanded Cartesian caps.
+      break;
+    }
+    trajectory = std::move(slower);
+  }
   return trajectory;
 }
 
 tl::expected<JointTrajectory, std::string>
 CartesianPathPlanner::planTimeOptimal(const CartesianPath& path,
                                       const Eigen::VectorXd& q_start_full) {
-  // Resolve a dense geometric joint path that hugs the Cartesian path. The resolution speed sets
-  // only the sampling density and tracking tightness, since TOPP-RA assigns the final timing.
-  //
-  // A control step advances the reference by `dt` and the tracker nulls the pose error over roughly
-  // that long, so the robot trails the reference by about one step of travel. Hold each modality's
-  // step to this fraction of its own tolerance to keep that lag small, since a trailing trace would
-  // be faithfully reproduced by TOPP-RA.
-  constexpr double kLagFraction = 0.125;
-
-  // Each speed is then clamped to a band measured across the example models. Above the band the
-  // tracker stops keeping up unaided and leans on the servo loop's throttle retries; below it the
-  // trace grows dense enough that per-step jitter accumulates, and the resample stride, which is
-  // derived from tool travel, over-decimates a rotation-dominated path.
-  constexpr double kMinLinearSpeed = 0.05;   // m/s
-  constexpr double kMaxLinearSpeed = 0.15;   // m/s
-  constexpr double kMinAngularSpeed = 0.25;  // rad/s
-  constexpr double kMaxAngularSpeed = 1.0;   // rad/s
-
-  // Translation is additionally held to the resample spacing so the trace is never resolved coarser
-  // than the waypoints it feeds. The spacing is tool travel in meters, so rotation has no such
-  // target, and a non-positive spacing disables the resample and leaves only the lag bound.
-  double step_travel = kLagFraction * options_.max_position_error;
-  if (options_.toppra_waypoint_spacing > 0.0) {
-    step_travel = std::min(step_travel, options_.toppra_waypoint_spacing);
+  const auto resolved = resolvePath(path, q_start_full);
+  if (!resolved) {
+    return tl::make_unexpected(resolved.error());
   }
-  const double step_rotation = kLagFraction * options_.max_orientation_error;
-  const double resolution_linear_speed =
-      std::clamp(step_travel / options_.dt, kMinLinearSpeed, kMaxLinearSpeed);
-  const double resolution_angular_speed =
-      std::clamp(step_rotation / options_.dt, kMinAngularSpeed, kMaxAngularSpeed);
+  return timeParameterize(*resolved, options_.velocity_scale, options_.acceleration_scale);
+}
 
-  // Geometric resolution is velocity-level only; TOPP-RA enforces the acceleration limits in the
-  // re-timing stage, so trace at a constant resolution feedrate (no Cartesian acceleration
-  // profile).
-  auto tracked =
-      trackReference(path, q_start_full, resolution_linear_speed, resolution_angular_speed,
-                     /*linear_acceleration=*/0.0, /*angular_acceleration=*/0.0);
-  if (!tracked) {
-    return tl::make_unexpected(tracked.error());
+/// @brief Resolves a joint group, throwing the planner's construction error if it does not exist.
+JointGroupInfo resolveJointGroup(const Scene& scene, const std::string& group_name) {
+  auto maybe_joint_group_info = scene.getJointGroupInfo(group_name);
+  if (!maybe_joint_group_info) {
+    throw std::runtime_error("Could not initialize Cartesian path planner: " +
+                             maybe_joint_group_info.error());
   }
-
-  // The LinearBlend geometry treats every waypoint as a potential corner. At the raw trace
-  // spacing (resolution_linear_speed * dt of tool travel per waypoint), even sub-milliradian
-  // servo jitter dominates the direction change between adjacent waypoints, so each one
-  // becomes a tight blend arc whose centripetal acceleration bound throttles the whole
-  // trajectory far below the joint limits. Resample the trace to space tool travel between
-  // waypoints coarse enough that genuine path geometry dominates the blend angles, but is
-  // still fine enough to preserve the corners within the blend deviation.
-  const std::vector<Eigen::VectorXd>& trace_positions = tracked->positions;
-  size_t num_target_waypoints = kMaxToppraWaypoints;
-  if (options_.toppra_waypoint_spacing > 0.0) {
-    const double waypoint_stride =
-        std::max(1.0, options_.toppra_waypoint_spacing / (resolution_linear_speed * options_.dt));
-    num_target_waypoints =
-        std::clamp<size_t>(static_cast<size_t>(std::ceil(
-                               static_cast<double>(trace_positions.size()) / waypoint_stride)),
-                           2, kMaxToppraWaypoints);
-  }
-  JointPath joint_path;
-  joint_path.joint_names = joint_group_info_.joint_names;
-  joint_path.positions = trace_positions.size() > num_target_waypoints
-                             ? resampleUniform(trace_positions, num_target_waypoints, *scene_,
-                                               joint_group_info_.q_indices)
-                             : trace_positions;
-  if (joint_path.positions.size() < 2) {
-    return tl::make_unexpected(
-        "Resolved joint path has fewer than 2 waypoints; the Cartesian path may be degenerate "
-        "or too short to time-parameterize.");
-  }
-
-  // Time-parameterize the joint path with TOPP-RA so the result respects joint velocity and
-  // acceleration limits. Use the LinearBlend geometry (straight segments with circular corner
-  // blends): its straight segments have zero curvature, so the dense, slightly jittery diff-IK
-  // trace no longer inflates the acceleration constraint and crawls the trajectory the way an
-  // interpolating cubic spline would. Corners are rounded within toppra_blend_deviation.
-  TOPPRAOptions toppra_options;
-  toppra_options.dt = options_.dt;
-  toppra_options.mode = SplineFittingMode::LinearBlend;
-  toppra_options.velocity_scale = options_.velocity_scale;
-  toppra_options.acceleration_scale = options_.acceleration_scale;
-  toppra_options.max_blend_deviation = options_.toppra_blend_deviation;
-  auto maybe_trajectory = toppra_.generate(joint_path, toppra_options);
-  if (!maybe_trajectory) {
-    return tl::make_unexpected("TOPP-RA time parameterization failed: " + maybe_trajectory.error());
-  }
-  return std::move(maybe_trajectory.value());
+  return maybe_joint_group_info.value();
 }
 
 }  // namespace roboplan


### PR DESCRIPTION
Majorly refactors the Cartesian planner to make it more robust for longer trajectories -- again found on the NASA CLR case.

I guess how do I explain this change? It shifted things from doing a live servo loop with OInK that did slowdowns on the fly, to first doing a fully geometric pass and then afterwards using TOPPRA for trajectory timing and further resolving of Cartesian speeds/accelerations (if using `Bounded` mode).

Had a side benefit that it's an overall code _deletion_, despite burning a few extra lines on adding a `Scene::difference()` method.

[clr_cartesian_plan.webm](https://github.com/user-attachments/assets/77e49b0b-d48b-4646-a8f9-910575364339)
