### PR TITLE
Utilities to filter robot model from point cloud

### DIFF
--- a/roboplan_core/CMakeLists.txt
+++ b/roboplan_core/CMakeLists.txt
@@ -54,8 +54,13 @@ endif()
 # Add roboplan libraries.
 add_library(
   roboplan SHARED
-  src/core/scene_context.cpp src/core/path_utils.cpp src/core/pose_utils.cpp
-  src/core/scene.cpp src/core/scene_utils.cpp src/core/types.cpp)
+  src/core/scene_context.cpp
+  src/core/path_utils.cpp
+  src/core/pose_utils.cpp
+  src/core/robot_body_filter.cpp
+  src/core/scene.cpp
+  src/core/scene_utils.cpp
+  src/core/types.cpp)
 target_include_directories(
   roboplan PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                   $<INSTALL_INTERFACE:include>)

--- a/roboplan_core/bindings/include/roboplan_bindings/core.hpp
+++ b/roboplan_core/bindings/include/roboplan_bindings/core.hpp
@@ -28,4 +28,8 @@ void init_core_pose_utils(nanobind::module_& m);
 /// @param m The nanobind core module.
 void init_core_scene_utils(nanobind::module_& m);
 
+/// @brief Initializes Python bindings for the robot body (self) filter.
+/// @param m The nanobind core module.
+void init_core_robot_body_filter(nanobind::module_& m);
+
 }  // namespace roboplan

--- a/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
@@ -721,7 +721,7 @@ class RobotBodyFilterMethod(enum.Enum):
 class RobotBodyFilterOptions:
     """Options struct for the robot body filter."""
 
-    def __init__(self, padding: float = 0.05, method: RobotBodyFilterMethod = RobotBodyFilterMethod.NARROWPHASE) -> None: ...
+    def __init__(self, padding: float = 0.05, method: RobotBodyFilterMethod = RobotBodyFilterMethod.NARROWPHASE, num_threads: int = 0) -> None: ...
 
     @property
     def padding(self) -> float:
@@ -738,6 +738,15 @@ class RobotBodyFilterOptions:
 
     @method.setter
     def method(self, arg: RobotBodyFilterMethod, /) -> None: ...
+
+    @property
+    def num_threads(self) -> int:
+        """
+        Number of threads used to classify points, or 0 to use all hardware threads. Small clouds are processed serially regardless.
+        """
+
+    @num_threads.setter
+    def num_threads(self, arg: int, /) -> None: ...
 
 class RobotBodyFilter:
     """

--- a/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
@@ -524,6 +524,11 @@ class Scene:
         Gets a list of collision geometry IDs corresponding to a specified body.
         """
 
+    def getRobotCollisionGeometryIds(self) -> list[int]:
+        """
+        Gets the collision geometry IDs belonging to the robot model itself (excluding objects added to the scene).
+        """
+
     def setCollisions(self, body1: str, body2: str, enable: bool) -> None:
         """Sets the allowable collisions for a pair of bodies in the model."""
 
@@ -697,3 +702,61 @@ def expandContinuousJointPositions(scene: Scene, group_name: str, q_orig: Annota
     """
     Expands a joint position vector's continuous joints from downstream algorithms.
     """
+
+class RobotBodyFilterMethod(enum.Enum):
+    """
+    The test used by RobotBodyFilter to classify points near the robot geometry.
+    """
+
+    NARROWPHASE = 0
+    """
+    Exact Coal narrowphase query (point vs. geometry with the padding as security margin) after the broadphase AABB cull.
+    """
+
+    PADDED_OBB = 1
+    """
+    Conservative point-in-padded-OBB test after the broadphase AABB cull. Faster, but over-removes points near the corners of the oriented boxes.
+    """
+
+class RobotBodyFilterOptions:
+    """Options struct for the robot body filter."""
+
+    def __init__(self, padding: float = 0.05, method: RobotBodyFilterMethod = RobotBodyFilterMethod.NARROWPHASE) -> None: ...
+
+    @property
+    def padding(self) -> float:
+        """
+        Distance, in meters, around the robot's collision geometry within which points are considered part of the robot body.
+        """
+
+    @padding.setter
+    def padding(self, arg: float, /) -> None: ...
+
+    @property
+    def method(self) -> RobotBodyFilterMethod:
+        """The classification test to use."""
+
+    @method.setter
+    def method(self, arg: RobotBodyFilterMethod, /) -> None: ...
+
+class RobotBodyFilter:
+    """
+    Filters points that lie on or near the robot's own collision geometry (self filtering), e.g. to remove the robot body from a sensor point cloud before turning it into an octree obstacle.
+
+    The robot geometry is snapshotted at construction; objects added to the scene afterwards are not filtered against. The filter owns private scratch, so it is safe to use distinct filters concurrently on one Scene, but a single filter must not be shared across threads.
+    """
+
+    def __init__(self, scene: Scene, options: RobotBodyFilterOptions) -> None: ...
+
+    def computeMask(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], points: Annotated[NDArray[numpy.float64], dict(shape=(None, 3), writable=False)], extra_padding: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')] | None = None) -> Annotated[NDArray[numpy.bool_], dict(shape=(None,), order='C')]:
+        """
+        Returns a boolean mask over the (N x 3) points; true marks a point within the padded robot body at configuration q. extra_padding optionally adds a per-point padding, e.g. the half-diagonals of octree cells.
+        """
+
+    def filterPoints(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], points: Annotated[NDArray[numpy.float64], dict(shape=(None, 3), writable=False)], extra_padding: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')] | None = None) -> Annotated[NDArray[numpy.float64], dict(shape=(None, 3), order='C')]:
+        """
+        Returns only the rows of the (N x 3) points that lie outside the padded robot body at configuration q.
+        """
+
+    def getOptions(self) -> RobotBodyFilterOptions:
+        """The filter options."""

--- a/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
@@ -708,25 +708,25 @@ class RobotBodyFilterMethod(enum.Enum):
     The test used by RobotBodyFilter to classify points near the robot geometry.
     """
 
-    NARROWPHASE = 0
+    Narrowphase = 0
     """
-    Exact Coal narrowphase query (point vs. geometry with the padding as security margin) after the broadphase AABB cull.
+    Exact: after the broadphase AABB cull, each candidate point is checked with a Coal narrowphase collision query (point vs. padded geometry). This is exact for every geometry type, including meshes, at the cost of one GJK/BVH query per candidate point.
     """
 
-    PADDED_OBB = 1
+    PaddedObb = 1
     """
-    Conservative point-in-padded-OBB test after the broadphase AABB cull. Faster, but over-removes points near the corners of the oriented boxes.
+    Conservative: after the broadphase AABB cull, each candidate point is checked against the geometry's padded oriented bounding box (OBB). This is much faster since it is a few arithmetic operations per candidate, but over-removes points near the corners of the oriented boxes. The set of points it removes is always a superset of Narrowphase's.
     """
 
 class RobotBodyFilterOptions:
     """Options struct for the robot body filter."""
 
-    def __init__(self, padding: float = 0.05, method: RobotBodyFilterMethod = RobotBodyFilterMethod.NARROWPHASE, num_threads: int = 0) -> None: ...
+    def __init__(self, padding: float, method: RobotBodyFilterMethod = RobotBodyFilterMethod.Narrowphase, num_threads: int = 0) -> None: ...
 
     @property
     def padding(self) -> float:
         """
-        Distance, in meters, around the robot's collision geometry within which points are considered part of the robot body.
+        Distance, in meters, around the robot's collision geometry within which points are considered part of the robot body. Must be non-negative.
         """
 
     @padding.setter
@@ -742,7 +742,7 @@ class RobotBodyFilterOptions:
     @property
     def num_threads(self) -> int:
         """
-        Number of threads used to classify points, or 0 to use all hardware threads. Small clouds are processed serially regardless.
+        Number of threads used to classify points, or 0 to use all hardware threads. Points are split into blocks that the threads pull from a shared queue, so at most one thread per block is ever spawned and small clouds are processed serially either way.
         """
 
     @num_threads.setter
@@ -750,21 +750,34 @@ class RobotBodyFilterOptions:
 
 class RobotBodyFilter:
     """
-    Filters points that lie on or near the robot's own collision geometry (self filtering), e.g. to remove the robot body from a sensor point cloud before turning it into an octree obstacle.
+    Filters points that lie on or near the robot's own collision geometry.
 
-    The robot geometry is snapshotted at construction; objects added to the scene afterwards are not filtered against. The filter owns private scratch, so it is safe to use distinct filters concurrently on one Scene, but a single filter must not be shared across threads.
+    This is the usual "self filter" that removes the robot's body from a sensor point cloud (or the occupied cells of an octree) before the cloud is turned into a collision object, so that the robot does not see itself as an obstacle.
+
+    Both methods share a broadphase stage that culls points against the padded world-frame AABB of every robot collision geometry at the query configuration; they differ only in the exactness (and cost) of the test run on the surviving candidates. See RobotBodyFilterMethod.
+
+    Thread safety and lifetime: the filter owns private Pinocchio scratch over the Scene's robot description, so distinct filters may run concurrently on one Scene, but a single filter must not be shared across threads. Only the robot's own collision geometry is filtered against, and it is copied at construction, so objects can be freely added to or removed from the scene without rebuilding the filter.
     """
 
-    def __init__(self, scene: Scene, options: RobotBodyFilterOptions) -> None: ...
+    def __init__(self, scene: Scene, options: RobotBodyFilterOptions) -> None:
+        """Constructs a filter over the scene's current robot collision geometry."""
 
     def computeMask(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], points: Annotated[NDArray[numpy.float64], dict(shape=(None, 3), writable=False)], extra_padding: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')] | None = None) -> Annotated[NDArray[numpy.bool_], dict(shape=(None,), order='C')]:
         """
-        Returns a boolean mask over the (N x 3) points; true marks a point within the padded robot body at configuration q. extra_padding optionally adds a per-point padding, e.g. the half-diagonals of octree cells.
+        Classifies each point against the padded robot geometry at a joint configuration.
+
+        `q` is the joint configuration at which to place the robot (size model.nq) and `points` are the points to classify, one per row of an N x 3 array, in world frame. `extra_padding` is an optional per-point padding, in meters, added to the configured padding; useful when the points stand in for finite-sized cells (e.g. octree leaves), in which case passing each cell's half-diagonal keeps the test conservative.
+
+        Returns a mask sized to the number of points; true marks a point within the padded body.
         """
 
     def filterPoints(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], points: Annotated[NDArray[numpy.float64], dict(shape=(None, 3), writable=False)], extra_padding: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')] | None = None) -> Annotated[NDArray[numpy.float64], dict(shape=(None, 3), order='C')]:
         """
-        Returns only the rows of the (N x 3) points that lie outside the padded robot body at configuration q.
+        Returns only the points outside the padded robot body at a joint configuration.
+
+        `q` is the joint configuration at which to place the robot (size model.nq) and `points` are the points to filter, one per row of an N x 3 array, in world frame. `extra_padding` is an optional per-point padding, in meters, added to the configured padding.
+
+        Returns the rows of `points` whose computeMask() entry is false, in their original order.
         """
 
     def getOptions(self) -> RobotBodyFilterOptions:

--- a/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
+++ b/roboplan_core/bindings/python/roboplan/core/_core_ext.pyi
@@ -752,7 +752,7 @@ class RobotBodyFilter:
     """
     Filters points that lie on or near the robot's own collision geometry.
 
-    This is the usual "self filter" that removes the robot's body from a sensor point cloud (or the occupied cells of an octree) before the cloud is turned into a collision object, so that the robot does not see itself as an obstacle.
+    This removes the robot's body from a sensor point cloud (or the occupied cells of an octree) so that the robot does not see itself as an obstacle when planning.
 
     Both methods share a broadphase stage that culls points against the padded world-frame AABB of every robot collision geometry at the query configuration; they differ only in the exactness (and cost) of the test run on the surviving candidates. See RobotBodyFilterMethod.
 
@@ -765,19 +765,11 @@ class RobotBodyFilter:
     def computeMask(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], points: Annotated[NDArray[numpy.float64], dict(shape=(None, 3), writable=False)], extra_padding: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')] | None = None) -> Annotated[NDArray[numpy.bool_], dict(shape=(None,), order='C')]:
         """
         Classifies each point against the padded robot geometry at a joint configuration.
-
-        `q` is the joint configuration at which to place the robot (size model.nq) and `points` are the points to classify, one per row of an N x 3 array, in world frame. `extra_padding` is an optional per-point padding, in meters, added to the configured padding; useful when the points stand in for finite-sized cells (e.g. octree leaves), in which case passing each cell's half-diagonal keeps the test conservative.
-
-        Returns a mask sized to the number of points; true marks a point within the padded body.
         """
 
     def filterPoints(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], points: Annotated[NDArray[numpy.float64], dict(shape=(None, 3), writable=False)], extra_padding: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')] | None = None) -> Annotated[NDArray[numpy.float64], dict(shape=(None, 3), order='C')]:
         """
         Returns only the points outside the padded robot body at a joint configuration.
-
-        `q` is the joint configuration at which to place the robot (size model.nq) and `points` are the points to filter, one per row of an N x 3 array, in world frame. `extra_padding` is an optional per-point padding, in meters, added to the configured padding.
-
-        Returns the rows of `points` whose computeMask() entry is false, in their original order.
         """
 
     def getOptions(self) -> RobotBodyFilterOptions:

--- a/roboplan_core/bindings/src/core.cpp
+++ b/roboplan_core/bindings/src/core.cpp
@@ -468,12 +468,15 @@ void init_core_robot_body_filter(nanobind::module_& m) {
 
   nanobind::class_<RobotBodyFilterOptions>(m, "RobotBodyFilterOptions",
                                            "Options struct for the robot body filter.")
-      .def(nanobind::init<double, RobotBodyFilterMethod>(), "padding"_a = 0.05,
-           "method"_a = RobotBodyFilterMethod::NARROWPHASE)
+      .def(nanobind::init<double, RobotBodyFilterMethod, size_t>(), "padding"_a = 0.05,
+           "method"_a = RobotBodyFilterMethod::NARROWPHASE, "num_threads"_a = 0)
       .def_rw("padding", &RobotBodyFilterOptions::padding,
               "Distance, in meters, around the robot's collision geometry within which points "
               "are considered part of the robot body.")
-      .def_rw("method", &RobotBodyFilterOptions::method, "The classification test to use.");
+      .def_rw("method", &RobotBodyFilterOptions::method, "The classification test to use.")
+      .def_rw("num_threads", &RobotBodyFilterOptions::num_threads,
+              "Number of threads used to classify points, or 0 to use all hardware threads. "
+              "Small clouds are processed serially regardless.");
 
   nanobind::class_<RobotBodyFilter>(
       m, "RobotBodyFilter",

--- a/roboplan_core/bindings/src/core.cpp
+++ b/roboplan_core/bindings/src/core.cpp
@@ -9,6 +9,7 @@
 
 #include <roboplan/core/path_utils.hpp>
 #include <roboplan/core/pose_utils.hpp>
+#include <roboplan/core/robot_body_filter.hpp>
 #include <roboplan/core/scene.hpp>
 #include <roboplan/core/scene_context.hpp>
 #include <roboplan/core/scene_utils.hpp>
@@ -316,6 +317,9 @@ void init_core_scene(nanobind::module_& m) {
            "Removes a geometry from the scene.", "name"_a)
       .def("getCollisionGeometryIDs", unwrap_expected(&Scene::getCollisionGeometryIds),
            "Gets a list of collision geometry IDs corresponding to a specified body.", "body"_a)
+      .def("getRobotCollisionGeometryIds", &Scene::getRobotCollisionGeometryIds,
+           "Gets the collision geometry IDs belonging to the robot model itself (excluding "
+           "objects added to the scene).")
       .def("setCollisions", unwrap_expected(&Scene::setCollisions),
            "Sets the allowable collisions for a pair of bodies in the model.", "body1"_a, "body2"_a,
            "enable"_a)
@@ -449,6 +453,50 @@ void init_core_scene_utils(nanobind::module_& m) {
   m.def("expandContinuousJointPositions", unwrap_expected(&expandContinuousJointPositions),
         "Expands a joint position vector's continuous joints from downstream algorithms.",
         "scene"_a, "group_name"_a, "q_orig"_a);
+}
+
+void init_core_robot_body_filter(nanobind::module_& m) {
+  nanobind::enum_<RobotBodyFilterMethod>(
+      m, "RobotBodyFilterMethod",
+      "The test used by RobotBodyFilter to classify points near the robot geometry.")
+      .value("NARROWPHASE", RobotBodyFilterMethod::NARROWPHASE,
+             "Exact Coal narrowphase query (point vs. geometry with the padding as security "
+             "margin) after the broadphase AABB cull.")
+      .value("PADDED_OBB", RobotBodyFilterMethod::PADDED_OBB,
+             "Conservative point-in-padded-OBB test after the broadphase AABB cull. Faster, but "
+             "over-removes points near the corners of the oriented boxes.");
+
+  nanobind::class_<RobotBodyFilterOptions>(m, "RobotBodyFilterOptions",
+                                           "Options struct for the robot body filter.")
+      .def(nanobind::init<double, RobotBodyFilterMethod>(), "padding"_a = 0.05,
+           "method"_a = RobotBodyFilterMethod::NARROWPHASE)
+      .def_rw("padding", &RobotBodyFilterOptions::padding,
+              "Distance, in meters, around the robot's collision geometry within which points "
+              "are considered part of the robot body.")
+      .def_rw("method", &RobotBodyFilterOptions::method, "The classification test to use.");
+
+  nanobind::class_<RobotBodyFilter>(
+      m, "RobotBodyFilter",
+      "Filters points that lie on or near the robot's own collision geometry (self filtering), "
+      "e.g. to remove the robot body from a sensor point cloud before turning it into an "
+      "octree obstacle.\n\n"
+      "The robot geometry is snapshotted at construction; objects added to the scene afterwards "
+      "are not filtered against. The filter owns private scratch, so it is safe to use distinct "
+      "filters concurrently on one Scene, but a single filter must not be shared across threads.")
+      .def(nanobind::init<const std::shared_ptr<Scene>&, const RobotBodyFilterOptions&>(),
+           "scene"_a, "options"_a)
+      .def("computeMask", &RobotBodyFilter::computeMask,
+           nanobind::call_guard<nanobind::gil_scoped_release>(),
+           "Returns a boolean mask over the (N x 3) points; true marks a point within the padded "
+           "robot body at configuration q. extra_padding optionally adds a per-point padding, "
+           "e.g. the half-diagonals of octree cells.",
+           "q"_a, "points"_a, "extra_padding"_a = std::nullopt)
+      .def("filterPoints", &RobotBodyFilter::filterPoints,
+           nanobind::call_guard<nanobind::gil_scoped_release>(),
+           "Returns only the rows of the (N x 3) points that lie outside the padded robot body "
+           "at configuration q.",
+           "q"_a, "points"_a, "extra_padding"_a = std::nullopt)
+      .def("getOptions", &RobotBodyFilter::getOptions, "The filter options.");
 }
 
 }  // namespace roboplan

--- a/roboplan_core/bindings/src/core.cpp
+++ b/roboplan_core/bindings/src/core.cpp
@@ -459,45 +459,71 @@ void init_core_robot_body_filter(nanobind::module_& m) {
   nanobind::enum_<RobotBodyFilterMethod>(
       m, "RobotBodyFilterMethod",
       "The test used by RobotBodyFilter to classify points near the robot geometry.")
-      .value("NARROWPHASE", RobotBodyFilterMethod::NARROWPHASE,
-             "Exact Coal narrowphase query (point vs. geometry with the padding as security "
-             "margin) after the broadphase AABB cull.")
-      .value("PADDED_OBB", RobotBodyFilterMethod::PADDED_OBB,
-             "Conservative point-in-padded-OBB test after the broadphase AABB cull. Faster, but "
-             "over-removes points near the corners of the oriented boxes.");
+      .value("Narrowphase", RobotBodyFilterMethod::Narrowphase,
+             "Exact: after the broadphase AABB cull, each candidate point is checked with a Coal "
+             "narrowphase collision query (point vs. padded geometry). This is exact for every "
+             "geometry type, including meshes, at the cost of one GJK/BVH query per candidate "
+             "point.")
+      .value("PaddedObb", RobotBodyFilterMethod::PaddedObb,
+             "Conservative: after the broadphase AABB cull, each candidate point is checked "
+             "against the geometry's padded oriented bounding box (OBB). This is much faster "
+             "since it is a few arithmetic operations per candidate, but over-removes points "
+             "near the corners of the oriented boxes. The set of points it removes is always a "
+             "superset of Narrowphase's.");
 
   nanobind::class_<RobotBodyFilterOptions>(m, "RobotBodyFilterOptions",
                                            "Options struct for the robot body filter.")
-      .def(nanobind::init<double, RobotBodyFilterMethod, size_t>(), "padding"_a = 0.05,
-           "method"_a = RobotBodyFilterMethod::NARROWPHASE, "num_threads"_a = 0)
+      .def(nanobind::init<double, RobotBodyFilterMethod, size_t>(), "padding"_a,
+           "method"_a = RobotBodyFilterMethod::Narrowphase, "num_threads"_a = 0)
       .def_rw("padding", &RobotBodyFilterOptions::padding,
               "Distance, in meters, around the robot's collision geometry within which points "
-              "are considered part of the robot body.")
+              "are considered part of the robot body. Must be non-negative.")
       .def_rw("method", &RobotBodyFilterOptions::method, "The classification test to use.")
       .def_rw("num_threads", &RobotBodyFilterOptions::num_threads,
               "Number of threads used to classify points, or 0 to use all hardware threads. "
-              "Small clouds are processed serially regardless.");
+              "Points are split into blocks that the threads pull from a shared queue, so at "
+              "most one thread per block is ever spawned and small clouds are processed serially "
+              "either way.");
 
   nanobind::class_<RobotBodyFilter>(
       m, "RobotBodyFilter",
-      "Filters points that lie on or near the robot's own collision geometry (self filtering), "
-      "e.g. to remove the robot body from a sensor point cloud before turning it into an "
-      "octree obstacle.\n\n"
-      "The robot geometry is snapshotted at construction; objects added to the scene afterwards "
-      "are not filtered against. The filter owns private scratch, so it is safe to use distinct "
-      "filters concurrently on one Scene, but a single filter must not be shared across threads.")
+      "Filters points that lie on or near the robot's own collision geometry.\n\n"
+      "This is the usual \"self filter\" that removes the robot's body from a sensor point cloud "
+      "(or the occupied cells of an octree) before the cloud is turned into a collision object, "
+      "so that the robot does not see itself as an obstacle.\n\n"
+      "Both methods share a broadphase stage that culls points against the padded world-frame "
+      "AABB of every robot collision geometry at the query configuration; they differ only in "
+      "the exactness (and cost) of the test run on the surviving candidates. See "
+      "RobotBodyFilterMethod.\n\n"
+      "Thread safety and lifetime: the filter owns private Pinocchio scratch over the Scene's "
+      "robot description, so distinct filters may run concurrently on one Scene, but a single "
+      "filter must not be shared across threads. Only the robot's own collision geometry is "
+      "filtered against, and it is copied at construction, so objects can be freely added to or "
+      "removed from the scene without rebuilding the filter.")
       .def(nanobind::init<const std::shared_ptr<Scene>&, const RobotBodyFilterOptions&>(),
-           "scene"_a, "options"_a)
+           "scene"_a, "options"_a,
+           "Constructs a filter over the scene's current robot collision geometry.")
       .def("computeMask", &RobotBodyFilter::computeMask,
            nanobind::call_guard<nanobind::gil_scoped_release>(),
-           "Returns a boolean mask over the (N x 3) points; true marks a point within the padded "
-           "robot body at configuration q. extra_padding optionally adds a per-point padding, "
-           "e.g. the half-diagonals of octree cells.",
+           "Classifies each point against the padded robot geometry at a joint configuration.\n\n"
+           "`q` is the joint configuration at which to place the robot (size model.nq) and "
+           "`points` are the points to classify, one per row of an N x 3 array, in world frame. "
+           "`extra_padding` is an optional per-point padding, in meters, added to the configured "
+           "padding; useful when the points stand in for finite-sized cells (e.g. octree "
+           "leaves), in which case passing each cell's half-diagonal keeps the test "
+           "conservative.\n\n"
+           "Returns a mask sized to the number of points; true marks a point within the padded "
+           "body.",
            "q"_a, "points"_a, "extra_padding"_a = std::nullopt)
       .def("filterPoints", &RobotBodyFilter::filterPoints,
            nanobind::call_guard<nanobind::gil_scoped_release>(),
-           "Returns only the rows of the (N x 3) points that lie outside the padded robot body "
-           "at configuration q.",
+           "Returns only the points outside the padded robot body at a joint configuration.\n\n"
+           "`q` is the joint configuration at which to place the robot (size model.nq) and "
+           "`points` are the points to filter, one per row of an N x 3 array, in world frame. "
+           "`extra_padding` is an optional per-point padding, in meters, added to the configured "
+           "padding.\n\n"
+           "Returns the rows of `points` whose computeMask() entry is false, in their original "
+           "order.",
            "q"_a, "points"_a, "extra_padding"_a = std::nullopt)
       .def("getOptions", &RobotBodyFilter::getOptions, "The filter options.");
 }

--- a/roboplan_core/bindings/src/core.cpp
+++ b/roboplan_core/bindings/src/core.cpp
@@ -488,9 +488,8 @@ void init_core_robot_body_filter(nanobind::module_& m) {
   nanobind::class_<RobotBodyFilter>(
       m, "RobotBodyFilter",
       "Filters points that lie on or near the robot's own collision geometry.\n\n"
-      "This is the usual \"self filter\" that removes the robot's body from a sensor point cloud "
-      "(or the occupied cells of an octree) before the cloud is turned into a collision object, "
-      "so that the robot does not see itself as an obstacle.\n\n"
+      "This removes the robot's body from a sensor point cloud (or the occupied cells of an "
+      "octree) so that the robot does not see itself as an obstacle when planning.\n\n"
       "Both methods share a broadphase stage that culls points against the padded world-frame "
       "AABB of every robot collision geometry at the query configuration; they differ only in "
       "the exactness (and cost) of the test run on the surviving candidates. See "
@@ -505,26 +504,12 @@ void init_core_robot_body_filter(nanobind::module_& m) {
            "Constructs a filter over the scene's current robot collision geometry.")
       .def("computeMask", &RobotBodyFilter::computeMask,
            nanobind::call_guard<nanobind::gil_scoped_release>(),
-           "Classifies each point against the padded robot geometry at a joint configuration.\n\n"
-           "`q` is the joint configuration at which to place the robot (size model.nq) and "
-           "`points` are the points to classify, one per row of an N x 3 array, in world frame. "
-           "`extra_padding` is an optional per-point padding, in meters, added to the configured "
-           "padding; useful when the points stand in for finite-sized cells (e.g. octree "
-           "leaves), in which case passing each cell's half-diagonal keeps the test "
-           "conservative.\n\n"
-           "Returns a mask sized to the number of points; true marks a point within the padded "
-           "body.",
+           "Classifies each point against the padded robot geometry at a joint configuration.",
            "q"_a, "points"_a, "extra_padding"_a = std::nullopt)
       .def("filterPoints", &RobotBodyFilter::filterPoints,
            nanobind::call_guard<nanobind::gil_scoped_release>(),
-           "Returns only the points outside the padded robot body at a joint configuration.\n\n"
-           "`q` is the joint configuration at which to place the robot (size model.nq) and "
-           "`points` are the points to filter, one per row of an N x 3 array, in world frame. "
-           "`extra_padding` is an optional per-point padding, in meters, added to the configured "
-           "padding.\n\n"
-           "Returns the rows of `points` whose computeMask() entry is false, in their original "
-           "order.",
-           "q"_a, "points"_a, "extra_padding"_a = std::nullopt)
+           "Returns only the points outside the padded robot body at a joint configuration.", "q"_a,
+           "points"_a, "extra_padding"_a = std::nullopt)
       .def("getOptions", &RobotBodyFilter::getOptions, "The filter options.");
 }
 

--- a/roboplan_core/bindings/src/core_ext.cpp
+++ b/roboplan_core/bindings/src/core_ext.cpp
@@ -16,6 +16,7 @@ NB_MODULE(_core_ext, m) {
   init_core_path_utils(m);
   init_core_pose_utils(m);
   init_core_scene_utils(m);
+  init_core_robot_body_filter(m);
 }
 
 }  // namespace roboplan

--- a/roboplan_core/bindings/test/CMakeLists.txt
+++ b/roboplan_core/bindings/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Register the Python binding tests (colcon picks these up via ament). They run
 # against the installed package, so the roboplan namespace is importable.
 find_package(ament_cmake_pytest REQUIRED)
-set(BINDINGS_TESTS_PY test_import test_scene test_filters)
+set(BINDINGS_TESTS_PY test_import test_scene test_filters
+                      test_robot_body_filter)
 foreach(test_name ${BINDINGS_TESTS_PY})
   ament_add_pytest_test(${test_name} ${test_name}.py TIMEOUT 300)
 endforeach()

--- a/roboplan_core/bindings/test/test_robot_body_filter.py
+++ b/roboplan_core/bindings/test/test_robot_body_filter.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for the robot body filter bindings in RoboPlan.
+"""
+
+import numpy as np
+import pytest
+
+from roboplan.core import (
+    RobotBodyFilter,
+    RobotBodyFilterMethod,
+    RobotBodyFilterOptions,
+    Scene,
+)
+
+
+# A robot made of a single sphere of radius 0.1 fixed at the origin, so the filter's
+# classification can be checked against closed-form distances.
+URDF = """
+<robot name="ball_bot">
+  <link name="world"/>
+  <link name="ball_link">
+    <collision>
+      <geometry><sphere radius="0.1"/></geometry>
+    </collision>
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" iyy="0.01" izz="0.01" ixy="0.0" ixz="0.0" iyz="0.0"/>
+    </inertial>
+  </link>
+  <joint name="world_to_ball" type="fixed">
+    <parent link="world"/>
+    <child link="ball_link"/>
+    <origin xyz="0 0 0"/>
+  </joint>
+</robot>
+"""
+
+SRDF = """<robot name="ball_bot"/>"""
+
+
+@pytest.fixture
+def ball_scene():
+    return Scene("ball_scene", urdf=URDF, srdf=SRDF)
+
+
+# The padded body is the ball of radius 0.1 + 0.05 = 0.15 around the origin; the padded
+# OBB is the box of half extent 0.15. The corner point at distance ~0.17 tells them apart.
+POINTS = np.array(
+    [
+        [0.14, 0.0, 0.0],
+        [0.12, 0.12, 0.0],
+        [0.2, 0.0, 0.0],
+    ]
+)
+
+
+def test_narrowphase_mask(ball_scene):
+    body_filter = RobotBodyFilter(
+        ball_scene,
+        RobotBodyFilterOptions(padding=0.05, method=RobotBodyFilterMethod.NARROWPHASE),
+    )
+    mask = body_filter.computeMask(np.empty(0), POINTS)
+    assert mask.dtype == bool
+    assert np.array_equal(mask, [True, False, False])
+
+
+def test_padded_obb_mask_over_removes_corners(ball_scene):
+    body_filter = RobotBodyFilter(
+        ball_scene,
+        RobotBodyFilterOptions(padding=0.05, method=RobotBodyFilterMethod.PADDED_OBB),
+    )
+    mask = body_filter.computeMask(np.empty(0), POINTS)
+    assert np.array_equal(mask, [True, True, False])
+
+
+def test_extra_padding(ball_scene):
+    body_filter = RobotBodyFilter(ball_scene, RobotBodyFilterOptions(padding=0.05))
+    mask = body_filter.computeMask(np.empty(0), POINTS, np.array([0.0, 0.0, 0.1]))
+    assert np.array_equal(mask, [True, False, True])
+
+
+def test_filter_points(ball_scene):
+    body_filter = RobotBodyFilter(ball_scene, RobotBodyFilterOptions(padding=0.05))
+    kept = body_filter.filterPoints(np.empty(0), POINTS)
+    assert np.array_equal(kept, POINTS[1:])
+
+
+def test_negative_padding_raises(ball_scene):
+    with pytest.raises(ValueError):
+        RobotBodyFilter(ball_scene, RobotBodyFilterOptions(padding=-0.01))

--- a/roboplan_core/bindings/test/test_robot_body_filter.py
+++ b/roboplan_core/bindings/test/test_robot_body_filter.py
@@ -57,7 +57,7 @@ POINTS = np.array(
 def test_narrowphase_mask(ball_scene):
     body_filter = RobotBodyFilter(
         ball_scene,
-        RobotBodyFilterOptions(padding=0.05, method=RobotBodyFilterMethod.NARROWPHASE),
+        RobotBodyFilterOptions(padding=0.05, method=RobotBodyFilterMethod.Narrowphase),
     )
     mask = body_filter.computeMask(np.empty(0), POINTS)
     assert mask.dtype == bool
@@ -67,7 +67,7 @@ def test_narrowphase_mask(ball_scene):
 def test_padded_obb_mask_over_removes_corners(ball_scene):
     body_filter = RobotBodyFilter(
         ball_scene,
-        RobotBodyFilterOptions(padding=0.05, method=RobotBodyFilterMethod.PADDED_OBB),
+        RobotBodyFilterOptions(padding=0.05, method=RobotBodyFilterMethod.PaddedObb),
     )
     mask = body_filter.computeMask(np.empty(0), POINTS)
     assert np.array_equal(mask, [True, True, False])

--- a/roboplan_core/include/roboplan/core/geometry_wrappers.hpp
+++ b/roboplan_core/include/roboplan/core/geometry_wrappers.hpp
@@ -8,15 +8,25 @@
 // declaring `namespace coal = hpp::fcl;` ourselves.
 #if defined(__has_include) && __has_include(<coal/fwd.hh>)
 #include <coal/BVH/BVH_model.h>
+#include <coal/collision_object.h>
 #include <coal/mesh_loader/loader.h>
 #include <coal/octree.h>
 #include <coal/shape/geometric_shapes.h>
+namespace roboplan {
+/// @brief The Coal rigid transform type (renamed from Transform3f to Transform3s in coal).
+using CoalTransform = coal::Transform3s;
+}  // namespace roboplan
 #else
 #include <hpp/fcl/BVH/BVH_model.h>
+#include <hpp/fcl/collision_object.h>
 #include <hpp/fcl/mesh_loader/loader.h>
 #include <hpp/fcl/octree.h>
 #include <hpp/fcl/shape/geometric_shapes.h>
 namespace coal = hpp::fcl;
+namespace roboplan {
+/// @brief The Coal rigid transform type (renamed from Transform3f to Transform3s in coal).
+using CoalTransform = coal::Transform3f;
+}  // namespace roboplan
 #endif
 
 namespace roboplan {

--- a/roboplan_core/include/roboplan/core/robot_body_filter.hpp
+++ b/roboplan_core/include/roboplan/core/robot_body_filter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -38,6 +39,11 @@ struct RobotBodyFilterOptions {
 
   /// @brief The classification test to use.
   RobotBodyFilterMethod method = RobotBodyFilterMethod::NARROWPHASE;
+
+  /// @brief Number of threads used to classify points, or 0 to use all hardware threads. The
+  /// points are split into blocks that the threads pull from a shared queue, so at most one
+  /// thread per block is ever spawned and small clouds are processed serially either way.
+  size_t num_threads = 0;
 };
 
 /// @brief Filters points that lie on or near the robot's own collision geometry.

--- a/roboplan_core/include/roboplan/core/robot_body_filter.hpp
+++ b/roboplan_core/include/roboplan/core/robot_body_filter.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <roboplan/core/scene.hpp>
+
+namespace roboplan {
+
+// The transform type was renamed from Transform3f (hpp-fcl) to Transform3s (coal). Pick the
+// right one for whichever library the coal namespace resolves to (see geometry_wrappers.hpp).
+#if defined(__has_include) && __has_include(<coal/fwd.hh>)
+using CoalTransform = coal::Transform3s;
+#else
+using CoalTransform = coal::Transform3f;
+#endif
+
+/// @brief The test used by RobotBodyFilter to classify points near the robot geometry.
+enum class RobotBodyFilterMethod {
+  /// Exact: after the broadphase AABB cull, each candidate point is checked with a Coal
+  /// narrowphase collision query (point vs. geometry, with the padding as the security margin).
+  /// Exact for every geometry type, including meshes, at the cost of one GJK/BVH query per
+  /// candidate point.
+  NARROWPHASE,
+  /// Conservative: after the broadphase AABB cull, each candidate point is checked against the
+  /// geometry's padded local AABB (an oriented box in world frame). Much faster since it is a
+  /// few arithmetic operations per candidate, but over-removes points near the corners of the
+  /// oriented boxes. The set of points it removes is always a superset of NARROWPHASE's.
+  PADDED_OBB,
+};
+
+/// @brief Options struct for the robot body filter.
+struct RobotBodyFilterOptions {
+  /// @brief Distance, in meters, around the robot's collision geometry within which points are
+  /// considered part of the robot body. Must be non-negative.
+  double padding = 0.05;
+
+  /// @brief The classification test to use.
+  RobotBodyFilterMethod method = RobotBodyFilterMethod::NARROWPHASE;
+};
+
+/// @brief Filters points that lie on or near the robot's own collision geometry.
+///
+/// This is the usual "self filter" that removes the robot's body from a sensor point cloud (or
+/// the occupied cells of an octree) before the cloud is turned into a collision object, so that
+/// the robot does not see itself as an obstacle.
+///
+/// Both methods share a broadphase stage that culls points against the padded world-frame AABB of
+/// every robot collision geometry at the query configuration; they differ only in the exactness
+/// (and cost) of the test run on the surviving candidates. See RobotBodyFilterMethod.
+///
+/// @par Thread safety
+/// The filter owns private Pinocchio scratch over the Scene's immutable robot description, so
+/// distinct filters may run concurrently on one Scene, but a single filter must not be shared
+/// across threads. The robot geometry is snapshotted at construction; objects added to (or
+/// removed from) the scene afterwards do not affect it.
+class RobotBodyFilter {
+public:
+  /// @brief Points are given as an N x 3 row-major matrix (one point per row, matching the
+  /// default NumPy layout so the bindings can map arrays without copying).
+  using PointMatrix = Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
+  /// @brief Boolean mask over points; true means the point belongs to the robot body.
+  using Mask = Eigen::Matrix<bool, Eigen::Dynamic, 1>;
+
+  /// @brief Constructs a filter over the scene's current robot collision geometry.
+  /// @param scene The scene whose robot geometry to filter against.
+  /// @param options The filter options.
+  RobotBodyFilter(const std::shared_ptr<Scene>& scene, const RobotBodyFilterOptions& options);
+
+  /// @brief Classifies each point against the padded robot geometry at a joint configuration.
+  /// @param q The joint configuration at which to place the robot (size model.nq).
+  /// @param points The points to classify, one per row, in world frame.
+  /// @param extra_padding Optional per-point padding, in meters, added to the configured padding.
+  /// Useful when the points stand in for finite-sized cells (e.g. octree leaves), in which case
+  /// passing each cell's half-diagonal keeps the test conservative.
+  /// @return A mask sized to the number of points; true marks a point within the padded body.
+  Mask computeMask(const Eigen::VectorXd& q, const Eigen::Ref<const PointMatrix>& points,
+                   const std::optional<Eigen::VectorXd>& extra_padding = std::nullopt);
+
+  /// @brief Returns only the points outside the padded robot body at a joint configuration.
+  /// @param q The joint configuration at which to place the robot (size model.nq).
+  /// @param points The points to filter, one per row, in world frame.
+  /// @param extra_padding Optional per-point padding, in meters, added to the configured padding.
+  /// @return The rows of `points` whose computeMask() entry is false, in their original order.
+  PointMatrix filterPoints(const Eigen::VectorXd& q, const Eigen::Ref<const PointMatrix>& points,
+                           const std::optional<Eigen::VectorXd>& extra_padding = std::nullopt);
+
+  /// @brief The filter options.
+  const RobotBodyFilterOptions& getOptions() const { return options_; }
+
+private:
+  /// @brief The scene whose robot description (model and collision geometry) is filtered against.
+  std::shared_ptr<Scene> scene_;
+
+  /// @brief The filter options.
+  RobotBodyFilterOptions options_;
+
+  /// @brief A snapshot of the robot's own collision geometries (the ones loaded from the URDF,
+  /// excluding objects added to the scene), so later scene edits cannot invalidate the filter.
+  pinocchio::GeometryModel robot_geom_model_;
+
+  /// @brief Private kinematics scratch for placing the robot geometry at the query configuration.
+  pinocchio::Data data_;
+
+  /// @brief Private geometry scratch holding the world placements of robot_geom_model_.
+  pinocchio::GeometryData robot_geom_data_;
+
+  /// @brief Per-geometry scratch recomputed by computeMask() at each query configuration.
+  struct GeometryScratch {
+    /// @brief World-frame rotation and translation of the geometry.
+    Eigen::Matrix3d rotation;
+    Eigen::Vector3d translation;
+    /// @brief Center and half extents of the geometry's local AABB, in the geometry frame.
+    Eigen::Vector3d local_center;
+    Eigen::Vector3d local_half_extents;
+    /// @brief World-frame AABB of the placed geometry, already padded by the configured padding.
+    Eigen::Vector3d aabb_min;
+    Eigen::Vector3d aabb_max;
+    /// @brief The underlying Coal geometry and its placement, for narrowphase queries.
+    const coal::CollisionGeometry* geometry;
+    CoalTransform transform;
+  };
+  std::vector<GeometryScratch> geom_scratch_;
+};
+
+}  // namespace roboplan

--- a/roboplan_core/include/roboplan/core/robot_body_filter.hpp
+++ b/roboplan_core/include/roboplan/core/robot_body_filter.hpp
@@ -9,58 +9,49 @@
 
 namespace roboplan {
 
-// The transform type was renamed from Transform3f (hpp-fcl) to Transform3s (coal). Pick the
-// right one for whichever library the coal namespace resolves to (see geometry_wrappers.hpp).
-#if defined(__has_include) && __has_include(<coal/fwd.hh>)
-using CoalTransform = coal::Transform3s;
-#else
-using CoalTransform = coal::Transform3f;
-#endif
-
 /// @brief The test used by RobotBodyFilter to classify points near the robot geometry.
 enum class RobotBodyFilterMethod {
   /// Exact: after the broadphase AABB cull, each candidate point is checked with a Coal
-  /// narrowphase collision query (point vs. geometry, with the padding as the security margin).
-  /// Exact for every geometry type, including meshes, at the cost of one GJK/BVH query per
-  /// candidate point.
-  NARROWPHASE,
+  /// narrowphase collision query (point vs. padded geometry). This is exact for every geometry
+  /// type, including meshes, at the cost of one GJK/BVH query per candidate point.
+  Narrowphase,
   /// Conservative: after the broadphase AABB cull, each candidate point is checked against the
-  /// geometry's padded local AABB (an oriented box in world frame). Much faster since it is a
-  /// few arithmetic operations per candidate, but over-removes points near the corners of the
-  /// oriented boxes. The set of points it removes is always a superset of NARROWPHASE's.
-  PADDED_OBB,
+  /// geometry's padded oriented bounding box (OBB). This is much faster since it is a few
+  /// arithmetic operations per candidate, but over-removes points near the corners of the
+  /// oriented boxes. The set of points it removes is always a superset of Narrowphase's.
+  PaddedObb,
 };
 
 /// @brief Options struct for the robot body filter.
 struct RobotBodyFilterOptions {
   /// @brief Distance, in meters, around the robot's collision geometry within which points are
   /// considered part of the robot body. Must be non-negative.
-  double padding = 0.05;
+  double padding;
 
   /// @brief The classification test to use.
-  RobotBodyFilterMethod method = RobotBodyFilterMethod::NARROWPHASE;
+  RobotBodyFilterMethod method = RobotBodyFilterMethod::Narrowphase;
 
-  /// @brief Number of threads used to classify points, or 0 to use all hardware threads. The
-  /// points are split into blocks that the threads pull from a shared queue, so at most one
+  /// @brief Number of threads used to classify points, or 0 to use all hardware threads.
+  /// Points are split into blocks that the threads pull from a shared queue, so at most one
   /// thread per block is ever spawned and small clouds are processed serially either way.
   size_t num_threads = 0;
 };
 
 /// @brief Filters points that lie on or near the robot's own collision geometry.
 ///
-/// This is the usual "self filter" that removes the robot's body from a sensor point cloud (or
-/// the occupied cells of an octree) before the cloud is turned into a collision object, so that
-/// the robot does not see itself as an obstacle.
+/// This removes the robot's body from a sensor point cloud (or the occupied cells of an octree)
+/// so that the robot does not see itself as an obstacle when planning.
 ///
 /// Both methods share a broadphase stage that culls points against the padded world-frame AABB of
 /// every robot collision geometry at the query configuration; they differ only in the exactness
 /// (and cost) of the test run on the surviving candidates. See RobotBodyFilterMethod.
 ///
-/// @par Thread safety
-/// The filter owns private Pinocchio scratch over the Scene's immutable robot description, so
-/// distinct filters may run concurrently on one Scene, but a single filter must not be shared
-/// across threads. The robot geometry is snapshotted at construction; objects added to (or
-/// removed from) the scene afterwards do not affect it.
+/// @par Thread safety and lifetime
+/// The filter owns private Pinocchio scratch over the Scene's robot description, so distinct
+/// filters may run concurrently on one Scene, but a single filter must not be shared across
+/// threads. Only the robot's own collision geometry is filtered against, and it is copied at
+/// construction, so objects can be freely added to or removed from the scene without rebuilding
+/// the filter.
 class RobotBodyFilter {
 public:
   /// @brief Points are given as an N x 3 row-major matrix (one point per row, matching the
@@ -103,6 +94,9 @@ private:
   /// @brief The filter options.
   RobotBodyFilterOptions options_;
 
+  /// @brief The thread cap from the options, with 0 resolved to the hardware thread count.
+  size_t max_threads_;
+
   /// @brief A snapshot of the robot's own collision geometries (the ones loaded from the URDF,
   /// excluding objects added to the scene), so later scene edits cannot invalidate the filter.
   pinocchio::GeometryModel robot_geom_model_;
@@ -113,22 +107,10 @@ private:
   /// @brief Private geometry scratch holding the world placements of robot_geom_model_.
   pinocchio::GeometryData robot_geom_data_;
 
-  /// @brief Per-geometry scratch recomputed by computeMask() at each query configuration.
-  struct GeometryScratch {
-    /// @brief World-frame rotation and translation of the geometry.
-    Eigen::Matrix3d rotation;
-    Eigen::Vector3d translation;
-    /// @brief Center and half extents of the geometry's local AABB, in the geometry frame.
-    Eigen::Vector3d local_center;
-    Eigen::Vector3d local_half_extents;
-    /// @brief World-frame AABB of the placed geometry, already padded by the configured padding.
-    Eigen::Vector3d aabb_min;
-    Eigen::Vector3d aabb_max;
-    /// @brief The underlying Coal geometry and its placement, for narrowphase queries.
-    const coal::CollisionGeometry* geometry;
-    CoalTransform transform;
-  };
-  std::vector<GeometryScratch> geom_scratch_;
+  /// @brief One Coal collision object per geometry in robot_geom_model_, placed by computeMask()
+  /// at the query configuration. Provides the world-frame AABB for the broadphase cull and the
+  /// geometry and transform for the narrowphase and OBB tests.
+  std::vector<coal::CollisionObject> collision_objects_;
 };
 
 }  // namespace roboplan

--- a/roboplan_core/include/roboplan/core/scene.hpp
+++ b/roboplan_core/include/roboplan/core/scene.hpp
@@ -473,6 +473,17 @@ public:
   tl::expected<std::vector<pinocchio::GeomIndex>, std::string>
   getCollisionGeometryIds(const std::string& body);
 
+  /// @brief Gets the collision geometry IDs belonging to the robot model itself.
+  /// @details That is, the geometries loaded from the URDF at construction, excluding any
+  /// objects (boxes, spheres, meshes, octrees, etc.) added to the scene afterwards. These IDs
+  /// are computed once at construction: added objects always append after the robot's
+  /// geometries, and only added objects can be removed (shifting only the indices above the
+  /// robot's), so they stay valid for the Scene's lifetime.
+  /// @return The collision geometry indices for the robot's own geometry.
+  const std::vector<pinocchio::GeomIndex>& getRobotCollisionGeometryIds() const {
+    return robot_collision_geometry_ids_;
+  }
+
   /// @brief Sets the allowable collisions for a pair of bodies in the model.
   /// @details The body names can either be model frame names or collision model geometry names.
   /// @param body1 The name of the first body.
@@ -543,6 +554,9 @@ private:
 
   /// @brief Maps each added collision geometry to its respective Pinocchio geometry ID.
   std::unordered_map<std::string, pinocchio::GeomIndex> collision_geometry_map_;
+
+  /// @brief The collision geometry IDs of the robot itself (see getRobotCollisionGeometryIds).
+  std::vector<pinocchio::GeomIndex> robot_collision_geometry_ids_;
 
   /// @brief Incremented on every change to the collision geometry, so that SceneContexts
   /// snapshotted from an older version can detect that they are stale.

--- a/roboplan_core/src/core/robot_body_filter.cpp
+++ b/roboplan_core/src/core/robot_body_filter.cpp
@@ -1,5 +1,11 @@
+#include <algorithm>
+#include <atomic>
+#include <exception>
+#include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <pinocchio/algorithm/geometry.hpp>
 
@@ -81,43 +87,105 @@ RobotBodyFilter::computeMask(const Eigen::VectorXd& q, const Eigen::Ref<const Po
 
   const bool use_narrowphase = (options_.method == RobotBodyFilterMethod::NARROWPHASE);
   const coal::Sphere point_geom(0.0);
-  coal::CollisionRequest request;
 
   Mask mask = Mask::Constant(num_points, false);
-  for (Eigen::Index i = 0; i < num_points; ++i) {
-    const Eigen::Vector3d point = points.row(i);
-    const double extra = extra_padding ? (*extra_padding)(i) : 0.0;
 
-    for (const auto& scratch : geom_scratch_) {
-      // Broadphase: skip geometries whose padded world AABB does not contain the point.
-      if (((point - scratch.aabb_min).array() < -extra).any() ||
-          ((point - scratch.aabb_max).array() > extra).any()) {
-        continue;
-      }
+  // Classifies the points in [begin, end). Each worker owns its request so the per-point
+  // security margin can be set without sharing state; the geometries and their placements are
+  // read-only for the duration of the query, and each point writes only its own mask entry.
+  const auto classify_block = [&](const Eigen::Index begin, const Eigen::Index end,
+                                  coal::CollisionRequest& request) {
+    for (Eigen::Index i = begin; i < end; ++i) {
+      const Eigen::Vector3d point = points.row(i);
+      const double extra = extra_padding ? (*extra_padding)(i) : 0.0;
 
-      bool near_body;
-      if (use_narrowphase) {
-        // Exact point-vs-geometry query: a zero-radius sphere collides when it is within the
-        // security margin of the geometry surface, i.e. within the padding distance.
-        request.security_margin = padding + extra;
-        coal::CollisionResult result;
-        coal::collide(&point_geom, CoalTransform(point), scratch.geometry, scratch.transform,
-                      request, result);
-        near_body = result.isCollision();
-      } else {
-        // Conservative point-in-padded-OBB test in the geometry's local frame.
-        const Eigen::Vector3d local_point =
-            scratch.rotation.transpose() * (point - scratch.translation);
-        near_body = ((local_point - scratch.local_center).cwiseAbs().array() <=
-                     scratch.local_half_extents.array() + (padding + extra))
-                        .all();
-      }
+      for (const auto& scratch : geom_scratch_) {
+        // Broadphase: skip geometries whose padded world AABB does not contain the point.
+        if (((point - scratch.aabb_min).array() < -extra).any() ||
+            ((point - scratch.aabb_max).array() > extra).any()) {
+          continue;
+        }
 
-      if (near_body) {
-        mask(i) = true;
-        break;
+        bool near_body;
+        if (use_narrowphase) {
+          // Exact point-vs-geometry query: a zero-radius sphere collides when it is within the
+          // security margin of the geometry surface, i.e. within the padding distance.
+          request.security_margin = padding + extra;
+          coal::CollisionResult result;
+          coal::collide(&point_geom, CoalTransform(point), scratch.geometry, scratch.transform,
+                        request, result);
+          near_body = result.isCollision();
+        } else {
+          // Conservative point-in-padded-OBB test in the geometry's local frame.
+          const Eigen::Vector3d local_point =
+              scratch.rotation.transpose() * (point - scratch.translation);
+          near_body = ((local_point - scratch.local_center).cwiseAbs().array() <=
+                       scratch.local_half_extents.array() + (padding + extra))
+                          .all();
+        }
+
+        if (near_body) {
+          mask(i) = true;
+          break;
+        }
       }
     }
+  };
+
+  // Points are handed out in small fixed-size blocks from a shared counter, so threads that land
+  // on stretches of cheap (culled) points simply take more blocks than those doing narrowphase
+  // work, even when the points on the robot are clustered together in the cloud (as they are in
+  // a sensor scan). Spawning a thread costs on the order of the time it takes to classify a few
+  // thousand culled points, so the thread count is also capped to keep small clouds serial.
+  constexpr Eigen::Index kBlockSize = 256;
+  constexpr Eigen::Index kMinPointsPerThread = 8192;
+  const size_t max_threads = (options_.num_threads == 0)
+                                 ? std::max(1u, std::thread::hardware_concurrency())
+                                 : options_.num_threads;
+  const size_t num_threads = std::min<size_t>(
+      max_threads,
+      static_cast<size_t>(std::max<Eigen::Index>(1, num_points / kMinPointsPerThread)));
+
+  if (num_threads <= 1) {
+    coal::CollisionRequest request;
+    classify_block(0, num_points, request);
+    return mask;
+  }
+
+  std::atomic<Eigen::Index> next_begin{0};
+  std::exception_ptr worker_error;
+  std::mutex error_mutex;
+  const auto worker = [&]() {
+    try {
+      coal::CollisionRequest request;
+      while (true) {
+        const auto begin = next_begin.fetch_add(kBlockSize, std::memory_order_relaxed);
+        if (begin >= num_points) {
+          break;
+        }
+        classify_block(begin, std::min(begin + kBlockSize, num_points), request);
+      }
+    } catch (...) {
+      const std::lock_guard<std::mutex> lock(error_mutex);
+      if (!worker_error) {
+        worker_error = std::current_exception();
+      }
+      // Drain the remaining blocks so the other workers stop promptly.
+      next_begin.store(num_points, std::memory_order_relaxed);
+    }
+  };
+
+  std::vector<std::thread> workers;
+  workers.reserve(num_threads - 1);
+  for (size_t t = 1; t < num_threads; ++t) {
+    workers.emplace_back(worker);
+  }
+  worker();  // The calling thread takes part as well.
+  for (auto& thread : workers) {
+    thread.join();
+  }
+  if (worker_error) {
+    std::rethrow_exception(worker_error);
   }
   return mask;
 }

--- a/roboplan_core/src/core/robot_body_filter.cpp
+++ b/roboplan_core/src/core/robot_body_filter.cpp
@@ -1,0 +1,139 @@
+#include <stdexcept>
+#include <string>
+
+#include <pinocchio/algorithm/geometry.hpp>
+
+#include <roboplan/core/robot_body_filter.hpp>
+
+// Mirror the coal/hpp-fcl include guard used in geometry_wrappers.hpp.
+#if defined(__has_include) && __has_include(<coal/fwd.hh>)
+#include <coal/collision.h>
+#include <coal/shape/geometric_shapes.h>
+#else
+#include <hpp/fcl/collision.h>
+#include <hpp/fcl/shape/geometric_shapes.h>
+#endif
+
+namespace roboplan {
+
+RobotBodyFilter::RobotBodyFilter(const std::shared_ptr<Scene>& scene,
+                                 const RobotBodyFilterOptions& options)
+    : scene_{scene}, options_{options}, data_{scene->getModel()} {
+  if (options_.padding < 0.0) {
+    throw std::invalid_argument("RobotBodyFilter padding must be non-negative, got " +
+                                std::to_string(options_.padding) + ".");
+  }
+
+  // Snapshot the robot's own geometries into a private geometry model. The Coal geometry
+  // pointers are shared with the scene, but the model structure (and thus the scratch shaped
+  // from it) stays valid even if objects are later added to or removed from the scene.
+  const auto& collision_model = scene_->getCollisionModel();
+  for (const auto robot_geom_id : scene_->getRobotCollisionGeometryIds()) {
+    const auto& geom_obj = collision_model.geometryObjects[robot_geom_id];
+    // Make sure the local AABB used by both the broadphase cull and the OBB test is available.
+    geom_obj.geometry->computeLocalAABB();
+    robot_geom_model_.addGeometryObject(geom_obj);
+  }
+
+  robot_geom_data_ = pinocchio::GeometryData(robot_geom_model_);
+  geom_scratch_.resize(robot_geom_model_.ngeoms);
+}
+
+RobotBodyFilter::Mask
+RobotBodyFilter::computeMask(const Eigen::VectorXd& q, const Eigen::Ref<const PointMatrix>& points,
+                             const std::optional<Eigen::VectorXd>& extra_padding) {
+  const auto num_points = points.rows();
+  if (extra_padding && extra_padding->size() != num_points) {
+    throw std::invalid_argument("RobotBodyFilter extra_padding has size " +
+                                std::to_string(extra_padding->size()) + " but there are " +
+                                std::to_string(num_points) + " points.");
+  }
+
+  // Place the robot geometry at the query configuration (runs forward kinematics).
+  pinocchio::updateGeometryPlacements(scene_->getModel(), data_, robot_geom_model_,
+                                      robot_geom_data_, q);
+
+  // Per-geometry setup: world placements and padded world-frame AABBs. The AABB of a rotated
+  // box with half extents h is |R| * h, expanded here by the scalar padding; any per-point
+  // extra padding is applied at test time instead.
+  const double padding = options_.padding;
+  for (size_t g = 0; g < robot_geom_model_.ngeoms; ++g) {
+    auto& scratch = geom_scratch_[g];
+    const auto& oMg = robot_geom_data_.oMg[g];
+    const auto& geom = *robot_geom_model_.geometryObjects[g].geometry;
+
+    scratch.rotation = oMg.rotation();
+    scratch.translation = oMg.translation();
+    scratch.local_center = geom.aabb_local.center();
+    scratch.local_half_extents = 0.5 * (geom.aabb_local.max_ - geom.aabb_local.min_);
+
+    const Eigen::Vector3d world_center =
+        scratch.rotation * scratch.local_center + scratch.translation;
+    const Eigen::Vector3d world_half_extents =
+        scratch.rotation.cwiseAbs() * scratch.local_half_extents +
+        Eigen::Vector3d::Constant(padding);
+    scratch.aabb_min = world_center - world_half_extents;
+    scratch.aabb_max = world_center + world_half_extents;
+
+    scratch.geometry = &geom;
+    scratch.transform = CoalTransform(scratch.rotation, scratch.translation);
+  }
+
+  const bool use_narrowphase = (options_.method == RobotBodyFilterMethod::NARROWPHASE);
+  const coal::Sphere point_geom(0.0);
+  coal::CollisionRequest request;
+
+  Mask mask = Mask::Constant(num_points, false);
+  for (Eigen::Index i = 0; i < num_points; ++i) {
+    const Eigen::Vector3d point = points.row(i);
+    const double extra = extra_padding ? (*extra_padding)(i) : 0.0;
+
+    for (const auto& scratch : geom_scratch_) {
+      // Broadphase: skip geometries whose padded world AABB does not contain the point.
+      if (((point - scratch.aabb_min).array() < -extra).any() ||
+          ((point - scratch.aabb_max).array() > extra).any()) {
+        continue;
+      }
+
+      bool near_body;
+      if (use_narrowphase) {
+        // Exact point-vs-geometry query: a zero-radius sphere collides when it is within the
+        // security margin of the geometry surface, i.e. within the padding distance.
+        request.security_margin = padding + extra;
+        coal::CollisionResult result;
+        coal::collide(&point_geom, CoalTransform(point), scratch.geometry, scratch.transform,
+                      request, result);
+        near_body = result.isCollision();
+      } else {
+        // Conservative point-in-padded-OBB test in the geometry's local frame.
+        const Eigen::Vector3d local_point =
+            scratch.rotation.transpose() * (point - scratch.translation);
+        near_body = ((local_point - scratch.local_center).cwiseAbs().array() <=
+                     scratch.local_half_extents.array() + (padding + extra))
+                        .all();
+      }
+
+      if (near_body) {
+        mask(i) = true;
+        break;
+      }
+    }
+  }
+  return mask;
+}
+
+RobotBodyFilter::PointMatrix
+RobotBodyFilter::filterPoints(const Eigen::VectorXd& q, const Eigen::Ref<const PointMatrix>& points,
+                              const std::optional<Eigen::VectorXd>& extra_padding) {
+  const Mask mask = computeMask(q, points, extra_padding);
+  PointMatrix kept(points.rows() - mask.count(), 3);
+  Eigen::Index kept_idx = 0;
+  for (Eigen::Index i = 0; i < points.rows(); ++i) {
+    if (!mask(i)) {
+      kept.row(kept_idx++) = points.row(i);
+    }
+  }
+  return kept;
+}
+
+}  // namespace roboplan

--- a/roboplan_core/src/core/robot_body_filter.cpp
+++ b/roboplan_core/src/core/robot_body_filter.cpp
@@ -14,13 +14,21 @@
 // Mirror the coal/hpp-fcl include guard used in geometry_wrappers.hpp.
 #if defined(__has_include) && __has_include(<coal/fwd.hh>)
 #include <coal/collision.h>
-#include <coal/shape/geometric_shapes.h>
 #else
 #include <hpp/fcl/collision.h>
-#include <hpp/fcl/shape/geometric_shapes.h>
 #endif
 
 namespace roboplan {
+
+namespace {
+
+/// @brief Number of points each worker thread claims at a time from the shared block counter.
+constexpr Eigen::Index kBlockSize = 256;
+
+/// @brief Minimum number of points per thread before an extra thread is worth spawning.
+constexpr Eigen::Index kMinPointsPerThread = 8192;
+
+}  // namespace
 
 RobotBodyFilter::RobotBodyFilter(const std::shared_ptr<Scene>& scene,
                                  const RobotBodyFilterOptions& options)
@@ -29,20 +37,18 @@ RobotBodyFilter::RobotBodyFilter(const std::shared_ptr<Scene>& scene,
     throw std::invalid_argument("RobotBodyFilter padding must be non-negative, got " +
                                 std::to_string(options_.padding) + ".");
   }
+  max_threads_ = (options_.num_threads == 0) ? std::max(1u, std::thread::hardware_concurrency())
+                                             : options_.num_threads;
 
-  // Snapshot the robot's own geometries into a private geometry model. The Coal geometry
-  // pointers are shared with the scene, but the model structure (and thus the scratch shaped
-  // from it) stays valid even if objects are later added to or removed from the scene.
+  // Snapshot the robot's own geometries so later scene edits cannot invalidate the filter. The
+  // collision objects compute each geometry's local AABB on construction.
   const auto& collision_model = scene_->getCollisionModel();
   for (const auto robot_geom_id : scene_->getRobotCollisionGeometryIds()) {
     const auto& geom_obj = collision_model.geometryObjects[robot_geom_id];
-    // Make sure the local AABB used by both the broadphase cull and the OBB test is available.
-    geom_obj.geometry->computeLocalAABB();
     robot_geom_model_.addGeometryObject(geom_obj);
+    collision_objects_.emplace_back(geom_obj.geometry);
   }
-
   robot_geom_data_ = pinocchio::GeometryData(robot_geom_model_);
-  geom_scratch_.resize(robot_geom_model_.ngeoms);
 }
 
 RobotBodyFilter::Mask
@@ -59,69 +65,48 @@ RobotBodyFilter::computeMask(const Eigen::VectorXd& q, const Eigen::Ref<const Po
   pinocchio::updateGeometryPlacements(scene_->getModel(), data_, robot_geom_model_,
                                       robot_geom_data_, q);
 
-  // Per-geometry setup: world placements and padded world-frame AABBs. The AABB of a rotated
-  // box with half extents h is |R| * h, expanded here by the scalar padding; any per-point
-  // extra padding is applied at test time instead.
-  const double padding = options_.padding;
-  for (size_t g = 0; g < robot_geom_model_.ngeoms; ++g) {
-    auto& scratch = geom_scratch_[g];
+  // Place the collision objects at the query configuration and refresh their world-frame AABBs.
+  for (size_t g = 0; g < collision_objects_.size(); ++g) {
     const auto& oMg = robot_geom_data_.oMg[g];
-    const auto& geom = *robot_geom_model_.geometryObjects[g].geometry;
-
-    scratch.rotation = oMg.rotation();
-    scratch.translation = oMg.translation();
-    scratch.local_center = geom.aabb_local.center();
-    scratch.local_half_extents = 0.5 * (geom.aabb_local.max_ - geom.aabb_local.min_);
-
-    const Eigen::Vector3d world_center =
-        scratch.rotation * scratch.local_center + scratch.translation;
-    const Eigen::Vector3d world_half_extents =
-        scratch.rotation.cwiseAbs() * scratch.local_half_extents +
-        Eigen::Vector3d::Constant(padding);
-    scratch.aabb_min = world_center - world_half_extents;
-    scratch.aabb_max = world_center + world_half_extents;
-
-    scratch.geometry = &geom;
-    scratch.transform = CoalTransform(scratch.rotation, scratch.translation);
+    collision_objects_[g].setTransform(oMg.rotation(), oMg.translation());
+    collision_objects_[g].computeAABB();
   }
 
-  const bool use_narrowphase = (options_.method == RobotBodyFilterMethod::NARROWPHASE);
+  const bool use_narrowphase = (options_.method == RobotBodyFilterMethod::Narrowphase);
   const coal::Sphere point_geom(0.0);
-
   Mask mask = Mask::Constant(num_points, false);
 
-  // Classifies the points in [begin, end). Each worker owns its request so the per-point
-  // security margin can be set without sharing state; the geometries and their placements are
-  // read-only for the duration of the query, and each point writes only its own mask entry.
-  const auto classify_block = [&](const Eigen::Index begin, const Eigen::Index end,
-                                  coal::CollisionRequest& request) {
+  // Classifies the points in [begin, end). The collision objects are read-only for the duration
+  // of the query and each point writes only its own mask entry, so blocks can run concurrently.
+  const auto classify_block = [&](const Eigen::Index begin, const Eigen::Index end) {
+    coal::CollisionRequest request;
     for (Eigen::Index i = begin; i < end; ++i) {
       const Eigen::Vector3d point = points.row(i);
-      const double extra = extra_padding ? (*extra_padding)(i) : 0.0;
+      const double margin = options_.padding + (extra_padding ? (*extra_padding)(i) : 0.0);
 
-      for (const auto& scratch : geom_scratch_) {
-        // Broadphase: skip geometries whose padded world AABB does not contain the point.
-        if (((point - scratch.aabb_min).array() < -extra).any() ||
-            ((point - scratch.aabb_max).array() > extra).any()) {
+      for (const auto& object : collision_objects_) {
+        // Broadphase: skip geometries whose world AABB, grown by the margin, misses the point.
+        const auto& aabb = object.getAABB();
+        if (((point - aabb.min_).array() < -margin).any() ||
+            ((point - aabb.max_).array() > margin).any()) {
           continue;
         }
 
         bool near_body;
         if (use_narrowphase) {
           // Exact point-vs-geometry query: a zero-radius sphere collides when it is within the
-          // security margin of the geometry surface, i.e. within the padding distance.
-          request.security_margin = padding + extra;
+          // security margin of the geometry surface.
+          request.security_margin = margin;
           coal::CollisionResult result;
-          coal::collide(&point_geom, CoalTransform(point), scratch.geometry, scratch.transform,
-                        request, result);
+          coal::collide(&point_geom, CoalTransform(point), object.collisionGeometry().get(),
+                        object.getTransform(), request, result);
           near_body = result.isCollision();
         } else {
-          // Conservative point-in-padded-OBB test in the geometry's local frame.
-          const Eigen::Vector3d local_point =
-              scratch.rotation.transpose() * (point - scratch.translation);
-          near_body = ((local_point - scratch.local_center).cwiseAbs().array() <=
-                       scratch.local_half_extents.array() + (padding + extra))
-                          .all();
+          // Conservative test against the local AABB, grown by the margin, in the geometry frame.
+          const auto& local_aabb = object.collisionGeometry()->aabb_local;
+          const Eigen::Vector3d local_point = object.getTransform().inverseTransform(point);
+          near_body = ((local_point - local_aabb.min_).array() >= -margin).all() &&
+                      ((local_point - local_aabb.max_).array() <= margin).all();
         }
 
         if (near_body) {
@@ -135,20 +120,11 @@ RobotBodyFilter::computeMask(const Eigen::VectorXd& q, const Eigen::Ref<const Po
   // Points are handed out in small fixed-size blocks from a shared counter, so threads that land
   // on stretches of cheap (culled) points simply take more blocks than those doing narrowphase
   // work, even when the points on the robot are clustered together in the cloud (as they are in
-  // a sensor scan). Spawning a thread costs on the order of the time it takes to classify a few
-  // thousand culled points, so the thread count is also capped to keep small clouds serial.
-  constexpr Eigen::Index kBlockSize = 256;
-  constexpr Eigen::Index kMinPointsPerThread = 8192;
-  const size_t max_threads = (options_.num_threads == 0)
-                                 ? std::max(1u, std::thread::hardware_concurrency())
-                                 : options_.num_threads;
-  const size_t num_threads = std::min<size_t>(
-      max_threads,
-      static_cast<size_t>(std::max<Eigen::Index>(1, num_points / kMinPointsPerThread)));
-
+  // a sensor scan). The thread count is also capped to keep small clouds serial.
+  const size_t num_threads =
+      std::min<size_t>(max_threads_, std::max<Eigen::Index>(1, num_points / kMinPointsPerThread));
   if (num_threads <= 1) {
-    coal::CollisionRequest request;
-    classify_block(0, num_points, request);
+    classify_block(0, num_points);
     return mask;
   }
 
@@ -157,21 +133,16 @@ RobotBodyFilter::computeMask(const Eigen::VectorXd& q, const Eigen::Ref<const Po
   std::mutex error_mutex;
   const auto worker = [&]() {
     try {
-      coal::CollisionRequest request;
-      while (true) {
-        const auto begin = next_begin.fetch_add(kBlockSize, std::memory_order_relaxed);
-        if (begin >= num_points) {
-          break;
-        }
-        classify_block(begin, std::min(begin + kBlockSize, num_points), request);
+      for (auto begin = next_begin.fetch_add(kBlockSize); begin < num_points;
+           begin = next_begin.fetch_add(kBlockSize)) {
+        classify_block(begin, std::min(begin + kBlockSize, num_points));
       }
     } catch (...) {
       const std::lock_guard<std::mutex> lock(error_mutex);
       if (!worker_error) {
         worker_error = std::current_exception();
       }
-      // Drain the remaining blocks so the other workers stop promptly.
-      next_begin.store(num_points, std::memory_order_relaxed);
+      next_begin.store(num_points);  // Drain the remaining blocks so the other workers stop.
     }
   };
 

--- a/roboplan_core/src/core/scene.cpp
+++ b/roboplan_core/src/core/scene.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <limits>
 #include <numbers>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -177,6 +178,12 @@ Scene::Scene(const std::string& name, const std::string& urdf, const std::string
                              collision_model_, package_paths_str);
   collision_model_.addAllCollisionPairs();
   pinocchio::srdf::removeCollisionPairsFromXML(model_, collision_model_, srdf);
+
+  // Everything in the collision model at this point came from the URDF, i.e. the robot itself.
+  // Objects added later always append (and only added objects can be removed, shifting only the
+  // indices above these), so this list stays valid for the Scene's lifetime.
+  robot_collision_geometry_ids_.resize(collision_model_.ngeoms);
+  std::iota(robot_collision_geometry_ids_.begin(), robot_collision_geometry_ids_.end(), 0);
 
   // Create auxiliary model info
   frame_map_ = createFrameMap(model_);

--- a/roboplan_core/test/CMakeLists.txt
+++ b/roboplan_core/test/CMakeLists.txt
@@ -22,6 +22,11 @@ set_property(TARGET test_path_utils PROPERTY CXX_STANDARD 20)
 target_link_libraries(test_path_utils roboplan GTest::gtest_main
                       roboplan_example_models::roboplan_example_models)
 
+add_executable(test_robot_body_filter test_robot_body_filter.cpp)
+set_property(TARGET test_robot_body_filter PROPERTY CXX_STANDARD 20)
+target_link_libraries(test_robot_body_filter roboplan GTest::gtest_main
+                      roboplan_example_models::roboplan_example_models)
+
 add_executable(test_scene_context test_scene_context.cpp)
 set_property(TARGET test_scene_context PROPERTY CXX_STANDARD 20)
 target_link_libraries(test_scene_context roboplan GTest::gtest_main
@@ -45,6 +50,7 @@ if(ament_cmake_gtest_FOUND)
   ament_add_gtest_test(test_scene)
   ament_add_gtest_test(test_joints)
   ament_add_gtest_test(test_path_utils)
+  ament_add_gtest_test(test_robot_body_filter)
   ament_add_gtest_test(test_scene_context)
   ament_add_gtest_test(test_se3_low_pass_filter)
   ament_add_gtest_test(test_urdf_extended_limits)
@@ -54,6 +60,7 @@ else()
   gtest_add_tests(TARGET test_scene)
   gtest_add_tests(TARGET test_joints)
   gtest_add_tests(TARGET test_path_utils)
+  gtest_add_tests(TARGET test_robot_body_filter)
   gtest_add_tests(TARGET test_scene_context)
   gtest_add_tests(TARGET test_se3_low_pass_filter)
   gtest_add_tests(TARGET test_urdf_extended_limits)

--- a/roboplan_core/test/test_robot_body_filter.cpp
+++ b/roboplan_core/test/test_robot_body_filter.cpp
@@ -1,0 +1,181 @@
+#include <memory>
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <roboplan/core/robot_body_filter.hpp>
+#include <roboplan/core/scene.hpp>
+#include <roboplan_example_models/resources.hpp>
+
+namespace roboplan {
+
+namespace {
+
+/// A robot made of a single sphere of radius 0.1 fixed at the origin, so the filter's
+/// classification can be checked against closed-form distances.
+constexpr const char* kBallUrdf = R"(
+<robot name="ball_bot">
+  <link name="world"/>
+  <link name="ball_link">
+    <collision>
+      <geometry><sphere radius="0.1"/></geometry>
+    </collision>
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" iyy="0.01" izz="0.01" ixy="0.0" ixz="0.0" iyz="0.0"/>
+    </inertial>
+  </link>
+  <joint name="world_to_ball" type="fixed">
+    <parent link="world"/>
+    <child link="ball_link"/>
+    <origin xyz="0 0 0"/>
+  </joint>
+</robot>
+)";
+
+constexpr const char* kBallSrdf = R"(<robot name="ball_bot"/>)";
+
+std::shared_ptr<Scene> makeBallScene() {
+  return std::make_shared<Scene>("ball_scene", std::string(kBallUrdf), std::string(kBallSrdf));
+}
+
+std::shared_ptr<Scene> makeUr5Scene() {
+  const auto model_prefix = example_models::get_package_models_dir();
+  return std::make_shared<Scene>(
+      "ur5_scene", model_prefix / "ur_robot_model" / "ur5_gripper.urdf",
+      model_prefix / "ur_robot_model" / "ur5_gripper.srdf",
+      std::vector<std::filesystem::path>{example_models::get_package_share_dir()},
+      model_prefix / "ur_robot_model" / "ur5_config.yaml");
+}
+
+}  // namespace
+
+TEST(RobotBodyFilterTest, NegativePaddingThrows) {
+  auto scene = makeBallScene();
+  EXPECT_THROW(RobotBodyFilter(scene, RobotBodyFilterOptions{.padding = -0.1}),
+               std::invalid_argument);
+}
+
+TEST(RobotBodyFilterTest, NarrowphaseMatchesExactSphereDistance) {
+  auto scene = makeBallScene();
+  RobotBodyFilter filter(
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+
+  // The padded body is the ball of radius 0.1 + 0.05 = 0.15 around the origin.
+  RobotBodyFilter::PointMatrix points(4, 3);
+  points.row(0) << 0.0, 0.0, 0.0;    // Center: inside.
+  points.row(1) << 0.14, 0.0, 0.0;   // Distance 0.14: inside.
+  points.row(2) << 0.12, 0.12, 0.0;  // Distance ~0.170: outside the ball, inside its AABB.
+  points.row(3) << 0.2, 0.0, 0.0;    // Distance 0.2: outside.
+
+  const auto mask = filter.computeMask(Eigen::VectorXd(0), points);
+  EXPECT_TRUE(mask(0));
+  EXPECT_TRUE(mask(1));
+  EXPECT_FALSE(mask(2));
+  EXPECT_FALSE(mask(3));
+}
+
+TEST(RobotBodyFilterTest, PaddedObbOverRemovesCorners) {
+  auto scene = makeBallScene();
+  RobotBodyFilter filter(
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::PADDED_OBB});
+
+  // The padded OBB is the box of half extent 0.15 around the origin.
+  RobotBodyFilter::PointMatrix points(3, 3);
+  points.row(0) << 0.14, 0.0, 0.0;   // Inside the ball: removed by both methods.
+  points.row(1) << 0.12, 0.12, 0.0;  // Corner region: only the OBB test removes it.
+  points.row(2) << 0.2, 0.0, 0.0;    // Outside the box: kept by both methods.
+
+  const auto mask = filter.computeMask(Eigen::VectorXd(0), points);
+  EXPECT_TRUE(mask(0));
+  EXPECT_TRUE(mask(1));
+  EXPECT_FALSE(mask(2));
+}
+
+TEST(RobotBodyFilterTest, ExtraPaddingIsAppliedPerPoint) {
+  auto scene = makeBallScene();
+  RobotBodyFilter filter(
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+
+  // Both points are 0.1 outside the ball surface, past the 0.05 padding; only the one granted
+  // 0.1 of extra padding is classified as part of the body.
+  RobotBodyFilter::PointMatrix points(2, 3);
+  points.row(0) << 0.2, 0.0, 0.0;
+  points.row(1) << 0.2, 0.0, 0.0;
+  Eigen::VectorXd extra_padding(2);
+  extra_padding << 0.0, 0.1;
+
+  const auto mask = filter.computeMask(Eigen::VectorXd(0), points, extra_padding);
+  EXPECT_FALSE(mask(0));
+  EXPECT_TRUE(mask(1));
+}
+
+TEST(RobotBodyFilterTest, FilterPointsKeepsUnmaskedRowsInOrder) {
+  auto scene = makeBallScene();
+  RobotBodyFilter filter(
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+
+  RobotBodyFilter::PointMatrix points(3, 3);
+  points.row(0) << 0.5, 0.0, 0.0;
+  points.row(1) << 0.0, 0.0, 0.0;
+  points.row(2) << 0.0, 0.6, 0.0;
+
+  const auto kept = filter.filterPoints(Eigen::VectorXd(0), points);
+  ASSERT_EQ(kept.rows(), 2);
+  EXPECT_TRUE(kept.row(0).isApprox(points.row(0)));
+  EXPECT_TRUE(kept.row(1).isApprox(points.row(2)));
+}
+
+TEST(RobotBodyFilterTest, PaddedObbMaskIsSupersetOfNarrowphase) {
+  auto scene = makeUr5Scene();
+  RobotBodyFilter narrowphase_filter(
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+  RobotBodyFilter obb_filter(
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::PADDED_OBB});
+
+  // Random points in a box around the robot at a fixed seed.
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+  RobotBodyFilter::PointMatrix points(500, 3);
+  for (Eigen::Index i = 0; i < points.rows(); ++i) {
+    points.row(i) << dist(rng), dist(rng), dist(rng);
+  }
+
+  const auto q = scene->getCurrentJointPositions();
+  const auto narrowphase_mask = narrowphase_filter.computeMask(q, points);
+  const auto obb_mask = obb_filter.computeMask(q, points);
+
+  EXPECT_GT(narrowphase_mask.count(), 0);
+  for (Eigen::Index i = 0; i < points.rows(); ++i) {
+    if (narrowphase_mask(i)) {
+      EXPECT_TRUE(obb_mask(i)) << "point " << i << " removed by NARROWPHASE but not PADDED_OBB";
+    }
+  }
+}
+
+TEST(RobotBodyFilterTest, IgnoresGeometryAddedToScene) {
+  auto scene = makeUr5Scene();
+  const auto num_robot_geoms = scene->getRobotCollisionGeometryIds().size();
+
+  // A point inside an obstacle added to the scene must not be classified as robot body,
+  // whether the filter was built before or after the obstacle was added.
+  RobotBodyFilter filter_before(scene, RobotBodyFilterOptions{.padding = 0.05});
+
+  Eigen::Matrix4d tform = Eigen::Matrix4d::Identity();
+  tform(0, 3) = 2.0;
+  ASSERT_TRUE(scene->addBoxGeometry("obstacle_box", "universe", Box(0.4, 0.4, 0.4), tform,
+                                    Eigen::Vector4d(1.0, 0.0, 0.0, 1.0)));
+  EXPECT_EQ(scene->getRobotCollisionGeometryIds().size(), num_robot_geoms);
+
+  RobotBodyFilter filter_after(scene, RobotBodyFilterOptions{.padding = 0.05});
+
+  RobotBodyFilter::PointMatrix points(1, 3);
+  points.row(0) << 2.0, 0.0, 0.0;
+
+  const auto q = scene->getCurrentJointPositions();
+  EXPECT_FALSE(filter_before.computeMask(q, points)(0));
+  EXPECT_FALSE(filter_after.computeMask(q, points)(0));
+}
+
+}  // namespace roboplan

--- a/roboplan_core/test/test_robot_body_filter.cpp
+++ b/roboplan_core/test/test_robot_body_filter.cpp
@@ -154,6 +154,41 @@ TEST(RobotBodyFilterTest, PaddedObbMaskIsSupersetOfNarrowphase) {
   }
 }
 
+TEST(RobotBodyFilterTest, MultiThreadedMaskMatchesSerial) {
+  auto scene = makeUr5Scene();
+
+  // A cloud large enough to be split across threads, with the points near the robot clustered
+  // together (as in a sensor scan) so the work is unevenly distributed along the array.
+  std::mt19937 rng(7);
+  std::uniform_real_distribution<double> far_dist(-2.0, 2.0);
+  std::uniform_real_distribution<double> near_dist(-0.3, 0.3);
+  constexpr Eigen::Index kNumFar = 60000;
+  constexpr Eigen::Index kNumNear = 5000;
+  RobotBodyFilter::PointMatrix points(kNumFar + kNumNear, 3);
+  for (Eigen::Index i = 0; i < kNumFar; ++i) {
+    points.row(i) << far_dist(rng), far_dist(rng), far_dist(rng);
+  }
+  for (Eigen::Index i = kNumFar; i < points.rows(); ++i) {
+    points.row(i) << near_dist(rng), near_dist(rng), 0.3 + near_dist(rng);
+  }
+  Eigen::VectorXd extra_padding = Eigen::VectorXd::Zero(points.rows());
+  extra_padding.tail(kNumNear).setConstant(0.02);
+
+  const auto q = scene->getCurrentJointPositions();
+  for (const auto method :
+       {RobotBodyFilterMethod::NARROWPHASE, RobotBodyFilterMethod::PADDED_OBB}) {
+    RobotBodyFilter serial_filter(
+        scene, RobotBodyFilterOptions{.padding = 0.05, .method = method, .num_threads = 1});
+    RobotBodyFilter threaded_filter(
+        scene, RobotBodyFilterOptions{.padding = 0.05, .method = method, .num_threads = 4});
+
+    const auto serial_mask = serial_filter.computeMask(q, points, extra_padding);
+    const auto threaded_mask = threaded_filter.computeMask(q, points, extra_padding);
+    EXPECT_GT(serial_mask.count(), 0);
+    EXPECT_EQ(serial_mask, threaded_mask);
+  }
+}
+
 TEST(RobotBodyFilterTest, IgnoresGeometryAddedToScene) {
   auto scene = makeUr5Scene();
   const auto num_robot_geoms = scene->getRobotCollisionGeometryIds().size();

--- a/roboplan_core/test/test_robot_body_filter.cpp
+++ b/roboplan_core/test/test_robot_body_filter.cpp
@@ -60,7 +60,7 @@ TEST(RobotBodyFilterTest, NegativePaddingThrows) {
 TEST(RobotBodyFilterTest, NarrowphaseMatchesExactSphereDistance) {
   auto scene = makeBallScene();
   RobotBodyFilter filter(
-      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::Narrowphase});
 
   // The padded body is the ball of radius 0.1 + 0.05 = 0.15 around the origin.
   RobotBodyFilter::PointMatrix points(4, 3);
@@ -79,7 +79,7 @@ TEST(RobotBodyFilterTest, NarrowphaseMatchesExactSphereDistance) {
 TEST(RobotBodyFilterTest, PaddedObbOverRemovesCorners) {
   auto scene = makeBallScene();
   RobotBodyFilter filter(
-      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::PADDED_OBB});
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::PaddedObb});
 
   // The padded OBB is the box of half extent 0.15 around the origin.
   RobotBodyFilter::PointMatrix points(3, 3);
@@ -96,7 +96,7 @@ TEST(RobotBodyFilterTest, PaddedObbOverRemovesCorners) {
 TEST(RobotBodyFilterTest, ExtraPaddingIsAppliedPerPoint) {
   auto scene = makeBallScene();
   RobotBodyFilter filter(
-      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::Narrowphase});
 
   // Both points are 0.1 outside the ball surface, past the 0.05 padding; only the one granted
   // 0.1 of extra padding is classified as part of the body.
@@ -114,7 +114,7 @@ TEST(RobotBodyFilterTest, ExtraPaddingIsAppliedPerPoint) {
 TEST(RobotBodyFilterTest, FilterPointsKeepsUnmaskedRowsInOrder) {
   auto scene = makeBallScene();
   RobotBodyFilter filter(
-      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::Narrowphase});
 
   RobotBodyFilter::PointMatrix points(3, 3);
   points.row(0) << 0.5, 0.0, 0.0;
@@ -130,9 +130,9 @@ TEST(RobotBodyFilterTest, FilterPointsKeepsUnmaskedRowsInOrder) {
 TEST(RobotBodyFilterTest, PaddedObbMaskIsSupersetOfNarrowphase) {
   auto scene = makeUr5Scene();
   RobotBodyFilter narrowphase_filter(
-      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::NARROWPHASE});
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::Narrowphase});
   RobotBodyFilter obb_filter(
-      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::PADDED_OBB});
+      scene, RobotBodyFilterOptions{.padding = 0.05, .method = RobotBodyFilterMethod::PaddedObb});
 
   // Random points in a box around the robot at a fixed seed.
   std::mt19937 rng(42);
@@ -149,7 +149,7 @@ TEST(RobotBodyFilterTest, PaddedObbMaskIsSupersetOfNarrowphase) {
   EXPECT_GT(narrowphase_mask.count(), 0);
   for (Eigen::Index i = 0; i < points.rows(); ++i) {
     if (narrowphase_mask(i)) {
-      EXPECT_TRUE(obb_mask(i)) << "point " << i << " removed by NARROWPHASE but not PADDED_OBB";
+      EXPECT_TRUE(obb_mask(i)) << "point " << i << " removed by Narrowphase but not PaddedObb";
     }
   }
 }
@@ -175,8 +175,7 @@ TEST(RobotBodyFilterTest, MultiThreadedMaskMatchesSerial) {
   extra_padding.tail(kNumNear).setConstant(0.02);
 
   const auto q = scene->getCurrentJointPositions();
-  for (const auto method :
-       {RobotBodyFilterMethod::NARROWPHASE, RobotBodyFilterMethod::PADDED_OBB}) {
+  for (const auto method : {RobotBodyFilterMethod::Narrowphase, RobotBodyFilterMethod::PaddedObb}) {
     RobotBodyFilter serial_filter(
         scene, RobotBodyFilterOptions{.padding = 0.05, .method = method, .num_threads = 1});
     RobotBodyFilter threaded_filter(

--- a/roboplan_examples/python/CMakeLists.txt
+++ b/roboplan_examples/python/CMakeLists.txt
@@ -4,6 +4,7 @@ install(
            example_cartesian_planning.py
            example_constrained_rrt.py
            example_ik.py
+           example_octree_filtering.py
            example_oink_position_barriers.py
            example_oink.py
            example_rrt.py

--- a/roboplan_examples/python/common.py
+++ b/roboplan_examples/python/common.py
@@ -505,6 +505,23 @@ def get_model_data():
     }
 
 
+def load_point_cloud(pointcloud_path: Path) -> NDArray:
+    """
+    Loads a point cloud from a PLY file.
+
+    Args:
+        pointcloud_path: The path to the point cloud.
+
+    Returns:
+        An (N, 3) array of point positions.
+    """
+    from plyfile import PlyData  # Lazy import to not require plyfile
+
+    ply_data = PlyData.read(pointcloud_path)
+    vertices = ply_data["vertex"]
+    return np.array([vertices["x"], vertices["y"], vertices["z"]], dtype=np.float64).T
+
+
 def load_octree_from_point_cloud(pointcloud_path: Path, voxel_resolution: float = 0.04):
     """
     Loads a point cloud from a PLY file and converts it into an octree structure.
@@ -517,17 +534,55 @@ def load_octree_from_point_cloud(pointcloud_path: Path, voxel_resolution: float 
         An octree data structure representing the hierarchical spatial partitioning
         of the point cloud.
     """
-    from plyfile import PlyData  # Lazy import to not require plyfile
+    return coal.makeOctree(load_point_cloud(pointcloud_path), voxel_resolution)
 
-    # Read the PLY file
-    ply_data = PlyData.read(pointcloud_path)
 
-    # Access vertex data
-    vertices = ply_data["vertex"]
-    vertex_array = np.array([vertices["x"], vertices["y"], vertices["z"]]).T
-    octree = coal.makeOctree(vertex_array, voxel_resolution)
+def sample_points_on_robot(
+    model: pin.Model,
+    collision_model: pin.GeometryModel,
+    q: NDArray,
+    num_points: int,
+    rng: np.random.Generator,
+    noise_std: float = 0.0,
+) -> NDArray:
+    """
+    Samples points on the robot's collision geometry at a given configuration.
 
-    return octree
+    This mimics what a depth camera would see of the robot's own body: points are drawn
+    from the collision mesh vertices (or the local bounding box, for primitive shapes)
+    of each geometry, placed at the configuration `q`, with optional sensor-like noise.
+
+    Args:
+        model: The Pinocchio model.
+        collision_model: The Pinocchio collision geometry model.
+        q: The joint configuration at which to place the robot.
+        num_points: The number of points to sample.
+        rng: The NumPy random generator to draw from.
+        noise_std: Standard deviation, in meters, of Gaussian noise added to the points.
+
+    Returns:
+        An (num_points, 3) array of world-frame points on the robot body.
+    """
+    data = model.createData()
+    geom_data = pin.GeometryData(collision_model)
+    pin.updateGeometryPlacements(model, data, collision_model, geom_data, q)
+
+    candidates = []
+    for geom_obj, oMg in zip(collision_model.geometryObjects, geom_data.oMg):
+        geom = geom_obj.geometry
+        if hasattr(geom, "vertices"):  # Meshes: use the actual surface vertices.
+            local_points = np.asarray(geom.vertices())
+        else:  # Primitive shapes: fall back to sampling the local bounding box.
+            geom.computeLocalAABB()
+            aabb = geom.aabb_local
+            local_points = rng.uniform(aabb.min_, aabb.max_, size=(64, 3))
+        candidates.append(local_points @ oMg.rotation.T + oMg.translation)
+    candidates = np.vstack(candidates)
+
+    points = candidates[rng.integers(0, len(candidates), size=num_points)]
+    if noise_std > 0.0:
+        points = points + rng.normal(scale=noise_std, size=points.shape)
+    return points
 
 
 def get_octree():

--- a/roboplan_examples/python/example_octree_filtering.py
+++ b/roboplan_examples/python/example_octree_filtering.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+"""
+Demonstrates filtering the robot's own body out of a point cloud before turning it into
+an octree collision object.
+
+The example uses the same environment point cloud as the octree RRT demo, but additionally
+scatters points on the Franka robot itself at its current pose, the way a depth camera
+looking at the workspace would also see the robot. Without filtering, those points become
+occupied voxels on the robot body and the current pose is immediately in collision, so no
+planning is possible. The RobotBodyFilter removes them, and the example then repeatedly
+plans RRT paths to random collision-free goals, refreshing the simulated point cloud and
+the filtered octree at every pose the robot stops at.
+
+The viewer shows the world as the point cloud itself: kept points in turquoise and the
+points removed by the filter in red. The octree built from the kept points is added to the
+scene only as the collision object the RRT plans against.
+
+The filter method (exact NARROWPHASE or the faster, conservative PADDED_OBB) is selected
+with --method, and each cycle prints its timing.
+"""
+
+import time
+
+import numpy as np
+import tyro
+import xacro
+
+try:
+    import coal
+except ModuleNotFoundError:
+    import hppfcl as coal
+
+import pinocchio as pin
+from pinocchio.visualize import ViserVisualizer
+
+from common import (
+    ROBOPLAN_MODELS_DIR,
+    get_home_configuration,
+    get_model_data,
+    load_point_cloud,
+    sample_points_on_robot,
+)
+from roboplan.core import (
+    JointConfiguration,
+    OcTree,
+    RobotBodyFilter,
+    RobotBodyFilterMethod,
+    RobotBodyFilterOptions,
+    Scene,
+)
+from roboplan.example_models import get_package_share_dir
+from roboplan.rrt import RRTOptions, RRT
+from roboplan.toppra import PathParameterizerTOPPRA, SplineFittingMode, TOPPRAOptions
+from roboplan.visualization import visualizeJointTrajectory
+
+
+OCTREE_NAME = "filtered_octree"
+
+
+def main(
+    method: RobotBodyFilterMethod = RobotBodyFilterMethod.NARROWPHASE,
+    padding: float = 0.08,
+    num_robot_points: int = 2000,
+    robot_point_noise_std: float = 0.005,
+    voxel_resolution: float = 0.04,
+    max_planning_time: float = 5.0,
+    rng_seed: int = 42,
+    host: str = "localhost",
+    port: str = "8000",
+    open_browser: bool = True,
+):
+    """
+    Run the octree filtering example with the provided parameters.
+
+    Parameters:
+        method: The filter method used to build the scene octree.
+        padding: Distance around the robot's collision geometry, in meters, within which
+            points are considered part of the robot body.
+        num_robot_points: Number of synthetic sensor points scattered on the robot body.
+        robot_point_noise_std: Standard deviation, in meters, of the noise on those points.
+        voxel_resolution: The octree voxel resolution, in meters.
+        max_planning_time: The maximum time (in seconds) for the RRT to search for a path.
+        rng_seed: The seed used for point sampling, goal selection, and RRT.
+        host: The host for the ViserVisualizer.
+        port: The port for the ViserVisualizer.
+        open_browser: Whether to open the Viser page in a browser.
+    """
+    model_data = get_model_data()["franka"]
+    package_paths = [get_package_share_dir()]
+
+    urdf_xml = xacro.process_file(model_data.urdf_path).toxml()
+    srdf_xml = xacro.process_file(model_data.srdf_path).toxml()
+    scene = Scene(
+        "octree_filtering_scene",
+        urdf=urdf_xml,
+        srdf=srdf_xml,
+        package_paths=package_paths,
+        yaml_config_path=model_data.yaml_config_path,
+    )
+    scene.setRngSeed(rng_seed)
+    group_name = model_data.default_joint_group
+    group_info = scene.getJointGroupInfo(group_name)
+
+    # Redundant Pinocchio models for visualization and robot point sampling (see example_rrt.py).
+    model = pin.buildModelFromXML(urdf_xml, mimic=True)
+    collision_model = pin.buildGeomFromUrdfString(
+        model, urdf_xml, pin.GeometryType.COLLISION, package_dirs=package_paths
+    )
+    visual_model = pin.buildGeomFromUrdfString(
+        model, urdf_xml, pin.GeometryType.VISUAL, package_dirs=package_paths
+    )
+
+    viz = ViserVisualizer(model, collision_model, visual_model)
+    viz.initViewer(open=open_browser, loadModel=True, host=host, port=port)
+
+    # The static environment cloud from the octree RRT demo. The robot's own sensor shadow is
+    # re-simulated at every pose the robot stops at.
+    env_points = load_point_cloud(
+        ROBOPLAN_MODELS_DIR / "pointclouds" / "example_point_cloud.ply"
+    )
+    print(f"Environment point cloud: {len(env_points)} points")
+
+    # The filter snapshots only the robot's own geometry, so the octree being swapped in and
+    # out of the scene below does not invalidate it.
+    body_filter = RobotBodyFilter(
+        scene, RobotBodyFilterOptions(padding=padding, method=method)
+    )
+
+    toppra = PathParameterizerTOPPRA(scene, group_name)
+    traj_dt = 0.01
+    rrt_options = RRTOptions(
+        group_name=group_name,
+        max_planning_time=max_planning_time,
+        rrt_connect=True,
+    )
+
+    q_current = get_home_configuration(scene, model_data)
+    scene.setJointPositions(q_current)
+    viz.display(q_current)
+
+    rng = np.random.default_rng(rng_seed)
+    plan_idx = 0
+    while True:
+        # Simulate a sensor snapshot at the current pose: the environment plus points on the
+        # robot body, then remove the robot's sensor shadow with the selected filter method.
+        robot_points = sample_points_on_robot(
+            model,
+            collision_model,
+            q_current,
+            num_robot_points,
+            rng,
+            robot_point_noise_std,
+        )
+        cloud = np.vstack([env_points, robot_points])
+
+        t_start = time.perf_counter()
+        mask = body_filter.computeMask(q_current, cloud)
+        elapsed = time.perf_counter() - t_start
+        print(
+            f"\n[plan {plan_idx}] {method.name} removed {mask.sum()} / {len(cloud)} "
+            f"points in {1000.0 * elapsed:.2f} ms"
+        )
+
+        # Rebuild the collision octree from the kept points and swap it into the scene. The
+        # viewer instead shows the cloud itself: kept points in turquoise, removed in red.
+        filtered_octree = coal.makeOctree(cloud[~mask], voxel_resolution)
+        if plan_idx > 0:
+            scene.removeGeometry(OCTREE_NAME)
+        scene.addOcTreeGeometry(
+            OCTREE_NAME,
+            "universe",
+            OcTree(filtered_octree.toBoxes(), voxel_resolution),
+            np.eye(4),
+            np.array([0.251, 0.878, 0.816, 1.0]),
+        )
+        viz.viewer.scene.add_point_cloud(
+            "/environment_points",
+            points=cloud[~mask],
+            colors=(64, 224, 208),
+            point_size=0.005,
+        )
+        viz.viewer.scene.add_point_cloud(
+            "/removed_points",
+            points=cloud[mask],
+            colors=(255, 60, 60),
+            point_size=0.005,
+        )
+
+        # Plan to a random collision-free goal through the fresh octree. The RRT is rebuilt
+        # because swapping the octree changed the scene's collision geometry.
+        rrt = RRT(scene, rrt_options)
+        rrt.setRngSeed(rng_seed + plan_idx)
+
+        start = JointConfiguration()
+        start.positions = q_current[group_info.q_indices]
+        goal = JointConfiguration()
+        goal.positions = scene.randomCollisionFreePositions()[group_info.q_indices]
+
+        t_start = time.time()
+        try:
+            path = rrt.plan(start, goal)
+        except RuntimeError as e:
+            print(f"Planning failed ({e}); retrying with a new goal.")
+            continue
+        print(
+            f"Found a path with {len(path.positions)} waypoints "
+            f"in {time.time() - t_start:.3f} s"
+        )
+
+        # Time-parameterize, visualize, and animate the trajectory.
+        traj = toppra.generate(
+            path, TOPPRAOptions(dt=traj_dt, mode=SplineFittingMode.Adaptive)
+        )
+        visualizeJointTrajectory(
+            viz, scene, traj, model_data.ee_names, (100, 0, 0), "/rrt/path"
+        )
+        for q in traj.positions:
+            viz.display(scene.toFullJointPositions(group_name, q))
+            time.sleep(traj_dt)
+
+        # The goal pose becomes the next sensing and planning pose.
+        q_current = scene.toFullJointPositions(group_name, goal.positions)
+        scene.setJointPositions(q_current)
+        plan_idx += 1
+        time.sleep(1.0)
+
+
+if __name__ == "__main__":
+    tyro.cli(main)

--- a/roboplan_examples/python/example_octree_filtering.py
+++ b/roboplan_examples/python/example_octree_filtering.py
@@ -4,19 +4,14 @@
 Demonstrates filtering the robot's own body out of a point cloud before turning it into
 an octree collision object.
 
-The example uses the same environment point cloud as the octree RRT demo, but additionally
-scatters points on the Franka robot itself at its current pose, the way a depth camera
-looking at the workspace would also see the robot. Without filtering, those points become
-occupied voxels on the robot body and the current pose is immediately in collision, so no
-planning is possible. The RobotBodyFilter removes them, and the example then repeatedly
+The example scatters points on the Franka robot itself at its current pose, the way a depth
+camera looking at the workspace would also see the robot. Without filtering, those points
+become occupied voxels on the robot body and the current pose is immediately in collision,
+so no planning is possible. The RobotBodyFilter removes them, and the example then repeatedly
 plans RRT paths to random collision-free goals, refreshing the simulated point cloud and
 the filtered octree at every pose the robot stops at.
 
-The viewer shows the world as the point cloud itself: kept points in turquoise and the
-points removed by the filter in red. The octree built from the kept points is added to the
-scene only as the collision object the RRT plans against.
-
-The filter method (exact NARROWPHASE or the faster, conservative PADDED_OBB) is selected
+The filter method (exact Narrowphase or the faster, conservative PaddedObb) is selected
 with --method, and each cycle prints its timing.
 """
 
@@ -55,11 +50,8 @@ from roboplan.toppra import PathParameterizerTOPPRA, SplineFittingMode, TOPPRAOp
 from roboplan.visualization import visualizeJointTrajectory
 
 
-OCTREE_NAME = "filtered_octree"
-
-
 def main(
-    method: RobotBodyFilterMethod = RobotBodyFilterMethod.NARROWPHASE,
+    method: RobotBodyFilterMethod = RobotBodyFilterMethod.Narrowphase,
     padding: float = 0.08,
     num_robot_points: int = 2000,
     robot_point_noise_std: float = 0.005,
@@ -114,26 +106,28 @@ def main(
     viz = ViserVisualizer(model, collision_model, visual_model)
     viz.initViewer(open=open_browser, loadModel=True, host=host, port=port)
 
-    # The static environment cloud from the octree RRT demo. The robot's own sensor shadow is
-    # re-simulated at every pose the robot stops at.
+    # The static environment cloud from the octree RRT demo.
     env_points = load_point_cloud(
         ROBOPLAN_MODELS_DIR / "pointclouds" / "example_point_cloud.ply"
     )
     print(f"Environment point cloud: {len(env_points)} points")
 
-    # The filter snapshots only the robot's own geometry, so the octree being swapped in and
-    # out of the scene below does not invalidate it.
+    # Swapping the octree in and out of the scene below does not invalidate the filter.
     body_filter = RobotBodyFilter(
         scene, RobotBodyFilterOptions(padding=padding, method=method)
     )
 
+    # Each plan() call snapshots the scene, so one planner sees every octree swap.
+    rrt = RRT(
+        scene,
+        RRTOptions(
+            group_name=group_name,
+            max_planning_time=max_planning_time,
+            rrt_connect=True,
+        ),
+    )
     toppra = PathParameterizerTOPPRA(scene, group_name)
     traj_dt = 0.01
-    rrt_options = RRTOptions(
-        group_name=group_name,
-        max_planning_time=max_planning_time,
-        rrt_connect=True,
-    )
 
     q_current = get_home_configuration(scene, model_data)
     scene.setJointPositions(q_current)
@@ -163,49 +157,42 @@ def main(
         )
 
         # Rebuild the collision octree from the kept points and swap it into the scene. The
-        # viewer instead shows the cloud itself: kept points in turquoise, removed in red.
+        # viewer shows the cloud itself instead: kept points in turquoise, removed points in red.
         filtered_octree = coal.makeOctree(cloud[~mask], voxel_resolution)
         if plan_idx > 0:
-            scene.removeGeometry(OCTREE_NAME)
+            scene.removeGeometry("filtered_octree")
         scene.addOcTreeGeometry(
-            OCTREE_NAME,
+            "filtered_octree",
             "universe",
             OcTree(filtered_octree.toBoxes(), voxel_resolution),
             np.eye(4),
             np.array([0.251, 0.878, 0.816, 1.0]),
         )
-        viz.viewer.scene.add_point_cloud(
-            "/environment_points",
-            points=cloud[~mask],
-            colors=(64, 224, 208),
-            point_size=0.005,
-        )
-        viz.viewer.scene.add_point_cloud(
-            "/removed_points",
-            points=cloud[mask],
-            colors=(255, 60, 60),
-            point_size=0.005,
-        )
+        for name, layer_mask, color in [
+            ("/kept_points", ~mask, (64, 224, 208)),
+            ("/removed_points", mask, (255, 60, 60)),
+        ]:
+            viz.viewer.scene.add_point_cloud(
+                name, points=cloud[layer_mask], colors=color, point_size=0.005
+            )
 
-        # Plan to a random collision-free goal through the fresh octree. The RRT is rebuilt
-        # because swapping the octree changed the scene's collision geometry.
-        rrt = RRT(scene, rrt_options)
-        rrt.setRngSeed(rng_seed + plan_idx)
-
+        # Plan to a random collision-free goal through the fresh octree, drawing a new goal
+        # if planning fails.
         start = JointConfiguration()
         start.positions = q_current[group_info.q_indices]
         goal = JointConfiguration()
-        goal.positions = scene.randomCollisionFreePositions()[group_info.q_indices]
-
-        t_start = time.time()
-        try:
-            path = rrt.plan(start, goal)
-        except RuntimeError as e:
-            print(f"Planning failed ({e}); retrying with a new goal.")
-            continue
+        rrt.setRngSeed(rng_seed + plan_idx)
+        while True:
+            goal.positions = scene.randomCollisionFreePositions()[group_info.q_indices]
+            t_start = time.perf_counter()
+            try:
+                path = rrt.plan(start, goal)
+                break
+            except RuntimeError as e:
+                print(f"Planning failed ({e}); retrying with a new goal.")
         print(
             f"Found a path with {len(path.positions)} waypoints "
-            f"in {time.time() - t_start:.3f} s"
+            f"in {time.perf_counter() - t_start:.3f} s"
         )
 
         # Time-parameterize, visualize, and animate the trajectory.


### PR DESCRIPTION
This adds a utility to filter the robot model (with some padding) from a point cloud, which is key for planning in environments with unstructured obstacles and depth sensing.

Example included:

<img width="1238" height="850" alt="image" src="https://github.com/user-attachments/assets/d20c0d6f-4a2c-4499-9746-36b745aa93b7" />
