### PR TITLE
fix missing braces warnings

### DIFF
--- a/roboplan_oink/src/barriers/position_barrier.cpp
+++ b/roboplan_oink/src/barriers/position_barrier.cpp
@@ -12,7 +12,7 @@
 namespace roboplan {
 
 namespace {
-constexpr std::array<std::string_view, 3> kAxisNames = {"x", "y", "z"};
+constexpr std::array<std::string_view, 3> kAxisNames = {{"x", "y", "z"}};
 }  // namespace
 
 PositionBarrier::PositionBarrier(const Oink& oink, const Scene& scene,
@@ -30,7 +30,7 @@ PositionBarrier::PositionBarrier(const Oink& oink, const Scene& scene,
   frame_id = maybe_frame_id.value();
 
   // Validate that p_min < p_max for enabled axes with finite bounds
-  const std::array<bool, 3> axes_enabled = {axis_selection.x, axis_selection.y, axis_selection.z};
+  const std::array<bool, 3> axes_enabled{{axis_selection.x, axis_selection.y, axis_selection.z}};
   for (int i = 0; i < 3; ++i) {
     if (axes_enabled[i] && std::isfinite(p_min[i]) && std::isfinite(p_max[i])) {
       if (p_min[i] >= p_max[i]) {

--- a/roboplan_toppra/src/toppra.cpp
+++ b/roboplan_toppra/src/toppra.cpp
@@ -141,8 +141,6 @@ PathParameterizerTOPPRA::generateCubicSpline(const toppra::Vectors& path_pos_vec
 
   // Set boundary conditions to zero velocity and acceleration at both endpoints.
   toppra::BoundaryCond bc{2, Eigen::VectorXd::Zero(path_pos_vecs.at(0).size())};
-  // BoundaryCondFull is a std::array, so the inner braces initialize the wrapped C array
-  // explicitly. Relying on brace elision here raises -Wmissing-braces on GCC.
   toppra::BoundaryCondFull bc_full{{bc, bc}};
 
   const auto spline = toppra::PiecewisePolyPath::CubicSpline(path_pos_vecs, times, bc_full);

--- a/roboplan_toppra/src/toppra.cpp
+++ b/roboplan_toppra/src/toppra.cpp
@@ -141,7 +141,9 @@ PathParameterizerTOPPRA::generateCubicSpline(const toppra::Vectors& path_pos_vec
 
   // Set boundary conditions to zero velocity and acceleration at both endpoints.
   toppra::BoundaryCond bc{2, Eigen::VectorXd::Zero(path_pos_vecs.at(0).size())};
-  toppra::BoundaryCondFull bc_full{bc, bc};
+  // BoundaryCondFull is a std::array, so the inner braces initialize the wrapped C array
+  // explicitly. Relying on brace elision here raises -Wmissing-braces on GCC.
+  toppra::BoundaryCondFull bc_full{{bc, bc}};
 
   const auto spline = toppra::PiecewisePolyPath::CubicSpline(path_pos_vecs, times, bc_full);
   return std::make_shared<toppra::PiecewisePolyPath>(spline);


### PR DESCRIPTION
## Problem

`std::array<T, N>` holds a single C-array member, so a brace-elided initializer like `{a, b}` triggers `-Wmissing-braces` on GCC. `-Wall` is already enabled repo-wide, so today these are warnings in upstream CI; in any downstream build that promotes them, they are hard build failures.

I hit this building the workspace with `colcon` on ROS 2 Humble at PAL Robotics, where `ament_cmake_pal` injects `-Werror=missing-braces` into every package:

```
roboplan_toppra/src/toppra.cpp:144:42: error: missing braces around initializer for
'std::__array_traits<toppra::BoundaryCond, 2>::_Type' {aka 'toppra::BoundaryCond [2]'}
[-Werror=missing-braces]
  144 |   toppra::BoundaryCondFull bc_full{bc, bc};
      |                                          ^
```

`roboplan_toppra` fails first, which aborts the rest of the workspace. With that fixed, `roboplan_oink` fails the same way at two sites in `barriers/position_barrier.cpp`.

## Change

Explicit inner braces at the three affected sites (`toppra::BoundaryCondFull` is `std::array<BoundaryCond, 2>`). Purely syntactic — the resulting objects are identical, no behaviour change.

## Testing

Ubuntu 22.04, GCC 11.4, ROS 2 Humble, `colcon build`:

- Full workspace builds; previously it stopped at `roboplan_toppra`.
- `colcon test --packages-select roboplan_toppra` passes.
- `clang-format` clean.

Two `roboplan_oink` tests fail in my environment — `OinkTest.InfeasibleQpSolvesClosestFeasibleProblem` and `PositionBarrierTest.BarrierLimitsMotion`, both with *"QP solver reached the maximum number of iterations"*. That is unrelated to this change (which cannot affect runtime behaviour) and looks like a proxsuite version difference on my side. Happy to open a separate issue if useful.

## Note

These sites can regress silently, since they are only warnings under the current CI flags. If you want them enforced, `-Werror=missing-braces` on the CI job would catch it.
