### PR TITLE
Constrain scope of DLL loader manipulation

### DIFF
--- a/packaging/python/CMakeLists.txt
+++ b/packaging/python/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 roboplan_register_build_tree_packages()
 
+add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_common" "roboplan_common")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_example_models" "roboplan_example_models")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan" "roboplan")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_simple_ik" "roboplan_simple_ik")

--- a/roboplan/bindings/CMakeLists.txt
+++ b/roboplan/bindings/CMakeLists.txt
@@ -169,6 +169,7 @@ if(GENERATE_PYTHON_STUBS AND COMMAND nanobind_add_stub)
   # own stub generation.
   set_target_properties(_core_ext PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pystage/roboplan/core")
+
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/python/roboplan/core/__init__.py"
     DESTINATION "${CMAKE_BINARY_DIR}/pystage/roboplan/core")
   set_target_properties(_filters_ext PROPERTIES

--- a/roboplan/bindings/python/roboplan/core/__init__.py
+++ b/roboplan/bindings/python/roboplan/core/__init__.py
@@ -1,13 +1,7 @@
 # The `roboplan.core` bindings, backed by the compiled `_core_ext` module.
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 from ._core_ext import *  # noqa: F401,F403
 from ._core_ext import __version__  # noqa: F401

--- a/roboplan/bindings/python/roboplan/filters/__init__.py
+++ b/roboplan/bindings/python/roboplan/filters/__init__.py
@@ -1,13 +1,7 @@
 # The `roboplan.filters` bindings, backed by the compiled `_filters_ext` module.
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 from ._filters_ext import *  # noqa: F401,F403
 from ._filters_ext import __version__  # noqa: F401

--- a/roboplan/package.xml
+++ b/roboplan/package.xml
@@ -18,6 +18,7 @@
   <build_depend>python3-dev</build_depend>
   <build_depend>python3-typing-extensions</build_depend>
 
+  <depend>roboplan_common</depend>
   <depend>eigen</depend>
   <depend>libexpected-dev</depend>
   <depend>pinocchio</depend>

--- a/roboplan/pyproject.toml
+++ b/roboplan/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-common"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -14,6 +14,7 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
+dependencies = ["roboplan-common"]
 
 [project.urls]
 Homepage = "https://github.com/open-planning/roboplan"

--- a/roboplan_cartesian_planning/bindings/python/roboplan/cartesian_planning/__init__.py
+++ b/roboplan_cartesian_planning/bindings/python/roboplan/cartesian_planning/__init__.py
@@ -1,14 +1,8 @@
 # The `roboplan.cartesian_planning` bindings, backed by `_cartesian_ext`.
 # Import core first to guarantee its types are registered before use.
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 import roboplan.core  # noqa: F401
 

--- a/roboplan_cartesian_planning/pyproject.toml
+++ b/roboplan_cartesian_planning/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-core", "roboplan-oink", "roboplan-toppra"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-common", "roboplan-core", "roboplan-oink", "roboplan-toppra"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -14,7 +14,7 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["roboplan-core", "roboplan-oink", "roboplan-toppra"]
+dependencies = ["roboplan-common", "roboplan-core", "roboplan-oink", "roboplan-toppra"]
 
 [project.urls]
 Homepage = "https://github.com/open-planning/roboplan"

--- a/roboplan_common/CMakeLists.txt
+++ b/roboplan_common/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.22)
+project(roboplan_common VERSION 0.6.1)
+
+find_package(ament_cmake QUIET)
+if(ament_cmake_FOUND)
+  find_package(ament_cmake_python REQUIRED)
+  ament_get_python_install_dir(PYTHON_DESTINATION)
+  if(PYTHON_DESTINATION MATCHES "dist-packages")
+    find_package(Python 3.8 COMPONENTS Interpreter REQUIRED)
+    set(PYTHON_DESTINATION
+        "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  endif()
+elseif(SKBUILD)
+  # scikit-build collects files installed at the wheel root.
+  set(PYTHON_DESTINATION ".")
+else()
+  find_package(Python REQUIRED COMPONENTS Interpreter)
+  file(TO_CMAKE_PATH "${Python_SITEARCH}" PYTHON_DESTINATION)
+endif()
+
+# Make the helper available to nanobind stub generation in sibling packages.
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/python/roboplan_common"
+  DESTINATION "${CMAKE_BINARY_DIR}/pystage")
+install(DIRECTORY python/roboplan_common DESTINATION "${PYTHON_DESTINATION}")
+
+if(ament_cmake_FOUND)
+  ament_package()
+endif()

--- a/roboplan_common/README.md
+++ b/roboplan_common/README.md
@@ -1,0 +1,3 @@
+# RoboPlan common runtime support
+
+Internal runtime support shared by RoboPlan Python packages.

--- a/roboplan_common/package.xml
+++ b/roboplan_common/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>roboplan_cartesian_planning</name>
+  <name>roboplan_common</name>
   <version>0.6.1</version>
-  <description>Cartesian path planner for RoboPlan.</description>
+  <description>Shared runtime support for RoboPlan Python packages.</description>
   <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
   <license>MIT</license>
 
@@ -13,18 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-
-  <build_depend>nanobind-dev</build_depend>
   <build_depend>python3-dev</build_depend>
-  <build_depend>python3-typing-extensions</build_depend>
-
-  <depend>roboplan_common</depend>
-  <depend>roboplan</depend>
-  <depend>roboplan_oink</depend>
-  <depend>roboplan_toppra</depend>
-
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>roboplan_example_models</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/roboplan_common/pyproject.toml
+++ b/roboplan_common/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-common", "roboplan-core"]
+requires = ["scikit-build-core >=0.10"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "roboplan-rrt"
+name = "roboplan-common"
 version = "0.6.1"
-description = "Rapidly-Exploring Random Tree (RRT) implementation for RoboPlan."
+description = "Shared runtime support for RoboPlan Python packages."
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
@@ -14,7 +14,6 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["roboplan-common", "roboplan-core"]
 
 [project.urls]
 Homepage = "https://github.com/open-planning/roboplan"
@@ -22,6 +21,3 @@ Homepage = "https://github.com/open-planning/roboplan"
 [tool.scikit-build]
 minimum-version = "build-system.requires"
 build-dir = "build/{wheel_tag}"
-cmake.define.BUILD_PYTHON_BINDINGS = "ON"
-cmake.define.BUILD_TESTING = "OFF"
-# PEP 420 namespace package: no top-level roboplan/__init__.py is shipped.

--- a/roboplan_common/python/roboplan_common/__init__.py
+++ b/roboplan_common/python/roboplan_common/__init__.py
@@ -1,0 +1,5 @@
+"""Shared runtime support for RoboPlan Python packages."""
+
+from .dll import add_dll_directories
+
+__all__ = ["add_dll_directories"]

--- a/roboplan_common/python/roboplan_common/dll.py
+++ b/roboplan_common/python/roboplan_common/dll.py
@@ -1,0 +1,33 @@
+"""Windows DLL search-path support for RoboPlan extension modules."""
+
+import os
+import sys
+from functools import cache
+
+
+@cache
+def add_dll_directories() -> list[object]:
+    """Register DLL directories from the active Python, Conda, and colcon prefixes."""
+    if os.name != "nt":
+        return []
+
+    prefixes = [sys.prefix, os.environ.get("CONDA_PREFIX", "")]
+    for variable in ("AMENT_PREFIX_PATH", "COLCON_PREFIX_PATH"):
+        prefixes.extend(os.environ.get(variable, "").split(os.pathsep))
+
+    handles = []
+    seen_directories = set()
+    for prefix in prefixes:
+        for directory in (
+            os.path.join(prefix, "bin"),
+            os.path.join(prefix, "Library", "bin"),
+        ):
+            if (
+                prefix
+                and directory not in seen_directories
+                and os.path.isdir(directory)
+            ):
+                seen_directories.add(directory)
+                handles.append(os.add_dll_directory(directory))
+
+    return handles

--- a/roboplan_example_models/bindings/python/roboplan/example_models/__init__.py
+++ b/roboplan_example_models/bindings/python/roboplan/example_models/__init__.py
@@ -1,13 +1,7 @@
 # The `roboplan.example_models` bindings, backed by `_example_models_ext`.
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 from ._example_models_ext import *  # noqa: F401,F403
 from ._example_models_ext import __version__  # noqa: F401

--- a/roboplan_example_models/package.xml
+++ b/roboplan_example_models/package.xml
@@ -18,6 +18,8 @@
   <build_depend>python3-dev</build_depend>
   <build_depend>python3-typing-extensions</build_depend>
 
+  <depend>roboplan_common</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/roboplan_example_models/pyproject.toml
+++ b/roboplan_example_models/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-common"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -14,6 +14,7 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
+dependencies = ["roboplan-common"]
 
 [project.urls]
 Homepage = "https://github.com/open-planning/roboplan"

--- a/roboplan_oink/bindings/python/roboplan/optimal_ik/__init__.py
+++ b/roboplan_oink/bindings/python/roboplan/optimal_ik/__init__.py
@@ -1,14 +1,8 @@
 # The `roboplan.optimal_ik` bindings, backed by `_optimal_ik_ext`.
 # Import core first to guarantee its types are registered before use.
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 import roboplan.core  # noqa: F401
 

--- a/roboplan_oink/package.xml
+++ b/roboplan_oink/package.xml
@@ -19,6 +19,7 @@
   <build_depend>python3-dev</build_depend>
   <build_depend>python3-typing-extensions</build_depend>
 
+  <depend>roboplan_common</depend>
   <depend>roboplan</depend>
   <depend>proxsuite</depend>
 

--- a/roboplan_oink/pyproject.toml
+++ b/roboplan_oink/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-core"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-common", "roboplan-core"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -14,7 +14,7 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["roboplan-core"]
+dependencies = ["roboplan-common", "roboplan-core"]
 
 [project.urls]
 Homepage = "https://github.com/open-planning/roboplan"

--- a/roboplan_rrt/bindings/python/roboplan/rrt/__init__.py
+++ b/roboplan_rrt/bindings/python/roboplan/rrt/__init__.py
@@ -1,12 +1,6 @@
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 import numpy as np
 from pinocchio.visualize import ViserVisualizer

--- a/roboplan_rrt/package.xml
+++ b/roboplan_rrt/package.xml
@@ -18,6 +18,7 @@
   <build_depend>python3-dev</build_depend>
   <build_depend>python3-typing-extensions</build_depend>
 
+  <depend>roboplan_common</depend>
   <depend>roboplan</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/roboplan_simple_ik/bindings/python/roboplan/simple_ik/__init__.py
+++ b/roboplan_simple_ik/bindings/python/roboplan/simple_ik/__init__.py
@@ -1,14 +1,8 @@
 # The `roboplan.simple_ik` bindings, backed by `_simple_ik_ext`.
 # Import core first to guarantee its types are registered before use.
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 import roboplan.core  # noqa: F401
 

--- a/roboplan_simple_ik/package.xml
+++ b/roboplan_simple_ik/package.xml
@@ -18,6 +18,7 @@
   <build_depend>python3-dev</build_depend>
   <build_depend>python3-typing-extensions</build_depend>
 
+  <depend>roboplan_common</depend>
   <depend>roboplan</depend>
 
   <export>

--- a/roboplan_simple_ik/pyproject.toml
+++ b/roboplan_simple_ik/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-core"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-common", "roboplan-core"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -14,7 +14,7 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["roboplan-core"]
+dependencies = ["roboplan-common", "roboplan-core"]
 
 [project.urls]
 Homepage = "https://github.com/open-planning/roboplan"

--- a/roboplan_toppra/bindings/python/roboplan/toppra/__init__.py
+++ b/roboplan_toppra/bindings/python/roboplan/toppra/__init__.py
@@ -1,14 +1,8 @@
 # The `roboplan.toppra` bindings, backed by `_toppra_ext`.
 # Import core first to guarantee its types are registered before use.
-import os
+from roboplan_common import add_dll_directories
 
-# Python >= 3.8 on Windows does not search PATH for the DLLs an extension
-# module links against, and in a colcon workspace they live outside this
-# package. Register the PATH entries explicitly before importing.
-if os.name == "nt":
-    for _entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _entry and os.path.isdir(_entry):
-            os.add_dll_directory(_entry)
+_dll_directories = add_dll_directories()
 
 import roboplan.core  # noqa: F401
 

--- a/roboplan_toppra/package.xml
+++ b/roboplan_toppra/package.xml
@@ -18,6 +18,7 @@
   <build_depend>python3-dev</build_depend>
   <build_depend>python3-typing-extensions</build_depend>
 
+  <depend>roboplan_common</depend>
   <depend>roboplan</depend>
   <depend>toppra</depend>
 

--- a/roboplan_toppra/pyproject.toml
+++ b/roboplan_toppra/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-core"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "roboplan-common", "roboplan-core"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -14,7 +14,7 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["roboplan-core"]
+dependencies = ["roboplan-common", "roboplan-core"]
 
 [project.urls]
 Homepage = "https://github.com/open-planning/roboplan"

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -45,6 +45,7 @@ if(BUILD_TESTING)
   enable_testing()
 endif()
 
+add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_common" "roboplan_common")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_example_models" "roboplan_example_models")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan" "roboplan")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_simple_ik" "roboplan_simple_ik")


### PR DESCRIPTION
I found while working on #301 that the existing DLL loader code can cause crashes if the `PATH` contains long directory names, thanks to the wonders of Windows's old filesystem APIs.

I figured just to be safe and responsible citizens on Windows machines, we should fix this problem by only registering DLLs from `AMENT_PREFIX_PATH` and `CONDA_PREFIX`. Technically the crash can still happen if your workspace path is really long, but this makes it less likely and is also good for separation of concerns.

Note that the particular `PATH` entry that was crashing it was a common one on dev machines: a really long Visual Studio utility path that was like six layers deep under Program Files.