### PR TITLE
Rename `filters` target to `roboplan_filters`

### DIFF
--- a/packaging/python/cmake/roboplan_python_packaging.cmake
+++ b/packaging/python/cmake/roboplan_python_packaging.cmake
@@ -44,7 +44,7 @@ function(roboplan_register_build_tree_packages)
   roboplan_register_build_tree_package(roboplan_example_models
     ALIASES roboplan_example_models::roboplan_example_models=roboplan_example_models)
   roboplan_register_build_tree_package(roboplan
-    ALIASES roboplan::roboplan=roboplan roboplan::filters=filters)
+    ALIASES roboplan::roboplan=roboplan roboplan::roboplan_filters=roboplan_filters)
   roboplan_register_build_tree_package(roboplan_simple_ik
     ALIASES roboplan_simple_ik::roboplan_simple_ik=roboplan_simple_ik)
   roboplan_register_build_tree_package(roboplan_oink

--- a/roboplan/CMakeLists.txt
+++ b/roboplan/CMakeLists.txt
@@ -92,6 +92,8 @@ target_link_libraries(filters
     pinocchio::pinocchio
 )
 set_property(TARGET filters PROPERTY CXX_STANDARD 20)
+
+set_target_properties(filters PROPERTIES OUTPUT_NAME roboplan_filters)
 list(APPEND TARGETS_LIST filters)
 
 set(ROBOPLAN_TARGETS ${TARGETS_LIST})

--- a/roboplan/CMakeLists.txt
+++ b/roboplan/CMakeLists.txt
@@ -79,22 +79,20 @@ else()
 endif()
 set_property(TARGET roboplan PROPERTY CXX_STANDARD 20)
 
-add_library(filters SHARED
+add_library(roboplan_filters SHARED
     src/filters/se3_low_pass_filter.cpp
 )
-target_include_directories(filters PUBLIC
+target_include_directories(roboplan_filters PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(filters
+target_link_libraries(roboplan_filters
     PUBLIC
     Eigen3::Eigen
     pinocchio::pinocchio
 )
-set_property(TARGET filters PROPERTY CXX_STANDARD 20)
-
-set_target_properties(filters PROPERTIES OUTPUT_NAME roboplan_filters)
-list(APPEND TARGETS_LIST filters)
+set_property(TARGET roboplan_filters PROPERTY CXX_STANDARD 20)
+list(APPEND TARGETS_LIST roboplan_filters)
 
 set(ROBOPLAN_TARGETS ${TARGETS_LIST})
 install(

--- a/roboplan/bindings/CMakeLists.txt
+++ b/roboplan/bindings/CMakeLists.txt
@@ -2,8 +2,8 @@
 #
 # This file is added via `add_subdirectory(bindings)` from the parent
 # roboplan/CMakeLists.txt only when BUILD_PYTHON_BINDINGS is ON, so the C++
-# targets (roboplan, filters) already exist in this configure and do not need
-# to be found via find_package.
+# targets (roboplan, roboplan_filters) already exist in this configure and
+# do not need to be found via find_package.
 #
 # NOTE: The ament/scikit-build/nanobind detection boilerplate below is
 # duplicated per package for now; it should be factored into a shared CMake
@@ -102,7 +102,7 @@ target_include_directories(_filters_ext PRIVATE
 target_compile_definitions(_filters_ext PRIVATE ROBOPLAN_VERSION="${PROJECT_VERSION}")
 set_property(TARGET _filters_ext PROPERTY CXX_STANDARD 20)
 target_link_libraries(_filters_ext PRIVATE
-  filters
+  roboplan_filters
 )
 
 # Ensure the extension can find workspace dylibs via @rpath on macOS, as it seems that

--- a/roboplan/test/CMakeLists.txt
+++ b/roboplan/test/CMakeLists.txt
@@ -42,7 +42,7 @@ add_executable(test_se3_low_pass_filter test_se3_low_pass_filter.cpp)
 set_property(TARGET test_se3_low_pass_filter PROPERTY CXX_STANDARD 20)
 target_link_libraries(
   test_se3_low_pass_filter
-  filters
+  roboplan_filters
   GTest::gtest_main
 )
 

--- a/tests/unified_python_package_test.py
+++ b/tests/unified_python_package_test.py
@@ -163,7 +163,7 @@ def test_packaging_entrypoint_provides_build_tree_package_configs() -> None:
             "function(roboplan_register_build_tree_package package_name)",
             "${package_name}_DIR",
             "roboplan::roboplan=roboplan",
-            "roboplan::filters=filters",
+            "roboplan::roboplan_filters=roboplan_filters",
             "roboplan_example_models::roboplan_example_models=roboplan_example_models",
             "roboplan_cartesian_planning::roboplan_cartesian_planning=roboplan_cartesian_planning",
         ],


### PR DESCRIPTION
RoboPlan's add_library(filters SHARED ...) emits _libfilters.so_.  This clashes with the one of ` ros-humble-nav2-costmap-2d`, that is: /opt/ros/humble/lib/libfilters.so and produces this build issue: 

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/nanobind/stubgen.py", line 1619, in <module>
    main()
  File "/usr/local/lib/python3.10/dist-packages/nanobind/stubgen.py", line 1538, in main
    mod_imported = importlib.import_module(mod)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 674, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 571, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 1176, in create_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
ImportError: /home/user/exchange/temp/build/roboplan/bindings/_filters_ext.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZNK8roboplan16SE3LowPassFilter3tauEv
gmake[2]: *** [bindings/CMakeFiles/_filters_ext_stub.dir/build.make:75: /home/user/exchange/temp/src/roboplan/roboplan/bindings/python/roboplan/filters/py.typed] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:366: bindings/CMakeFiles/_filters_ext_stub.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< roboplan [4.21s, exited with code 2]
```

i guess that because of the scoped headers' hierarchy:  Every ROS-sourced shell has /opt/ros/humble/lib on it, so nav2's library wins over roboplan's own. 
Result: _filters_ext.so links fine but fails at load with undefined symbol: _ZNK8roboplan16SE3LowPassFilter3tauEv. That kills the nanobind_add_stub step, so make fails and the whole roboplan package build fails.