### PR TITLE
Find pinocchio package in superbuild to simplify build logic

### DIFF
--- a/roboplan_core/CMakeLists.txt
+++ b/roboplan_core/CMakeLists.txt
@@ -20,13 +20,6 @@ find_package(pinocchio REQUIRED)
 find_package(console_bridge REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-# pinocchio's coal (collision library) dependency lands as a directory-scoped
-# IMPORTED target on CMake < 3.24, invisible to sibling add_subdirectory()
-# packages in a superbuild. Promote it to global so they can link pinocchio.
-if(TARGET coal::coal)
-  set_target_properties(coal::coal PROPERTIES IMPORTED_GLOBAL TRUE)
-endif()
-
 # Ament CMake is not immediately required, but we include it at the top so that
 # if it is found we can use it in build testing before requiring a
 # find_package(ament_cmake_test REQUIRED). Otherwise this can cause infinite recursion

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -49,6 +49,13 @@ if(BUILD_TESTING)
   enable_testing()
 endif()
 
+# Find pinocchio here, before any add_subdirectory(), so the side effects of
+# its config file reach every package to be consistent with the standalone builds.
+# That includes its IMPORTED targets: pinocchio's interface references coal::coal
+# via $<TARGET_PROPERTY:...>, which CMake resolves in the consuming target's
+# directory, so coal::coal must be visible to every sibling package.
+find_package(pinocchio REQUIRED)
+
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_common" "roboplan_common")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_example_models" "roboplan_example_models")
 add_subdirectory("${ROBOPLAN_REPOSITORY_ROOT}/roboplan_core" "roboplan_core")


### PR DESCRIPTION
Additionally removes the need for a windows conda workaround as described in https://github.com/open-planning/roboplan/pull/312#pullrequestreview-5126772126  / fixed in https://github.com/conda-forge/roboplan-feedstock/pull/22/changes/7ce9a4c97998c4923d29ec4773b87f729eab057b

It does incur a dual `find_package(pinocchio REQUIRED)` in `roboplan_core`, but that's probably not that big a deal and if we need to we can add a conditional there for "if pinocchio already found"