### PR TITLE
ci: change Python stub generation from imperative to declarative

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,7 +7,7 @@ on:
 
   # Nightly job on default (main) branch
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
   # Whenever certain branches are pushed
   push:
@@ -22,7 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   ubuntu_build_and_test:
     timeout-minutes: 30
     strategy:
@@ -64,11 +63,22 @@ jobs:
 
   # Build ROS docker images and run tests.
   ros_build_and_test:
+    name: "Build and Test: ROS {{ matrix.ros_distro }} {{ matrix.generate_python_stubs == 'ON' ? 'with' : 'without' }} Python stubs"
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        ros_distro: [humble, jazzy, kilted, lyrical, rolling]
+        include:
+          - ros_distro: humble
+            generate_python_stubs: "OFF"
+          - ros_distro: jazzy
+            generate_python_stubs: "ON"
+          - ros_distro: kilted
+            generate_python_stubs: "ON"
+          - ros_distro: lyrical
+            generate_python_stubs: "ON"
+          - ros_distro: rolling
+            generate_python_stubs: "ON"
 
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +102,7 @@ jobs:
           tags: roboplan_ros:${{ steps.sanitize_tag.outputs.tag }}
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}
-            GENERATE_PYTHON_STUBS=${{ matrix.ros_distro == 'humble' && 'OFF' || 'ON' }}
+            GENERATE_PYTHON_STUBS=${{ matrix.generate_python_stubs }}
           push: false
           load: true
           cache-from: type=gha,scope=ros-${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -63,7 +63,7 @@ jobs:
 
   # Build ROS docker images and run tests.
   ros_build_and_test:
-    name: "Build and Test: ROS {{ matrix.ros_distro }} {{ matrix.generate_python_stubs == 'ON' ? 'with' : 'without' }} Python stubs"
+    name: "Build and Test: ROS ${{ matrix.ros_distro }} ${{ matrix.generate_python_stubs == 'ON' ? 'with' : 'without' }} Python stubs"
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
YAML is not a programming language

which sounds like something the community would make up a tongue in cheek acronym for.. YINAPL?