### PR TITLE
Fix unstable Apt caching in ROS Docker image

### DIFF
--- a/.docker/ros/Dockerfile
+++ b/.docker/ros/Dockerfile
@@ -8,9 +8,11 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 SHELL ["/bin/bash", "-c"]
 
 # Install core dependencies.
-RUN apt update -y \
-    && apt upgrade -y \
-    && apt install -y python3-pip
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update -y \
+    && apt-get upgrade -y \
+    && apt-get install -y python3-pip
 
 # Install Python dependencies needed for bindings.
 # Note that since Pinocchio in ROS is built with Numpy 1.x, we must preserve this by
@@ -18,7 +20,8 @@ RUN apt update -y \
 # non-ROS workflows, so we cannot put these as requirements in the `pyproject.toml`.
 # As/if this package matures, a possible solution is to apply patches for ROS release.
 COPY .docker/ros/ros_python_requirements_${ROS_DISTRO}.txt /tmp/ros_python_requirements.txt
-RUN pip3 install -r /tmp/ros_python_requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip3 install -r /tmp/ros_python_requirements.txt
 
 # Create a ROS 2 workspace and copy in the source code.
 RUN mkdir -p /workspace/roboplan_ws/src/roboplan
@@ -26,7 +29,10 @@ WORKDIR /workspace/roboplan_ws
 COPY . src/roboplan
 
 # Install dependencies and build RoboPlan.
-RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    source /opt/ros/${ROS_DISTRO}/setup.bash \
+    && apt-get update -y \
     && rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --skip-keys proxsuite \
     && colcon build --cmake-args -DBUILD_TESTING=ON -DGENERATE_PYTHON_STUBS=${GENERATE_PYTHON_STUBS}
 


### PR DESCRIPTION
@sea-bass @eholum I think this is what blows up the ROS Docker builds.

- the Apt cache getting stuck in Docker layers because it was neither cache-mounted nor `rm -rf`'d at the end of each Apt step
- the `rosdep install` step not running `apt-get update` to refresh its apt cache.

For good measure I also shifted the pip cache out of the Docker layers into a cache mount.