### PR TITLE
General CMake cleanup

### DIFF
--- a/roboplan_cartesian_planning/bindings/CMakeLists.txt
+++ b/roboplan_cartesian_planning/bindings/CMakeLists.txt
@@ -39,8 +39,8 @@ target_compile_definitions(_cartesian_ext
 set_property(TARGET _cartesian_ext PROPERTY CXX_STANDARD 20)
 target_link_libraries(
   _cartesian_ext
-  PRIVATE roboplan_cartesian_planning roboplan::roboplan
-          roboplan_oink::roboplan_oink roboplan_toppra::roboplan_toppra)
+  PRIVATE roboplan_cartesian_planning roboplan_oink::roboplan_oink
+          roboplan_toppra::roboplan_toppra)
 
 # Resolve the Python install destination per build context:
 #

--- a/roboplan_cartesian_planning/test/CMakeLists.txt
+++ b/roboplan_cartesian_planning/test/CMakeLists.txt
@@ -5,13 +5,8 @@ find_package(roboplan_example_models REQUIRED)
 add_executable(test_cartesian_path_planner test_cartesian_path_planner.cpp)
 set_property(TARGET test_cartesian_path_planner PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_cartesian_path_planner
-  roboplan_cartesian_planning
-  roboplan::roboplan
-  roboplan_oink::roboplan_oink
-  roboplan_toppra::roboplan_toppra
-  roboplan_example_models::roboplan_example_models
-  GTest::gtest_main)
+  test_cartesian_path_planner roboplan_cartesian_planning
+  roboplan_example_models::roboplan_example_models GTest::gtest_main)
 
 # If ament_gtest is detected, make the tests visible in ROS 2.
 find_package(ament_cmake_gtest QUIET)

--- a/roboplan_core/CMakeLists.txt
+++ b/roboplan_core/CMakeLists.txt
@@ -54,14 +54,20 @@ endif()
 # Add roboplan libraries.
 add_library(
   roboplan SHARED
-  src/core/scene_context.cpp src/core/path_utils.cpp src/core/pose_utils.cpp
-  src/core/scene.cpp src/core/scene_utils.cpp src/core/types.cpp)
+  src/core/scene_context.cpp
+  src/core/path_utils.cpp
+  src/core/pose_utils.cpp
+  src/core/scene.cpp
+  src/core/scene_utils.cpp
+  src/core/types.cpp
+  src/filters/se3_low_pass_filter.cpp)
 target_include_directories(
   roboplan PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                   $<INSTALL_INTERFACE:include>)
 target_link_libraries(
   roboplan
-  PUBLIC Eigen3::Eigen pinocchio::pinocchio
+  INTERFACE Eigen3::Eigen
+  PUBLIC pinocchio::pinocchio
   PRIVATE tinyxml2::tinyxml2 console_bridge::console_bridge)
 if(yaml-cpp_VERSION VERSION_LESS "0.8") # for Ubuntu 22.04
   target_link_libraries(roboplan PRIVATE yaml-cpp)
@@ -72,16 +78,6 @@ set_property(TARGET roboplan PROPERTY CXX_STANDARD 20)
 # Alias so this works via add_subdirectory() too, not just installed
 # find_package().
 add_library(roboplan::roboplan ALIAS roboplan)
-
-add_library(roboplan_filters SHARED src/filters/se3_low_pass_filter.cpp)
-target_include_directories(
-  roboplan_filters PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                          $<INSTALL_INTERFACE:include>)
-target_link_libraries(roboplan_filters PUBLIC Eigen3::Eigen
-                                              pinocchio::pinocchio)
-set_property(TARGET roboplan_filters PROPERTY CXX_STANDARD 20)
-add_library(roboplan::roboplan_filters ALIAS roboplan_filters)
-list(APPEND TARGETS_LIST roboplan_filters)
 
 set(ROBOPLAN_TARGETS ${TARGETS_LIST})
 install(

--- a/roboplan_core/bindings/CMakeLists.txt
+++ b/roboplan_core/bindings/CMakeLists.txt
@@ -100,7 +100,7 @@ target_include_directories(_filters_ext
 target_compile_definitions(_filters_ext
                            PRIVATE ROBOPLAN_VERSION="${PROJECT_VERSION}")
 set_property(TARGET _filters_ext PROPERTY CXX_STANDARD 20)
-target_link_libraries(_filters_ext PRIVATE roboplan_filters)
+target_link_libraries(_filters_ext PRIVATE roboplan)
 
 # Ensure the extension can find workspace dylibs via @rpath on macOS, as it
 # seems that SIP will strip DYLD_LIBRARY_PATH from subprocesses, which will

--- a/roboplan_core/test/CMakeLists.txt
+++ b/roboplan_core/test/CMakeLists.txt
@@ -4,35 +4,40 @@ find_package(roboplan_example_models REQUIRED)
 # Build tests
 add_executable(test_types test_types.cpp)
 set_property(TARGET test_types PROPERTY CXX_STANDARD 20)
-target_link_libraries(test_types roboplan GTest::gtest_main)
+target_link_libraries(test_types PRIVATE roboplan GTest::gtest_main)
 
 add_executable(test_scene test_scene.cpp)
 set_property(TARGET test_scene PROPERTY CXX_STANDARD 20)
-target_link_libraries(test_scene roboplan GTest::gmock_main GTest::gtest_main
-                      roboplan_example_models::roboplan_example_models)
+target_link_libraries(
+  test_scene PRIVATE roboplan GTest::gmock_main GTest::gtest_main
+                     roboplan_example_models::roboplan_example_models)
 
 add_executable(test_joints test_joints.cpp)
 set_property(TARGET test_joints PROPERTY CXX_STANDARD 20)
-target_link_libraries(test_joints roboplan GTest::gmock_main GTest::gtest_main)
+target_link_libraries(test_joints PRIVATE roboplan GTest::gmock_main
+                                          GTest::gtest_main)
 
 add_executable(test_path_utils test_path_utils.cpp)
 set_property(TARGET test_path_utils PROPERTY CXX_STANDARD 20)
-target_link_libraries(test_path_utils roboplan GTest::gtest_main
-                      roboplan_example_models::roboplan_example_models)
+target_link_libraries(
+  test_path_utils PRIVATE roboplan GTest::gtest_main
+                          roboplan_example_models::roboplan_example_models)
 
 add_executable(test_scene_context test_scene_context.cpp)
 set_property(TARGET test_scene_context PROPERTY CXX_STANDARD 20)
-target_link_libraries(test_scene_context roboplan GTest::gtest_main
-                      roboplan_example_models::roboplan_example_models)
+target_link_libraries(
+  test_scene_context PRIVATE roboplan GTest::gtest_main
+                             roboplan_example_models::roboplan_example_models)
 
 add_executable(test_se3_low_pass_filter test_se3_low_pass_filter.cpp)
 set_property(TARGET test_se3_low_pass_filter PROPERTY CXX_STANDARD 20)
-target_link_libraries(test_se3_low_pass_filter roboplan_filters
-                      GTest::gtest_main)
+target_link_libraries(test_se3_low_pass_filter PRIVATE roboplan
+                                                       GTest::gtest_main)
 
 add_executable(test_urdf_extended_limits test_urdf_extended_limits.cpp)
 set_property(TARGET test_urdf_extended_limits PROPERTY CXX_STANDARD 20)
-target_link_libraries(test_urdf_extended_limits roboplan GTest::gtest_main)
+target_link_libraries(test_urdf_extended_limits PRIVATE roboplan
+                                                        GTest::gtest_main)
 
 # TODO: Define tests as a variable
 

--- a/roboplan_examples/cpp/CMakeLists.txt
+++ b/roboplan_examples/cpp/CMakeLists.txt
@@ -1,41 +1,41 @@
 add_executable(example_scene example_scene.cpp)
-target_link_libraries(example_scene roboplan::roboplan
-                      roboplan_example_models::roboplan_example_models)
+target_link_libraries(
+  example_scene PRIVATE roboplan::roboplan
+                        roboplan_example_models::roboplan_example_models)
 set_property(TARGET example_scene PROPERTY CXX_STANDARD 20)
 target_include_directories(example_scene PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                  ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(example_ik example_ik.cpp)
 target_link_libraries(
-  example_ik roboplan::roboplan
-  roboplan_example_models::roboplan_example_models
-  roboplan_simple_ik::roboplan_simple_ik)
+  example_ik PRIVATE roboplan_example_models::roboplan_example_models
+                     roboplan_simple_ik::roboplan_simple_ik)
 set_property(TARGET example_ik PROPERTY CXX_STANDARD 20)
 target_include_directories(example_ik PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                               ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(example_oink example_oink.cpp)
 target_link_libraries(
-  example_oink roboplan::roboplan
-  roboplan_example_models::roboplan_example_models roboplan_oink::roboplan_oink)
+  example_oink PRIVATE roboplan_example_models::roboplan_example_models
+                       roboplan_oink::roboplan_oink)
 set_property(TARGET example_oink PROPERTY CXX_STANDARD 20)
 target_include_directories(example_oink PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                 ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(example_rrt example_rrt.cpp)
 target_link_libraries(
-  example_rrt roboplan::roboplan
-  roboplan_example_models::roboplan_example_models roboplan_rrt::roboplan_rrt
-  roboplan_toppra::roboplan_toppra)
+  example_rrt
+  PRIVATE roboplan_example_models::roboplan_example_models
+          roboplan_rrt::roboplan_rrt roboplan_toppra::roboplan_toppra)
 set_property(TARGET example_rrt PROPERTY CXX_STANDARD 20)
 target_include_directories(example_rrt PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(example_cartesian_planning example_cartesian_planning.cpp)
 target_link_libraries(
-  example_cartesian_planning roboplan::roboplan
-  roboplan_example_models::roboplan_example_models
-  roboplan_cartesian_planning::roboplan_cartesian_planning)
+  example_cartesian_planning
+  PRIVATE roboplan_example_models::roboplan_example_models
+          roboplan_cartesian_planning::roboplan_cartesian_planning)
 set_property(TARGET example_cartesian_planning PROPERTY CXX_STANDARD 20)
 target_include_directories(
   example_cartesian_planning PRIVATE ${CMAKE_CURRENT_BINARY_DIR}

--- a/roboplan_oink/bindings/CMakeLists.txt
+++ b/roboplan_oink/bindings/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(_optimal_ik_ext
 target_compile_definitions(_optimal_ik_ext
                            PRIVATE ROBOPLAN_VERSION="${PROJECT_VERSION}")
 set_property(TARGET _optimal_ik_ext PROPERTY CXX_STANDARD 20)
-target_link_libraries(_optimal_ik_ext PRIVATE roboplan_oink roboplan::roboplan)
+target_link_libraries(_optimal_ik_ext PRIVATE roboplan_oink)
 
 # Resolve the Python install destination per build context:
 #

--- a/roboplan_oink/test/CMakeLists.txt
+++ b/roboplan_oink/test/CMakeLists.txt
@@ -9,59 +9,62 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(test_oink test_oink.cpp)
 set_property(TARGET test_oink PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_oink roboplan::roboplan roboplan_oink GTest::gmock_main
-  GTest::gtest_main roboplan_example_models::roboplan_example_models)
+  test_oink PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+                    roboplan_example_models::roboplan_example_models)
 
 # Build FrameTask unit tests
 add_executable(test_frame_task tasks/test_frame_task.cpp)
 set_property(TARGET test_frame_task PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_frame_task roboplan::roboplan roboplan_oink GTest::gmock_main
-  GTest::gtest_main roboplan_example_models::roboplan_example_models)
+  test_frame_task PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+                          roboplan_example_models::roboplan_example_models)
 
 # Build ConfigurationTask unit tests
 add_executable(test_configuration_task tasks/test_configuration_task.cpp)
 set_property(TARGET test_configuration_task PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_configuration_task roboplan::roboplan roboplan_oink GTest::gmock_main
-  GTest::gtest_main roboplan_example_models::roboplan_example_models)
+  test_configuration_task
+  PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+          roboplan_example_models::roboplan_example_models)
 
 # Build VelocityLimit unit tests
 add_executable(test_velocity_limit constraints/test_velocity_limit.cpp)
 set_property(TARGET test_velocity_limit PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_velocity_limit roboplan::roboplan roboplan_oink GTest::gmock_main
-  GTest::gtest_main roboplan_example_models::roboplan_example_models)
+  test_velocity_limit PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+                              roboplan_example_models::roboplan_example_models)
 
 # Build PositionLimit unit tests
 add_executable(test_position_limit constraints/test_position_limit.cpp)
 set_property(TARGET test_position_limit PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_position_limit roboplan::roboplan roboplan_oink GTest::gmock_main
-  GTest::gtest_main roboplan_example_models::roboplan_example_models)
+  test_position_limit PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+                              roboplan_example_models::roboplan_example_models)
 
 # Build AccelerationLimit unit tests
 add_executable(test_acceleration_limit constraints/test_acceleration_limit.cpp)
 set_property(TARGET test_acceleration_limit PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_acceleration_limit roboplan::roboplan roboplan_oink GTest::gmock_main
-  GTest::gtest_main roboplan_example_models::roboplan_example_models)
+  test_acceleration_limit
+  PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+          roboplan_example_models::roboplan_example_models)
 
 # Build PositionBarrier unit tests
 add_executable(test_position_barrier barriers/test_position_barrier.cpp)
 set_property(TARGET test_position_barrier PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_position_barrier roboplan::roboplan roboplan_oink GTest::gmock_main
-  GTest::gtest_main roboplan_example_models::roboplan_example_models)
+  test_position_barrier
+  PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+          roboplan_example_models::roboplan_example_models)
 
 # Build SelfCollisionBarrier unit tests
 add_executable(test_self_collision_barrier
                barriers/test_self_collision_barrier.cpp)
 set_property(TARGET test_self_collision_barrier PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_self_collision_barrier roboplan::roboplan roboplan_oink
-  GTest::gmock_main GTest::gtest_main
-  roboplan_example_models::roboplan_example_models)
+  test_self_collision_barrier
+  PRIVATE roboplan_oink GTest::gmock_main GTest::gtest_main
+          roboplan_example_models::roboplan_example_models)
 
 # If ament_gtest is detected, make the tests visible in ROS 2.
 find_package(ament_cmake_gtest QUIET)

--- a/roboplan_rrt/bindings/CMakeLists.txt
+++ b/roboplan_rrt/bindings/CMakeLists.txt
@@ -33,7 +33,7 @@ target_include_directories(_rrt_ext PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_definitions(_rrt_ext
                            PRIVATE ROBOPLAN_VERSION="${PROJECT_VERSION}")
 set_property(TARGET _rrt_ext PROPERTY CXX_STANDARD 20)
-target_link_libraries(_rrt_ext PRIVATE roboplan_rrt roboplan::roboplan)
+target_link_libraries(_rrt_ext PRIVATE roboplan_rrt)
 
 # Resolve the Python install destination per build context:
 #

--- a/roboplan_rrt/test/CMakeLists.txt
+++ b/roboplan_rrt/test/CMakeLists.txt
@@ -5,8 +5,9 @@ find_package(roboplan_example_models REQUIRED)
 add_executable(test_rrt test_rrt.cpp)
 set_property(TARGET test_rrt PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_rrt roboplan_rrt roboplan::roboplan
-  roboplan_example_models::roboplan_example_models GTest::gtest_main)
+  test_rrt
+  PRIVATE roboplan_rrt roboplan_example_models::roboplan_example_models
+          GTest::gtest_main)
 
 # TODO: Define tests as a variable
 

--- a/roboplan_simple_ik/bindings/CMakeLists.txt
+++ b/roboplan_simple_ik/bindings/CMakeLists.txt
@@ -34,8 +34,7 @@ target_include_directories(_simple_ik_ext
 target_compile_definitions(_simple_ik_ext
                            PRIVATE ROBOPLAN_VERSION="${PROJECT_VERSION}")
 set_property(TARGET _simple_ik_ext PROPERTY CXX_STANDARD 20)
-target_link_libraries(_simple_ik_ext PRIVATE roboplan_simple_ik
-                                             roboplan::roboplan)
+target_link_libraries(_simple_ik_ext PRIVATE roboplan_simple_ik)
 
 # Resolve the Python install destination per build context:
 #

--- a/roboplan_simple_ik/test/CMakeLists.txt
+++ b/roboplan_simple_ik/test/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(roboplan_example_models REQUIRED)
 add_executable(test_simple_ik test_simple_ik.cpp)
 set_property(TARGET test_simple_ik PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_simple_ik roboplan_simple_ik roboplan::roboplan
+  test_simple_ik roboplan_simple_ik
   roboplan_example_models::roboplan_example_models GTest::gtest_main)
 
 # If ament_gtest is detected, make the tests visible in ROS 2.

--- a/roboplan_toppra/bindings/CMakeLists.txt
+++ b/roboplan_toppra/bindings/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(_toppra_ext
 target_compile_definitions(_toppra_ext
                            PRIVATE ROBOPLAN_VERSION="${PROJECT_VERSION}")
 set_property(TARGET _toppra_ext PROPERTY CXX_STANDARD 20)
-target_link_libraries(_toppra_ext PRIVATE roboplan_toppra roboplan::roboplan)
+target_link_libraries(_toppra_ext PRIVATE roboplan_toppra)
 
 # Resolve the Python install destination per build context:
 #

--- a/roboplan_toppra/test/CMakeLists.txt
+++ b/roboplan_toppra/test/CMakeLists.txt
@@ -5,8 +5,9 @@ find_package(roboplan_example_models REQUIRED)
 add_executable(test_toppra test_toppra.cpp)
 set_property(TARGET test_toppra PROPERTY CXX_STANDARD 20)
 target_link_libraries(
-  test_toppra roboplan_toppra roboplan::roboplan
-  roboplan_example_models::roboplan_example_models GTest::gtest_main)
+  test_toppra
+  PRIVATE roboplan_toppra roboplan_example_models::roboplan_example_models
+          GTest::gtest_main)
 
 # TODO: Define tests as a variable
 

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -89,7 +89,6 @@ if(DEFINED ENV{CMEEL_BUILD})
     target IN
     ITEMS roboplan_example_models
           roboplan
-          roboplan_filters
           roboplan_simple_ik
           roboplan_oink
           roboplan_rrt


### PR DESCRIPTION
While finishing up all my recent CMake changes, figured I'd clean up the dependency graph a bit.

This PR:

- moves the `roboplan_filters` code into the core build target (rationale: this depends upon Pinocchio but not other RoboPlan modules, therefore it is a core API - otherwise we have two "bottom-most" libraries in RoboPlan)
- cleans up various `target_link_libraries` invocations, de-duplicating some transitive deps that were re-declared as direct deps and adding a few visibility specs where they were missing - helped with using `cmake --graphviz` to clean up the former